### PR TITLE
Allow unverified users to log in

### DIFF
--- a/Antital.API/Controllers/AuthenticationController.cs
+++ b/Antital.API/Controllers/AuthenticationController.cs
@@ -49,7 +49,7 @@ public class AuthenticationController(IMediator mediator) : BaseController
     [SwaggerResponse(StatusCodes.Status200OK, "Login successful", typeof(AuthResponseDto))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(AuthResponseExample))]
     [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid request data", typeof(void))]
-    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Invalid credentials or email not verified", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Invalid credentials", typeof(void))]
     [SwaggerResponse(StatusCodes.Status404NotFound, "User not found", typeof(void))]
     public async Task<IActionResult> Login(LoginCommand request, CancellationToken cancellationToken)
     {

--- a/Antital.Application/Features/Authentication/Login/LoginCommandHandler.cs
+++ b/Antital.Application/Features/Authentication/Login/LoginCommandHandler.cs
@@ -34,13 +34,7 @@ public class LoginCommandHandler(
             throw new UnauthorizedException(Messages.Unauthorized);
         }
 
-        // 3. Check if email is verified → throw UnauthorizedException if not verified
-        if (!user.IsEmailVerified)
-        {
-            throw new UnauthorizedException("Email address has not been verified. Please verify your email before logging in.");
-        }
-
-        // 3b. Generate refresh token and persist
+        // 3. Generate refresh token and persist (verified and unverified users can log in)
         var refreshToken = TokenGenerator.GenerateSecureToken();
         user.RefreshTokenHash = TokenGenerator.HashToken(refreshToken);
         user.RefreshTokenExpiresAt = DateTime.UtcNow.AddDays(_refreshTokenDays);

--- a/Antital.Test/Application/Features/Authentication/Login/LoginCommandHandlerTests.cs
+++ b/Antital.Test/Application/Features/Authentication/Login/LoginCommandHandlerTests.cs
@@ -159,7 +159,7 @@ public class LoginCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_UnverifiedEmail_ThrowsUnauthorizedException()
+    public async Task Handle_UnverifiedEmail_ReturnsAuthResponseDtoWithUnverifiedFlag()
     {
         // Arrange
         var command = new LoginCommand(
@@ -184,13 +184,25 @@ public class LoginCommandHandlerTests
             .Setup(x => x.VerifyPassword(command.Password, user.PasswordHash))
             .Returns(true);
 
+        var jwtToken = "jwt_token_unverified";
+        _jwtTokenServiceMock
+            .Setup(x => x.GenerateToken(user))
+            .Returns(jwtToken);
+
         // Act
-        Func<Task> act = async () => await _handler.Handle(command, CancellationToken.None);
+        var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        await act.Should().ThrowAsync<UnauthorizedException>();
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Token.Should().Be(jwtToken);
+        result.Value.IsEmailVerified.Should().BeFalse();
+        result.Value.RefreshToken.Should().NotBeNullOrEmpty();
 
-        _jwtTokenServiceMock.Verify(x => x.GenerateToken(It.IsAny<User>()), Times.Never);
+        _jwtTokenServiceMock.Verify(x => x.GenerateToken(user), Times.Once);
+        _userRepositoryMock.Verify(x => x.UpdateAsync(user, It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/Antital.Test/Integration/API/Controllers/AuthenticationControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/AuthenticationControllerTests.cs
@@ -404,7 +404,7 @@ public class AuthenticationControllerTests : IClassFixture<CustomWebApplicationF
     }
 
     [Fact]
-    public async Task Login_UnverifiedEmail_Returns401Unauthorized()
+    public async Task Login_UnverifiedEmail_Returns200WithUnverifiedFlag()
     {
         // Arrange
         var user = new User
@@ -436,7 +436,14 @@ public class AuthenticationControllerTests : IClassFixture<CustomWebApplicationF
         var response = await _client.PostAsJsonAsync("/api/auth/login", command);
 
         // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<AuthResponseDto>>(JsonOptions);
+        result.Should().NotBeNull();
+        result!.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.IsEmailVerified.Should().BeFalse();
+        result.Value.Token.Should().NotBeNullOrEmpty();
+        result.Value.RefreshToken.Should().NotBeNullOrEmpty();
     }
 
     [Fact]
@@ -774,7 +781,7 @@ public class AuthenticationControllerTests : IClassFixture<CustomWebApplicationF
     }
 
     [Fact]
-    public async Task FullFlow_SignUp_TryLoginWithoutVerification_ShouldFail()
+    public async Task FullFlow_SignUp_TryLoginWithoutVerification_ShouldSucceedWithUnverifiedFlag()
     {
         // Arrange & Act - SignUp
         var signUpCommand = new SignUpCommand(
@@ -805,7 +812,14 @@ public class AuthenticationControllerTests : IClassFixture<CustomWebApplicationF
         var loginResponse = await _client.PostAsJsonAsync("/api/auth/login", loginCommand);
 
         // Assert
-        loginResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var loginResult = await loginResponse.Content.ReadFromJsonAsync<Result<AuthResponseDto>>(JsonOptions);
+        loginResult.Should().NotBeNull();
+        loginResult!.IsSuccess.Should().BeTrue();
+        loginResult.Value.Should().NotBeNull();
+        loginResult.Value!.IsEmailVerified.Should().BeFalse();
+        loginResult.Value.Token.Should().NotBeNullOrEmpty();
+        loginResult.Value.RefreshToken.Should().NotBeNullOrEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Remove login-time block that returned 401 when IsEmailVerified was false.
- Continue issuing JWT + refresh token for unverified users.
- Update /api/auth/login Swagger 401 description to only mention invalid credentials.

## Tests Updated
- LoginCommandHandlerTests: unverified login now expected to succeed with IsEmailVerified=false.
- AuthenticationControllerTests: unverified login now expected 200 OK with unverified flag.

## Validation
- dotnet test Antital.Test/Antital.Test.csproj --filter "FullyQualifiedName~LoginCommandHandlerTests"
- dotnet test Antital.Test/Antital.Test.csproj --filter "FullyQualifiedName~Integration.API.Controllers.AuthenticationControllerTests"
- dotnet test Antital.Test/Antital.Test.csproj --filter "FullyQualifiedName~Integration"

All passed.