### PR TITLE
Ping endpoint, scheduled keep-alive, and lighter Hangfire job

### DIFF
--- a/.github/workflows/keep-api-alive.yml
+++ b/.github/workflows/keep-api-alive.yml
@@ -1,0 +1,37 @@
+# Hits GET /ping on a schedule so Azure App Service (or similar) stays warm.
+# Set repo secret KEEP_ALIVE_URL to the full URL, e.g. https://your-app.azurewebsites.net/ping
+# Schedule is UTC; */15 = every 15 minutes (GitHub allows at most every 5 minutes).
+
+name: Keep API alive
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: keep-api-alive
+  cancel-in-progress: true
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      KEEP_ALIVE_URL: ${{ secrets.KEEP_ALIVE_URL }}
+    steps:
+      - name: Ping /ping
+        run: |
+          set -euo pipefail
+          if [ -z "${KEEP_ALIVE_URL:-}" ]; then
+            echo "::error::Repository secret KEEP_ALIVE_URL is not set. Add it under Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+          code="$(curl -sS -o /tmp/ping-body -w "%{http_code}" --max-time 30 "$KEEP_ALIVE_URL")"
+          echo "HTTP $code"
+          if [ "$code" != "200" ]; then
+            echo "::error::Expected HTTP 200, got $code"
+            cat /tmp/ping-body || true
+            exit 1
+          fi
+          echo "Keep-alive ping succeeded."

--- a/Antital.API/Configs/AppUseExtensions.cs
+++ b/Antital.API/Configs/AppUseExtensions.cs
@@ -3,6 +3,7 @@ using Hangfire;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using System.Globalization;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Antital.Infrastructure;
@@ -63,9 +64,32 @@ public static class AppUseExtensions
         }
     }
 
+    /// <summary>
+    /// Lightweight outbound HTTP GET on a schedule (default: every 15 minutes UTC).
+    /// Set <c>HealthCheck:Uri</c> to your public API base ping, e.g. <c>https://{app}.azurewebsites.net/ping</c>.
+    /// If unset, no recurring job is registered (avoids empty-URL failures on deploy).
+    /// </summary>
     private static void UsingJobs(IConfiguration configuration)
     {
-        RecurringJob.AddOrUpdate<HealthCheckJob>("SampleJob", x => HealthCheckJob.CheckStatus(configuration["HealthCheck:Uri"]!), "* * * * *");
+        var uri = configuration["HealthCheck:Uri"]?.Trim();
+        if (string.IsNullOrEmpty(uri))
+        {
+            Console.WriteLine(
+                $"{DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture)} Hangfire: recurring HTTP ping skipped (HealthCheck:Uri is empty). Set it to e.g. https://your-app.azurewebsites.net/ping");
+            return;
+        }
+
+        const string jobId = "ApiHttpPing";
+        const string cronEvery15MinutesUtc = "*/15 * * * *";
+
+        RecurringJob.AddOrUpdate(
+            jobId,
+            () => HealthCheckJob.CheckStatus(uri),
+            cronEvery15MinutesUtc,
+            new RecurringJobOptions { TimeZone = TimeZoneInfo.Utc });
+
+        Console.WriteLine(
+            $"{DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture)} Hangfire: registered '{jobId}' → GET {uri} on cron {cronEvery15MinutesUtc} (UTC)");
     }
 
     private static IApplicationBuilder MigratingDatabase(this IApplicationBuilder app)

--- a/Antital.API/Controllers/PingController.cs
+++ b/Antital.API/Controllers/PingController.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Antital.API.Controllers;
+
+/// <summary>
+/// Lightweight keep-alive endpoint for schedulers (e.g. Azure App Service warm-up).
+/// Prefer GET /ping over Swagger UI or /healthz for frequent pings — minimal CPU and no DB.
+/// </summary>
+[ApiController]
+[AllowAnonymous]
+public sealed class PingController : ControllerBase
+{
+    [HttpGet("/ping")]
+    public IActionResult KeepAlive() => Ok("pong");
+}

--- a/Antital.API/appsettings.Development.json
+++ b/Antital.API/appsettings.Development.json
@@ -14,7 +14,7 @@
   "FeatureManagement": {
   },
   "HealthCheck": {
-    "Uri": "http://localhost:5274/healthz"
+    "Uri": "http://localhost:5274/ping"
   },
   "ElasticSearch": {
     "Uri": "http://localhost:9200"

--- a/Antital.API/appsettings.Staging.json
+++ b/Antital.API/appsettings.Staging.json
@@ -13,7 +13,7 @@
   },
   "FeatureManagement": {},
   "HealthCheck": {
-    "Uri": "https://antital-ui.netlify.app/healthz"
+    "Uri": ""
   },
   "ElasticSearch": {
     "Uri": ""


### PR DESCRIPTION
## Summary
- **GET `/ping`**: minimal anonymous endpoint for warm-up (prefer over Swagger or `/healthz` for frequent pings).
- **GitHub Actions** (`.github/workflows/keep-api-alive.yml`): runs every **15 minutes** (UTC); set repo secret **`KEEP_ALIVE_URL`** to the full ping URL (e.g. `https://&lt;app&gt;.azurewebsites.net/ping`). **`workflow_dispatch`** for manual runs.
- **Hangfire**: recurring job **`ApiHttpPing`** runs **every 15 minutes UTC**; targets **`HealthCheck:Uri`**; **no job registered** if URI is empty (fixes silent misconfig). Dev defaults to `http://localhost:5274/ping`.
- **Staging**: `HealthCheck:Uri` cleared (previously pointed at Netlify UI, not the API).

## Deploy / ops
- Azure App Service: set **`HealthCheck__Uri`** to your public API `/ping` URL if you want in-process Hangfire pings.
- GitHub: add **`KEEP_ALIVE_URL`** under Actions secrets for the workflow.

## Testing
- [x] `GET /ping` returns 200 and `"pong"` locally
- [x] After setting secrets/settings, confirm workflow and/or Hangfire job runs as expected

Made with [Cursor](https://cursor.com)