### PR TITLE
feat: implement OTP functionality for unverified user actions

### DIFF
--- a/Antital.API/Controllers/AuthenticationController.cs
+++ b/Antital.API/Controllers/AuthenticationController.cs
@@ -13,6 +13,7 @@ using Antital.Application.Features.Authentication.ForgotPassword;
 using Antital.Application.Features.Authentication.ResetPassword;
 using Antital.Application.Features.Authentication.ResendVerificationEmail;
 using Antital.Application.Features.Authentication.DeleteUnverifiedUser;
+using Antital.Application.Features.Authentication.RequestUnverifiedUserOtp;
 using Antital.Application.Features.Users.GetUsers;
 using Antital.Application.Features.Users.GetUserById;
 using Antital.Application.Features.Users.CreateUser;
@@ -120,10 +121,21 @@ public class AuthenticationController(IMediator mediator) : BaseController
         return ApiResult(result);
     }
 
+    [HttpPost("unverified/otp")]
+    [SwaggerOperation("Request Unverified Account OTP", "Sends a short-lived email OTP for unverified-account actions.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "OTP sent successfully", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Account is already verified or request is invalid", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "User not found", typeof(void))]
+    public async Task<IActionResult> RequestUnverifiedOtp(RequestUnverifiedUserOtpCommand request, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(request, cancellationToken);
+        return ApiResult(result);
+    }
+
     [HttpDelete("unverified")]
-    [SwaggerOperation("Delete Unverified Account", "Allows a user who has not yet verified their email to permanently delete their account. Requires the email address and the verification token that was sent during sign-up.")]
+    [SwaggerOperation("Delete Unverified Account", "Allows a user who has not yet verified their email to permanently delete their account. Requires the email address and a valid OTP sent via /api/auth/unverified/otp.")]
     [SwaggerResponse(StatusCodes.Status200OK, "Account deleted successfully", typeof(void))]
-    [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid or expired token, or account is already verified", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid/expired/used OTP, or account is already verified", typeof(void))]
     [SwaggerResponse(StatusCodes.Status404NotFound, "User not found", typeof(void))]
     public async Task<IActionResult> DeleteUnverified(DeleteUnverifiedUserCommand request, CancellationToken cancellationToken)
     {

--- a/Antital.API/appsettings.Development.json
+++ b/Antital.API/appsettings.Development.json
@@ -9,7 +9,8 @@
     "Audience": "http://localhost:28747/"
   },
   "Email": {
-    "VerificationExpiryHours": 24
+    "VerificationExpiryHours": 24,
+    "UnverifiedOtpExpiryMinutes": 10
   },
   "FeatureManagement": {
   },

--- a/Antital.API/appsettings.Production.json
+++ b/Antital.API/appsettings.Production.json
@@ -9,7 +9,8 @@
     "Audience": ""
   },
   "Email": {
-    "VerificationExpiryHours": 24
+    "VerificationExpiryHours": 24,
+    "UnverifiedOtpExpiryMinutes": 10
   },
   "FeatureManagement": {},
   "HealthCheck": {

--- a/Antital.API/appsettings.Staging.json
+++ b/Antital.API/appsettings.Staging.json
@@ -9,7 +9,8 @@
     "Audience": ""
   },
   "Email": {
-    "VerificationExpiryHours": 24
+    "VerificationExpiryHours": 24,
+    "UnverifiedOtpExpiryMinutes": 10
   },
   "FeatureManagement": {},
   "HealthCheck": {

--- a/Antital.Application/Common/Security/TokenGenerator.cs
+++ b/Antital.Application/Common/Security/TokenGenerator.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using System.Globalization;
 
 namespace Antital.Application.Common.Security;
 
@@ -19,5 +20,19 @@ public static class TokenGenerator
         var bytes = Encoding.UTF8.GetBytes(token);
         var hash = sha.ComputeHash(bytes);
         return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    public static bool VerifyTokenHash(string token, string storedHash)
+    {
+        var computedHash = HashToken(token);
+        var computedBytes = Encoding.UTF8.GetBytes(computedHash);
+        var storedBytes = Encoding.UTF8.GetBytes(storedHash);
+        return CryptographicOperations.FixedTimeEquals(computedBytes, storedBytes);
+    }
+
+    public static string GenerateSixDigitOtp()
+    {
+        var value = RandomNumberGenerator.GetInt32(0, 1_000_000);
+        return value.ToString("D6", CultureInfo.InvariantCulture);
     }
 }

--- a/Antital.Application/Features/Authentication/DeleteUnverifiedUser/DeleteUnverifiedUserCommand.cs
+++ b/Antital.Application/Features/Authentication/DeleteUnverifiedUser/DeleteUnverifiedUserCommand.cs
@@ -4,5 +4,5 @@ namespace Antital.Application.Features.Authentication.DeleteUnverifiedUser;
 
 public record DeleteUnverifiedUserCommand(
     string Email,
-    string Token
+    string Otp
 ) : ICommandQuery;

--- a/Antital.Application/Features/Authentication/DeleteUnverifiedUser/DeleteUnverifiedUserCommandHandler.cs
+++ b/Antital.Application/Features/Authentication/DeleteUnverifiedUser/DeleteUnverifiedUserCommandHandler.cs
@@ -1,3 +1,4 @@
+using Antital.Application.Common.Security;
 using Antital.Domain.Interfaces;
 using BuildingBlocks.Application.Exceptions;
 using BuildingBlocks.Application.Features;
@@ -30,20 +31,30 @@ public class DeleteUnverifiedUserCommandHandler(
             throw new BadRequestException("Account already verified.", errors);
         }
 
-        // 3. Verify the email verification token matches and has not expired
-        if (string.IsNullOrEmpty(user.EmailVerificationToken) ||
-            user.EmailVerificationToken != request.Token ||
-            !user.EmailVerificationTokenExpiry.HasValue ||
-            user.EmailVerificationTokenExpiry.Value < now)
+        // 3. Verify the one-time deletion OTP hash matches and has not expired/been consumed
+        var hasOtpState =
+            !string.IsNullOrWhiteSpace(user.UnverifiedOtpHash) &&
+            user.UnverifiedOtpCreatedAtUtc.HasValue &&
+            user.UnverifiedOtpExpiresAtUtc.HasValue;
+
+        var isOtpValid = hasOtpState &&
+            user.UnverifiedOtpExpiresAtUtc!.Value >= now &&
+            TokenGenerator.VerifyTokenHash(request.Otp, user.UnverifiedOtpHash!);
+
+        if (!isOtpValid)
         {
             var errors = new Dictionary<string, string[]>
             {
-                { "Token", new[] { "Invalid or expired verification token." } }
+                { "Otp", new[] { "Invalid, expired, or already-used OTP." } }
             };
-            throw new BadRequestException("Token validation failed.", errors);
+            throw new BadRequestException("OTP validation failed.", errors);
         }
 
-        // 4. Delete the unverified user account
+        // 4. Consume OTP and delete the unverified user account
+        user.UnverifiedOtpHash = null;
+        user.UnverifiedOtpCreatedAtUtc = null;
+        user.UnverifiedOtpExpiresAtUtc = null;
+
         await userRepository.DeleteAsync(user, cancellationToken);
         await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/Antital.Application/Features/Authentication/DeleteUnverifiedUser/DeleteUnverifiedUserCommandValidator.cs
+++ b/Antital.Application/Features/Authentication/DeleteUnverifiedUser/DeleteUnverifiedUserCommandValidator.cs
@@ -11,7 +11,8 @@ public class DeleteUnverifiedUserCommandValidator : AbstractValidator<DeleteUnve
             .NotEmpty().WithMessage("Email is required.")
             .Must(ValidationHelper.IsValidEmail).WithMessage("Email must be in a valid format.");
 
-        RuleFor(x => x.Token)
-            .NotEmpty().WithMessage("Verification token is required.");
+        RuleFor(x => x.Otp)
+            .NotEmpty().WithMessage("OTP is required.")
+            .Matches(@"^\d{6}$").WithMessage("OTP must be a 6-digit code.");
     }
 }

--- a/Antital.Application/Features/Authentication/RequestUnverifiedUserOtp/RequestUnverifiedUserOtpCommand.cs
+++ b/Antital.Application/Features/Authentication/RequestUnverifiedUserOtp/RequestUnverifiedUserOtpCommand.cs
@@ -1,0 +1,7 @@
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Authentication.RequestUnverifiedUserOtp;
+
+public record RequestUnverifiedUserOtpCommand(
+    string Email
+) : ICommandQuery;

--- a/Antital.Application/Features/Authentication/RequestUnverifiedUserOtp/RequestUnverifiedUserOtpCommandHandler.cs
+++ b/Antital.Application/Features/Authentication/RequestUnverifiedUserOtp/RequestUnverifiedUserOtpCommandHandler.cs
@@ -1,0 +1,55 @@
+using Antital.Application.Common.Security;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using BuildingBlocks.Domain.Interfaces;
+using BuildingBlocks.Resources;
+using Microsoft.Extensions.Configuration;
+
+namespace Antital.Application.Features.Authentication.RequestUnverifiedUserOtp;
+
+public class RequestUnverifiedUserOtpCommandHandler(
+    IUserRepository userRepository,
+    IEmailService emailService,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser,
+    IConfiguration configuration
+) : ICommandQueryHandler<RequestUnverifiedUserOtpCommand>
+{
+    private readonly int _otpExpiryMinutes = configuration.GetValue<int>("Email:UnverifiedOtpExpiryMinutes", 10);
+
+    public async Task<Result> Handle(RequestUnverifiedUserOtpCommand request, CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var user = await userRepository.GetByEmailAsync(request.Email, cancellationToken);
+        if (user is null)
+            throw new NotFoundException(Messages.NotFound);
+
+        if (user.IsEmailVerified)
+        {
+            var errors = new Dictionary<string, string[]>
+            {
+                { "Email", new[] { "This account is already verified. Please log in to manage your account." } }
+            };
+            throw new BadRequestException("Account already verified.", errors);
+        }
+
+        var otp = TokenGenerator.GenerateSixDigitOtp();
+        user.UnverifiedOtpHash = TokenGenerator.HashToken(otp);
+        user.UnverifiedOtpCreatedAtUtc = now;
+        user.UnverifiedOtpExpiresAtUtc = now.AddMinutes(_otpExpiryMinutes);
+
+        var updatedBy = !string.IsNullOrWhiteSpace(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrWhiteSpace(currentUser.IPAddress) ? currentUser.IPAddress : "System");
+        user.Updated(updatedBy);
+
+        await userRepository.UpdateAsync(user, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        await emailService.SendUnverifiedOtpEmailAsync(user.Email, otp, _otpExpiryMinutes, cancellationToken);
+
+        var result = new Result();
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Authentication/RequestUnverifiedUserOtp/RequestUnverifiedUserOtpCommandValidator.cs
+++ b/Antital.Application/Features/Authentication/RequestUnverifiedUserOtp/RequestUnverifiedUserOtpCommandValidator.cs
@@ -1,0 +1,14 @@
+using BuildingBlocks.Application.Methods;
+using FluentValidation;
+
+namespace Antital.Application.Features.Authentication.RequestUnverifiedUserOtp;
+
+public class RequestUnverifiedUserOtpCommandValidator : AbstractValidator<RequestUnverifiedUserOtpCommand>
+{
+    public RequestUnverifiedUserOtpCommandValidator()
+    {
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("Email is required.")
+            .Must(ValidationHelper.IsValidEmail).WithMessage("Email must be in a valid format.");
+    }
+}

--- a/Antital.Domain/Interfaces/IEmailService.cs
+++ b/Antital.Domain/Interfaces/IEmailService.cs
@@ -4,5 +4,6 @@ public interface IEmailService
 {
     Task SendVerificationEmailAsync(string email, string token, CancellationToken cancellationToken);
     Task SendPasswordResetEmailAsync(string email, string token, CancellationToken cancellationToken);
+    Task SendUnverifiedOtpEmailAsync(string email, string otp, int validMinutes, CancellationToken cancellationToken);
     Task SendWelcomeEmailAsync(string email, string username, CancellationToken cancellationToken);
 }

--- a/Antital.Domain/Models/User.cs
+++ b/Antital.Domain/Models/User.cs
@@ -29,4 +29,8 @@ public class User : TrackableEntity
     [MaxLength(500)]
     public string? PasswordResetTokenHash { get; set; }
     public DateTime? PasswordResetTokenExpiry { get; set; }
+    [MaxLength(500)]
+    public string? UnverifiedOtpHash { get; set; }
+    public DateTime? UnverifiedOtpCreatedAtUtc { get; set; }
+    public DateTime? UnverifiedOtpExpiresAtUtc { get; set; }
 }

--- a/Antital.Infrastructure/AntitalDBContext.cs
+++ b/Antital.Infrastructure/AntitalDBContext.cs
@@ -102,6 +102,9 @@ public class AntitalDBContext(
             entity.Property(e => e.RefreshTokenHash)
                 .HasMaxLength(500);
 
+            entity.Property(e => e.UnverifiedOtpHash)
+                .HasMaxLength(500);
+
             entity.HasIndex(e => e.RefreshTokenHash)
                 .HasFilter("\"RefreshTokenHash\" IS NOT NULL AND \"IsDeleted\" = false");
         });

--- a/Antital.Infrastructure/EmailTemplates/unverified_otp.html
+++ b/Antital.Infrastructure/EmailTemplates/unverified_otp.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Account OTP</title>
+</head>
+<body style="font-family:Arial,sans-serif;background:#f8fafc;color:#0f172a;padding:24px;">
+  <div style="max-width:560px;margin:0 auto;background:#ffffff;border:1px solid #e2e8f0;border-radius:12px;padding:24px;">
+    <h2 style="margin:0 0 12px 0;">Account Verification Code</h2>
+    <p style="margin:0 0 12px 0;">Hello {{ email }},</p>
+    <p style="margin:0 0 12px 0;">Use the OTP below to continue your unverified account request.</p>
+    <p style="margin:18px 0;font-size:28px;letter-spacing:6px;font-weight:700;">{{ otp }}</p>
+    <p style="margin:0 0 12px 0;">This OTP expires in {{ valid_minutes }} minutes.</p>
+    <p style="margin:0;color:#475569;">If you did not request this, you can ignore this email.</p>
+  </div>
+</body>
+</html>

--- a/Antital.Infrastructure/Migrations/20260426233312_AddUnverifiedOtpFields.Designer.cs
+++ b/Antital.Infrastructure/Migrations/20260426233312_AddUnverifiedOtpFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Antital.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Antital.Infrastructure.Migrations
 {
     [DbContext(typeof(AntitalDBContext))]
-    partial class AntitalDBContextModelSnapshot : ModelSnapshot
+    [Migration("20260426233312_AddUnverifiedOtpFields")]
+    partial class AddUnverifiedOtpFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Antital.Infrastructure/Migrations/20260426233312_AddUnverifiedOtpFields.cs
+++ b/Antital.Infrastructure/Migrations/20260426233312_AddUnverifiedOtpFields.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Antital.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUnverifiedOtpFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UnverifiedOtpCreatedAtUtc",
+                table: "Users",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UnverifiedOtpExpiresAtUtc",
+                table: "Users",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UnverifiedOtpHash",
+                table: "Users",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UnverifiedOtpCreatedAtUtc",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "UnverifiedOtpExpiresAtUtc",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "UnverifiedOtpHash",
+                table: "Users");
+        }
+    }
+}

--- a/Antital.Infrastructure/Services/EmailService.cs
+++ b/Antital.Infrastructure/Services/EmailService.cs
@@ -88,6 +88,28 @@ public class EmailService : IEmailService
         return SendEmailAsync(email, "Reset Your Password", htmlBody, cancellationToken);
     }
 
+    public Task SendUnverifiedOtpEmailAsync(string email, string otp, int validMinutes, CancellationToken cancellationToken)
+    {
+        var htmlBody = BuildEmailBody("unverified_otp.html", new Dictionary<string, string>
+        {
+            { "{{ email }}", email },
+            { "{{ otp }}", otp },
+            { "{{ valid_minutes }}", validMinutes.ToString() },
+            { "{{ base_url }}", _settings.BaseUrl ?? string.Empty }
+        },
+        fallback: $"""
+            <html><body>
+            <p>Hello,</p>
+            <p>Use this OTP to continue your unverified account request:</p>
+            <p><strong>{otp}</strong></p>
+            <p>This OTP will expire in {validMinutes} minutes.</p>
+            </body></html>
+            """);
+
+        LogEmail("Unverified Account OTP", email, "n/a", htmlBody);
+        return SendEmailAsync(email, "Your Account OTP", htmlBody, cancellationToken);
+    }
+
     public Task SendWelcomeEmailAsync(string email, string username, CancellationToken cancellationToken)
     {
         var htmlBody = BuildEmailBody("new_account.html", new Dictionary<string, string>

--- a/Antital.Test/Application/Features/Authentication/DeleteUnverifiedUser/DeleteUnverifiedUserCommandHandlerTests.cs
+++ b/Antital.Test/Application/Features/Authentication/DeleteUnverifiedUser/DeleteUnverifiedUserCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using Antital.Application.Common.Security;
 using Antital.Application.Features.Authentication.DeleteUnverifiedUser;
 using Antital.Domain.Interfaces;
 using Antital.Domain.Models;
@@ -28,11 +29,12 @@ public class DeleteUnverifiedUserCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ValidTokenUnverifiedUser_DeletesUser()
+    public async Task Handle_ValidOtpUnverifiedUser_DeletesUser()
     {
+        var otp = "123456";
         var command = new DeleteUnverifiedUserCommand(
             Email: "user@example.com",
-            Token: "valid_token_12345"
+            Otp: otp
         );
 
         var user = new User
@@ -40,8 +42,9 @@ public class DeleteUnverifiedUserCommandHandlerTests
             Id = 1,
             Email = command.Email,
             IsEmailVerified = false,
-            EmailVerificationToken = command.Token,
-            EmailVerificationTokenExpiry = DateTime.UtcNow.AddHours(1)
+            UnverifiedOtpHash = TokenGenerator.HashToken(otp),
+            UnverifiedOtpCreatedAtUtc = DateTime.UtcNow.AddMinutes(-1),
+            UnverifiedOtpExpiresAtUtc = DateTime.UtcNow.AddMinutes(10)
         };
 
         _userRepositoryMock
@@ -53,6 +56,10 @@ public class DeleteUnverifiedUserCommandHandlerTests
         result.IsSuccess.Should().BeTrue();
         _userRepositoryMock.Verify(x => x.DeleteAsync(user, It.IsAny<CancellationToken>()), Times.Once);
         _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+
+        user.UnverifiedOtpHash.Should().BeNull();
+        user.UnverifiedOtpCreatedAtUtc.Should().BeNull();
+        user.UnverifiedOtpExpiresAtUtc.Should().BeNull();
     }
 
     [Fact]
@@ -60,7 +67,7 @@ public class DeleteUnverifiedUserCommandHandlerTests
     {
         var command = new DeleteUnverifiedUserCommand(
             Email: "nonexistent@example.com",
-            Token: "any_token"
+            Otp: "123456"
         );
 
         _userRepositoryMock
@@ -78,16 +85,14 @@ public class DeleteUnverifiedUserCommandHandlerTests
     {
         var command = new DeleteUnverifiedUserCommand(
             Email: "verified@example.com",
-            Token: "some_token"
+            Otp: "123456"
         );
 
         var user = new User
         {
             Id = 2,
             Email = command.Email,
-            IsEmailVerified = true,
-            EmailVerificationToken = command.Token,
-            EmailVerificationTokenExpiry = DateTime.UtcNow.AddHours(1)
+            IsEmailVerified = true
         };
 
         _userRepositoryMock
@@ -101,11 +106,11 @@ public class DeleteUnverifiedUserCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_InvalidToken_ThrowsBadRequestException()
+    public async Task Handle_WrongOtp_ThrowsBadRequestException()
     {
         var command = new DeleteUnverifiedUserCommand(
             Email: "user@example.com",
-            Token: "wrong_token"
+            Otp: "000000"
         );
 
         var user = new User
@@ -113,8 +118,9 @@ public class DeleteUnverifiedUserCommandHandlerTests
             Id = 3,
             Email = command.Email,
             IsEmailVerified = false,
-            EmailVerificationToken = "correct_token",
-            EmailVerificationTokenExpiry = DateTime.UtcNow.AddHours(1)
+            UnverifiedOtpHash = TokenGenerator.HashToken("123456"),
+            UnverifiedOtpCreatedAtUtc = DateTime.UtcNow.AddMinutes(-1),
+            UnverifiedOtpExpiresAtUtc = DateTime.UtcNow.AddMinutes(10)
         };
 
         _userRepositoryMock
@@ -128,11 +134,12 @@ public class DeleteUnverifiedUserCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ExpiredToken_ThrowsBadRequestException()
+    public async Task Handle_ExpiredOtp_ThrowsBadRequestException()
     {
+        var otp = "123456";
         var command = new DeleteUnverifiedUserCommand(
             Email: "user@example.com",
-            Token: "expired_token"
+            Otp: otp
         );
 
         var user = new User
@@ -140,8 +147,9 @@ public class DeleteUnverifiedUserCommandHandlerTests
             Id = 4,
             Email = command.Email,
             IsEmailVerified = false,
-            EmailVerificationToken = command.Token,
-            EmailVerificationTokenExpiry = DateTime.UtcNow.AddHours(-1) // Expired
+            UnverifiedOtpHash = TokenGenerator.HashToken(otp),
+            UnverifiedOtpCreatedAtUtc = DateTime.UtcNow.AddMinutes(-15),
+            UnverifiedOtpExpiresAtUtc = DateTime.UtcNow.AddMinutes(-1)
         };
 
         _userRepositoryMock
@@ -155,11 +163,11 @@ public class DeleteUnverifiedUserCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_NullVerificationToken_ThrowsBadRequestException()
+    public async Task Handle_ConsumedOtp_ThrowsBadRequestException()
     {
         var command = new DeleteUnverifiedUserCommand(
             Email: "user@example.com",
-            Token: "some_token"
+            Otp: "123456"
         );
 
         var user = new User
@@ -167,8 +175,9 @@ public class DeleteUnverifiedUserCommandHandlerTests
             Id = 5,
             Email = command.Email,
             IsEmailVerified = false,
-            EmailVerificationToken = null,
-            EmailVerificationTokenExpiry = DateTime.UtcNow.AddHours(1)
+            UnverifiedOtpHash = null,
+            UnverifiedOtpCreatedAtUtc = null,
+            UnverifiedOtpExpiresAtUtc = null
         };
 
         _userRepositoryMock

--- a/Antital.Test/Application/Features/Authentication/RequestUnverifiedUserOtp/RequestUnverifiedUserOtpCommandHandlerTests.cs
+++ b/Antital.Test/Application/Features/Authentication/RequestUnverifiedUserOtp/RequestUnverifiedUserOtpCommandHandlerTests.cs
@@ -1,0 +1,144 @@
+using Antital.Application.Common.Security;
+using Antital.Application.Features.Authentication.RequestUnverifiedUserOtp;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Domain.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using Xunit;
+
+namespace Antital.Test.Application.Features.Authentication.RequestUnverifiedUserOtp;
+
+public class RequestUnverifiedUserOtpCommandHandlerTests
+{
+    private readonly Mock<IUserRepository> _userRepositoryMock = new();
+    private readonly Mock<IEmailService> _emailServiceMock = new();
+    private readonly Mock<IAntitalUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ICurrentUser> _currentUserMock = new();
+    private readonly RequestUnverifiedUserOtpCommandHandler _handler;
+
+    public RequestUnverifiedUserOtpCommandHandlerTests()
+    {
+        var inMemorySettings = new Dictionary<string, string?>
+        {
+            { "Email:UnverifiedOtpExpiryMinutes", "10" }
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings!)
+            .Build();
+
+        _unitOfWorkMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        _handler = new RequestUnverifiedUserOtpCommandHandler(
+            _userRepositoryMock.Object,
+            _emailServiceMock.Object,
+            _unitOfWorkMock.Object,
+            _currentUserMock.Object,
+            configuration
+        );
+    }
+
+    [Fact]
+    public async Task Handle_ExistingUnverifiedUser_GeneratesOtpAndSendsEmail()
+    {
+        var command = new RequestUnverifiedUserOtpCommand("user@example.com");
+        var user = new User
+        {
+            Id = 1,
+            Email = command.Email,
+            IsEmailVerified = false
+        };
+
+        _userRepositoryMock
+            .Setup(x => x.GetByEmailAsync(command.Email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        user.UnverifiedOtpHash.Should().NotBeNullOrWhiteSpace();
+        user.UnverifiedOtpCreatedAtUtc.Should().NotBeNull();
+        user.UnverifiedOtpExpiresAtUtc.Should().NotBeNull();
+        user.UnverifiedOtpExpiresAtUtc.Should().BeAfter(user.UnverifiedOtpCreatedAtUtc!.Value);
+
+        _userRepositoryMock.Verify(x => x.UpdateAsync(user, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _emailServiceMock.Verify(
+            x => x.SendUnverifiedOtpEmailAsync(command.Email, It.Is<string>(otp => otp.Length == 6 && otp.All(char.IsDigit)), 10, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UserDoesNotExist_ThrowsNotFoundException()
+    {
+        var command = new RequestUnverifiedUserOtpCommand("missing@example.com");
+
+        _userRepositoryMock
+            .Setup(x => x.GetByEmailAsync(command.Email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        Func<Task> act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+        _userRepositoryMock.Verify(x => x.UpdateAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+        _emailServiceMock.Verify(
+            x => x.SendUnverifiedOtpEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_UserAlreadyVerified_ThrowsBadRequestException()
+    {
+        var command = new RequestUnverifiedUserOtpCommand("verified@example.com");
+        var user = new User
+        {
+            Id = 2,
+            Email = command.Email,
+            IsEmailVerified = true
+        };
+
+        _userRepositoryMock
+            .Setup(x => x.GetByEmailAsync(command.Email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        Func<Task> act = async () => await _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<BadRequestException>();
+        _userRepositoryMock.Verify(x => x.UpdateAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+        _emailServiceMock.Verify(
+            x => x.SendUnverifiedOtpEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_StoresHashedOtp_NotPlaintext()
+    {
+        var command = new RequestUnverifiedUserOtpCommand("user@example.com");
+        var user = new User
+        {
+            Id = 3,
+            Email = command.Email,
+            IsEmailVerified = false
+        };
+        string? sentOtp = null;
+
+        _userRepositoryMock
+            .Setup(x => x.GetByEmailAsync(command.Email, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+
+        _emailServiceMock
+            .Setup(x => x.SendUnverifiedOtpEmailAsync(command.Email, It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, int, CancellationToken>((_, otp, _, _) => sentOtp = otp)
+            .Returns(Task.CompletedTask);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        sentOtp.Should().NotBeNullOrWhiteSpace();
+        user.UnverifiedOtpHash.Should().NotBe(sentOtp);
+        TokenGenerator.VerifyTokenHash(sentOtp!, user.UnverifiedOtpHash!).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
- Added a new endpoint to request a one-time password (OTP) for unverified accounts.
- Updated the user model to include fields for OTP management.
- Implemented email service to send OTP emails.
- Modified the delete unverified user command to validate OTP instead of a verification token.
- Updated application settings to include OTP expiry configuration.
- Added necessary migrations for database schema changes.
- Enhanced validation for OTP input in the command handler.

This change improves the security and user experience for managing unverified accounts.