### PR TITLE
Add domain-first investment offerings API

### DIFF
--- a/Antital.API/Configs/AppUseExtensions.cs
+++ b/Antital.API/Configs/AppUseExtensions.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using Antital.Infrastructure;
+using Antital.Infrastructure.Seed;
 using System.Text;
 
 namespace Antital.API.Configs;
@@ -112,6 +113,11 @@ public static class AppUseExtensions
                 }
 
                 context.Database.Migrate();
+
+                if (!env.IsEnvironment("Testing"))
+                {
+                    InvestmentOfferingSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
+                }
             }
             catch (Exception ex)
             {

--- a/Antital.API/Configs/DependencyInjection.cs
+++ b/Antital.API/Configs/DependencyInjection.cs
@@ -1,3 +1,4 @@
+using Antital.Application.Features.Investments;
 using Antital.Application.Features.Onboarding;
 using Antital.Application.Services;
 using Antital.Domain.Interfaces;
@@ -55,6 +56,7 @@ public static class DependencyInjection
         services.AddScoped(typeof(IUserOnboardingRepository), typeof(UserOnboardingRepository));
         services.AddScoped(typeof(IUserInvestmentProfileRepository), typeof(UserInvestmentProfileRepository));
         services.AddScoped(typeof(IUserKycRepository), typeof(UserKycRepository));
+        services.AddScoped(typeof(IInvestmentOfferingRepository), typeof(InvestmentOfferingRepository));
 
         return services;
     }
@@ -98,6 +100,7 @@ public static class DependencyInjection
         services.AddScoped<IAntitalCurrentUser, AntitalCurrentUser>();
         services.AddScoped<IKycVerificationService, PassThroughKycVerificationService>();
         services.AddScoped<IOnboardingUserAccess, OnboardingUserAccess>();
+        services.AddScoped<InvestmentOfferingAccess>();
 
         return services;
     }

--- a/Antital.API/Controllers/InvestmentsController.cs
+++ b/Antital.API/Controllers/InvestmentsController.cs
@@ -1,0 +1,112 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Application.Features.Investments.GetOfferingContentBlocks;
+using Antital.Application.Features.Investments.GetOfferingDocuments;
+using Antital.Application.Features.Investments.GetOfferingFinancials;
+using Antital.Application.Features.Investments.GetOfferingHighlights;
+using Antital.Application.Features.Investments.GetOfferingMedia;
+using Antital.Application.Features.Investments.GetOfferingRisks;
+using Antital.Application.Features.Investments.GetOfferingShell;
+using Antital.Application.Features.Investments.GetOfferingTeam;
+using Antital.Application.Features.Investments.GetOfferingTestimonials;
+using Antital.Application.Features.Investments.GetOfferingUpdates;
+using Antital.Application.Features.Investments.ListInvestments;
+using BuildingBlocks.API.Controllers;
+using BuildingBlocks.Application.Features;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Antital.API.Controllers;
+
+[SwaggerTag("Investments")]
+[Route("api/investments")]
+[AllowAnonymous]
+[ApiController]
+public class InvestmentsController(IMediator mediator) : BaseController
+{
+    [HttpGet]
+    [SwaggerOperation("List Investments", "Returns paginated published investment offerings for explore/landing cards.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<InvestmentListResponse>))]
+    public async Task<IActionResult> List(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 12,
+        [FromQuery] string? category = null,
+        [FromQuery] string? risk = null,
+        [FromQuery] string? search = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new ListInvestmentsQuery(page, pageSize, category, risk, search),
+            cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpGet("{idOrSlug}")]
+    [SwaggerOperation("Get Investment Shell", "Returns offering identity, funding, deal terms, and corporate profile.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<OfferingShellResponse>))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Not found", typeof(void))]
+    public async Task<IActionResult> GetShell(string idOrSlug, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetOfferingShellQuery(idOrSlug), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpGet("{idOrSlug}/highlights")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<IReadOnlyList<HighlightDto>>))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Not found", typeof(void))]
+    public async Task<IActionResult> GetHighlights(string idOrSlug, CancellationToken cancellationToken) =>
+        ApiResult(await mediator.Send(new GetOfferingHighlightsQuery(idOrSlug), cancellationToken));
+
+    [HttpGet("{idOrSlug}/content-blocks")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<IReadOnlyList<ContentBlockDto>>))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Not found", typeof(void))]
+    public async Task<IActionResult> GetContentBlocks(string idOrSlug, CancellationToken cancellationToken) =>
+        ApiResult(await mediator.Send(new GetOfferingContentBlocksQuery(idOrSlug), cancellationToken));
+
+    [HttpGet("{idOrSlug}/team")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<IReadOnlyList<TeamMemberDto>>))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Not found", typeof(void))]
+    public async Task<IActionResult> GetTeam(string idOrSlug, CancellationToken cancellationToken) =>
+        ApiResult(await mediator.Send(new GetOfferingTeamQuery(idOrSlug), cancellationToken));
+
+    [HttpGet("{idOrSlug}/financials")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<OfferingFinancialsResponse>))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Not found", typeof(void))]
+    public async Task<IActionResult> GetFinancials(string idOrSlug, CancellationToken cancellationToken) =>
+        ApiResult(await mediator.Send(new GetOfferingFinancialsQuery(idOrSlug), cancellationToken));
+
+    [HttpGet("{idOrSlug}/risks")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<IReadOnlyList<OfferingRiskDto>>))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Not found", typeof(void))]
+    public async Task<IActionResult> GetRisks(string idOrSlug, CancellationToken cancellationToken) =>
+        ApiResult(await mediator.Send(new GetOfferingRisksQuery(idOrSlug), cancellationToken));
+
+    [HttpGet("{idOrSlug}/documents")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<IReadOnlyList<OfferingDocumentDto>>))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Not found", typeof(void))]
+    public async Task<IActionResult> GetDocuments(string idOrSlug, CancellationToken cancellationToken) =>
+        ApiResult(await mediator.Send(new GetOfferingDocumentsQuery(idOrSlug), cancellationToken));
+
+    [HttpGet("{idOrSlug}/media")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<IReadOnlyList<MediaAssetDto>>))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Not found", typeof(void))]
+    public async Task<IActionResult> GetMedia(string idOrSlug, CancellationToken cancellationToken) =>
+        ApiResult(await mediator.Send(new GetOfferingMediaQuery(idOrSlug), cancellationToken));
+
+    [HttpGet("{idOrSlug}/updates")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<OfferingUpdatesResponse>))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Not found", typeof(void))]
+    public async Task<IActionResult> GetUpdates(
+        string idOrSlug,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default) =>
+        ApiResult(await mediator.Send(new GetOfferingUpdatesQuery(idOrSlug, page, pageSize), cancellationToken));
+
+    [HttpGet("{idOrSlug}/testimonials")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<IReadOnlyList<TestimonialDto>>))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Not found", typeof(void))]
+    public async Task<IActionResult> GetTestimonials(string idOrSlug, CancellationToken cancellationToken) =>
+        ApiResult(await mediator.Send(new GetOfferingTestimonialsQuery(idOrSlug), cancellationToken));
+}

--- a/Antital.Application/DTOs/Investments/InvestmentListDtos.cs
+++ b/Antital.Application/DTOs/Investments/InvestmentListDtos.cs
@@ -1,0 +1,22 @@
+namespace Antital.Application.DTOs.Investments;
+
+public record InvestmentListItemDto(
+    int Id,
+    string Slug,
+    string Name,
+    string Category,
+    string Tagline,
+    string CoverImageUrl,
+    string Risk,
+    int InvestorCount,
+    int? DaysLeft,
+    decimal MinInvestment,
+    decimal RaisedAmount,
+    decimal FundingGoal,
+    int FundingProgressPercent);
+
+public record InvestmentListResponse(
+    IReadOnlyList<InvestmentListItemDto> Items,
+    int Page,
+    int PageSize,
+    int TotalCount);

--- a/Antital.Application/DTOs/Investments/OfferingResourceDtos.cs
+++ b/Antital.Application/DTOs/Investments/OfferingResourceDtos.cs
@@ -1,0 +1,93 @@
+namespace Antital.Application.DTOs.Investments;
+
+public record HighlightDto(
+    int Id,
+    string Kind,
+    string? Headline,
+    string Body,
+    int SortOrder);
+
+public record ContentBlockItemDto(
+    int Id,
+    string Label,
+    string Body,
+    int SortOrder);
+
+public record ContentBlockDto(
+    int Id,
+    string BlockType,
+    string? Key,
+    string? Title,
+    string? Summary,
+    int SortOrder,
+    IReadOnlyList<ContentBlockItemDto> Items);
+
+public record TeamMemberDto(
+    int Id,
+    string Name,
+    string Title,
+    string Bio,
+    string? ImageUrl,
+    int SortOrder);
+
+public record FinancialMetricDto(
+    int Id,
+    string MetricName,
+    string PeriodLabel,
+    int PeriodSortOrder,
+    decimal? Value,
+    string Unit,
+    string? CurrencyCode,
+    string ValueType);
+
+public record UseOfProceedsItemDto(
+    int Id,
+    decimal? AllocationPercent,
+    string Category,
+    string Description,
+    int SortOrder);
+
+public record OfferingFinancialsResponse(
+    IReadOnlyList<FinancialMetricDto> Metrics,
+    IReadOnlyList<UseOfProceedsItemDto> UseOfProceeds);
+
+public record OfferingRiskDto(
+    int Id,
+    string Category,
+    string Description,
+    string Mitigation,
+    int SortOrder);
+
+public record OfferingDocumentDto(
+    int Id,
+    string Title,
+    string FileUrl,
+    string DocumentType,
+    int? PageCount);
+
+public record MediaAssetDto(
+    int Id,
+    string AssetType,
+    string Url,
+    int SortOrder);
+
+public record OfferingUpdateDto(
+    int Id,
+    DateTime PublishedAt,
+    string Title,
+    string Body,
+    int LikeCount);
+
+public record OfferingUpdatesResponse(
+    IReadOnlyList<OfferingUpdateDto> Items,
+    int Page,
+    int PageSize,
+    int TotalCount);
+
+public record TestimonialDto(
+    int Id,
+    string Quote,
+    string AuthorName,
+    string AuthorTitle,
+    string? ImageUrl,
+    int SortOrder);

--- a/Antital.Application/DTOs/Investments/OfferingShellDtos.cs
+++ b/Antital.Application/DTOs/Investments/OfferingShellDtos.cs
@@ -1,0 +1,44 @@
+namespace Antital.Application.DTOs.Investments;
+
+public record OfferingSummaryDto(
+    int Id,
+    string Slug,
+    string Name,
+    string Category,
+    string Tagline,
+    string CoverImageUrl,
+    string Risk,
+    int? DaysLeft,
+    string Status);
+
+public record OfferingFundingDto(
+    decimal RaisedAmount,
+    decimal FundingGoal,
+    int InvestorCount,
+    decimal SharePrice,
+    decimal? TargetRating,
+    decimal MinInvestment,
+    decimal MaxInvestment,
+    int FundingProgressPercent);
+
+public record DealTermsDto(
+    long TotalSharesOffered,
+    decimal PricePerShare,
+    decimal MinimumInvestment,
+    decimal MaximumInvestment,
+    decimal MinimumThreshold,
+    decimal FundingGoal,
+    DateTime Deadline);
+
+public record CorporateProfileDto(
+    string EntityType,
+    string Jurisdiction,
+    int IncorporationYear,
+    string RegistrationId,
+    string? AdditionalNotes);
+
+public record OfferingShellResponse(
+    OfferingSummaryDto Offering,
+    OfferingFundingDto Funding,
+    DealTermsDto DealTerms,
+    CorporateProfileDto? CorporateProfile);

--- a/Antital.Application/Features/Investments/GetOfferingContentBlocks/GetOfferingContentBlocksQuery.cs
+++ b/Antital.Application/Features/Investments/GetOfferingContentBlocks/GetOfferingContentBlocksQuery.cs
@@ -1,0 +1,27 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.GetOfferingContentBlocks;
+
+public record GetOfferingContentBlocksQuery(string IdOrSlug) : ICommandQuery<IReadOnlyList<ContentBlockDto>>;
+
+public class GetOfferingContentBlocksQueryHandler(
+    InvestmentOfferingAccess offeringAccess,
+    IInvestmentOfferingRepository repository)
+    : ICommandQueryHandler<GetOfferingContentBlocksQuery, IReadOnlyList<ContentBlockDto>>
+{
+    public async Task<Result<IReadOnlyList<ContentBlockDto>>> Handle(
+        GetOfferingContentBlocksQuery request,
+        CancellationToken cancellationToken)
+    {
+        var offeringId = await offeringAccess.RequirePublishedOfferingIdAsync(request.IdOrSlug, cancellationToken);
+        var blocks = await repository.GetContentBlocksAsync(offeringId, cancellationToken);
+        var dtos = blocks.Select(InvestmentMappers.ToContentBlockDto).ToList();
+
+        var result = new Result<IReadOnlyList<ContentBlockDto>>();
+        result.AddValue(dtos);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investments/GetOfferingDocuments/GetOfferingDocumentsQuery.cs
+++ b/Antital.Application/Features/Investments/GetOfferingDocuments/GetOfferingDocumentsQuery.cs
@@ -1,0 +1,27 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.GetOfferingDocuments;
+
+public record GetOfferingDocumentsQuery(string IdOrSlug) : ICommandQuery<IReadOnlyList<OfferingDocumentDto>>;
+
+public class GetOfferingDocumentsQueryHandler(
+    InvestmentOfferingAccess offeringAccess,
+    IInvestmentOfferingRepository repository)
+    : ICommandQueryHandler<GetOfferingDocumentsQuery, IReadOnlyList<OfferingDocumentDto>>
+{
+    public async Task<Result<IReadOnlyList<OfferingDocumentDto>>> Handle(
+        GetOfferingDocumentsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var offeringId = await offeringAccess.RequirePublishedOfferingIdAsync(request.IdOrSlug, cancellationToken);
+        var documents = await repository.GetDocumentsAsync(offeringId, cancellationToken);
+        var dtos = documents.Select(InvestmentMappers.ToDocumentDto).ToList();
+
+        var result = new Result<IReadOnlyList<OfferingDocumentDto>>();
+        result.AddValue(dtos);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investments/GetOfferingFinancials/GetOfferingFinancialsQuery.cs
+++ b/Antital.Application/Features/Investments/GetOfferingFinancials/GetOfferingFinancialsQuery.cs
@@ -1,0 +1,31 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.GetOfferingFinancials;
+
+public record GetOfferingFinancialsQuery(string IdOrSlug) : ICommandQuery<OfferingFinancialsResponse>;
+
+public class GetOfferingFinancialsQueryHandler(
+    InvestmentOfferingAccess offeringAccess,
+    IInvestmentOfferingRepository repository)
+    : ICommandQueryHandler<GetOfferingFinancialsQuery, OfferingFinancialsResponse>
+{
+    public async Task<Result<OfferingFinancialsResponse>> Handle(
+        GetOfferingFinancialsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var offeringId = await offeringAccess.RequirePublishedOfferingIdAsync(request.IdOrSlug, cancellationToken);
+        var metrics = await repository.GetFinancialMetricsAsync(offeringId, cancellationToken);
+        var useOfProceeds = await repository.GetUseOfProceedsItemsAsync(offeringId, cancellationToken);
+
+        var response = new OfferingFinancialsResponse(
+            metrics.Select(InvestmentMappers.ToFinancialMetricDto).ToList(),
+            useOfProceeds.Select(InvestmentMappers.ToUseOfProceedsDto).ToList());
+
+        var result = new Result<OfferingFinancialsResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investments/GetOfferingHighlights/GetOfferingHighlightsQuery.cs
+++ b/Antital.Application/Features/Investments/GetOfferingHighlights/GetOfferingHighlightsQuery.cs
@@ -1,0 +1,27 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.GetOfferingHighlights;
+
+public record GetOfferingHighlightsQuery(string IdOrSlug) : ICommandQuery<IReadOnlyList<HighlightDto>>;
+
+public class GetOfferingHighlightsQueryHandler(
+    InvestmentOfferingAccess offeringAccess,
+    IInvestmentOfferingRepository repository)
+    : ICommandQueryHandler<GetOfferingHighlightsQuery, IReadOnlyList<HighlightDto>>
+{
+    public async Task<Result<IReadOnlyList<HighlightDto>>> Handle(
+        GetOfferingHighlightsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var offeringId = await offeringAccess.RequirePublishedOfferingIdAsync(request.IdOrSlug, cancellationToken);
+        var highlights = await repository.GetHighlightsAsync(offeringId, cancellationToken);
+        var dtos = highlights.Select(InvestmentMappers.ToHighlightDto).ToList();
+
+        var result = new Result<IReadOnlyList<HighlightDto>>();
+        result.AddValue(dtos);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investments/GetOfferingMedia/GetOfferingMediaQuery.cs
+++ b/Antital.Application/Features/Investments/GetOfferingMedia/GetOfferingMediaQuery.cs
@@ -1,0 +1,27 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.GetOfferingMedia;
+
+public record GetOfferingMediaQuery(string IdOrSlug) : ICommandQuery<IReadOnlyList<MediaAssetDto>>;
+
+public class GetOfferingMediaQueryHandler(
+    InvestmentOfferingAccess offeringAccess,
+    IInvestmentOfferingRepository repository)
+    : ICommandQueryHandler<GetOfferingMediaQuery, IReadOnlyList<MediaAssetDto>>
+{
+    public async Task<Result<IReadOnlyList<MediaAssetDto>>> Handle(
+        GetOfferingMediaQuery request,
+        CancellationToken cancellationToken)
+    {
+        var offeringId = await offeringAccess.RequirePublishedOfferingIdAsync(request.IdOrSlug, cancellationToken);
+        var media = await repository.GetMediaAssetsAsync(offeringId, cancellationToken);
+        var dtos = media.Select(InvestmentMappers.ToMediaAssetDto).ToList();
+
+        var result = new Result<IReadOnlyList<MediaAssetDto>>();
+        result.AddValue(dtos);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investments/GetOfferingRisks/GetOfferingRisksQuery.cs
+++ b/Antital.Application/Features/Investments/GetOfferingRisks/GetOfferingRisksQuery.cs
@@ -1,0 +1,27 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.GetOfferingRisks;
+
+public record GetOfferingRisksQuery(string IdOrSlug) : ICommandQuery<IReadOnlyList<OfferingRiskDto>>;
+
+public class GetOfferingRisksQueryHandler(
+    InvestmentOfferingAccess offeringAccess,
+    IInvestmentOfferingRepository repository)
+    : ICommandQueryHandler<GetOfferingRisksQuery, IReadOnlyList<OfferingRiskDto>>
+{
+    public async Task<Result<IReadOnlyList<OfferingRiskDto>>> Handle(
+        GetOfferingRisksQuery request,
+        CancellationToken cancellationToken)
+    {
+        var offeringId = await offeringAccess.RequirePublishedOfferingIdAsync(request.IdOrSlug, cancellationToken);
+        var risks = await repository.GetRisksAsync(offeringId, cancellationToken);
+        var dtos = risks.Select(InvestmentMappers.ToRiskDto).ToList();
+
+        var result = new Result<IReadOnlyList<OfferingRiskDto>>();
+        result.AddValue(dtos);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investments/GetOfferingShell/GetOfferingShellQuery.cs
+++ b/Antital.Application/Features/Investments/GetOfferingShell/GetOfferingShellQuery.cs
@@ -1,0 +1,6 @@
+using Antital.Application.DTOs.Investments;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.GetOfferingShell;
+
+public record GetOfferingShellQuery(string IdOrSlug) : ICommandQuery<OfferingShellResponse>;

--- a/Antital.Application/Features/Investments/GetOfferingShell/GetOfferingShellQueryHandler.cs
+++ b/Antital.Application/Features/Investments/GetOfferingShell/GetOfferingShellQueryHandler.cs
@@ -1,0 +1,27 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using BuildingBlocks.Resources;
+
+namespace Antital.Application.Features.Investments.GetOfferingShell;
+
+public class GetOfferingShellQueryHandler(IInvestmentOfferingRepository repository)
+    : ICommandQueryHandler<GetOfferingShellQuery, OfferingShellResponse>
+{
+    public async Task<Result<OfferingShellResponse>> Handle(GetOfferingShellQuery request, CancellationToken cancellationToken)
+    {
+        var offering = await repository.GetPublishedShellByIdOrSlugAsync(request.IdOrSlug, cancellationToken);
+        if (offering?.Funding == null || offering.DealTerms == null)
+        {
+            throw new NotFoundException(Messages.NotFound);
+        }
+
+        var response = InvestmentMappers.ToShellResponse(offering);
+
+        var result = new Result<OfferingShellResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investments/GetOfferingTeam/GetOfferingTeamQuery.cs
+++ b/Antital.Application/Features/Investments/GetOfferingTeam/GetOfferingTeamQuery.cs
@@ -1,0 +1,27 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.GetOfferingTeam;
+
+public record GetOfferingTeamQuery(string IdOrSlug) : ICommandQuery<IReadOnlyList<TeamMemberDto>>;
+
+public class GetOfferingTeamQueryHandler(
+    InvestmentOfferingAccess offeringAccess,
+    IInvestmentOfferingRepository repository)
+    : ICommandQueryHandler<GetOfferingTeamQuery, IReadOnlyList<TeamMemberDto>>
+{
+    public async Task<Result<IReadOnlyList<TeamMemberDto>>> Handle(
+        GetOfferingTeamQuery request,
+        CancellationToken cancellationToken)
+    {
+        var offeringId = await offeringAccess.RequirePublishedOfferingIdAsync(request.IdOrSlug, cancellationToken);
+        var team = await repository.GetTeamMembersAsync(offeringId, cancellationToken);
+        var dtos = team.Select(InvestmentMappers.ToTeamMemberDto).ToList();
+
+        var result = new Result<IReadOnlyList<TeamMemberDto>>();
+        result.AddValue(dtos);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investments/GetOfferingTestimonials/GetOfferingTestimonialsQuery.cs
+++ b/Antital.Application/Features/Investments/GetOfferingTestimonials/GetOfferingTestimonialsQuery.cs
@@ -1,0 +1,27 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.GetOfferingTestimonials;
+
+public record GetOfferingTestimonialsQuery(string IdOrSlug) : ICommandQuery<IReadOnlyList<TestimonialDto>>;
+
+public class GetOfferingTestimonialsQueryHandler(
+    InvestmentOfferingAccess offeringAccess,
+    IInvestmentOfferingRepository repository)
+    : ICommandQueryHandler<GetOfferingTestimonialsQuery, IReadOnlyList<TestimonialDto>>
+{
+    public async Task<Result<IReadOnlyList<TestimonialDto>>> Handle(
+        GetOfferingTestimonialsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var offeringId = await offeringAccess.RequirePublishedOfferingIdAsync(request.IdOrSlug, cancellationToken);
+        var testimonials = await repository.GetTestimonialsAsync(offeringId, cancellationToken);
+        var dtos = testimonials.Select(InvestmentMappers.ToTestimonialDto).ToList();
+
+        var result = new Result<IReadOnlyList<TestimonialDto>>();
+        result.AddValue(dtos);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investments/GetOfferingUpdates/GetOfferingUpdatesQuery.cs
+++ b/Antital.Application/Features/Investments/GetOfferingUpdates/GetOfferingUpdatesQuery.cs
@@ -1,0 +1,36 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.GetOfferingUpdates;
+
+public record GetOfferingUpdatesQuery(string IdOrSlug, int Page = 1, int PageSize = 20) : ICommandQuery<OfferingUpdatesResponse>;
+
+public class GetOfferingUpdatesQueryHandler(
+    InvestmentOfferingAccess offeringAccess,
+    IInvestmentOfferingRepository repository)
+    : ICommandQueryHandler<GetOfferingUpdatesQuery, OfferingUpdatesResponse>
+{
+    private const int MaxPageSize = 50;
+
+    public async Task<Result<OfferingUpdatesResponse>> Handle(
+        GetOfferingUpdatesQuery request,
+        CancellationToken cancellationToken)
+    {
+        var offeringId = await offeringAccess.RequirePublishedOfferingIdAsync(request.IdOrSlug, cancellationToken);
+        var page = request.Page < 1 ? 1 : request.Page;
+        var pageSize = request.PageSize < 1 ? 20 : Math.Min(request.PageSize, MaxPageSize);
+
+        var (items, totalCount) = await repository.GetUpdatesAsync(offeringId, page, pageSize, cancellationToken);
+        var response = new OfferingUpdatesResponse(
+            items.Select(InvestmentMappers.ToUpdateDto).ToList(),
+            page,
+            pageSize,
+            totalCount);
+
+        var result = new Result<OfferingUpdatesResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investments/InvestmentMappers.cs
+++ b/Antital.Application/Features/Investments/InvestmentMappers.cs
@@ -132,20 +132,24 @@ internal static class InvestmentMappers
             testimonial.ImageUrl,
             testimonial.SortOrder);
 
-    public static OfferingRiskLevel? ParseRiskFilter(string? risk)
+    public static bool TryParseRiskFilter(string? risk, out OfferingRiskLevel? parsed)
     {
+        parsed = null;
+
         if (string.IsNullOrWhiteSpace(risk))
         {
-            return null;
+            return true;
         }
 
-        return risk.Trim().ToLowerInvariant() switch
+        parsed = risk.Trim().ToLowerInvariant() switch
         {
             "low" => OfferingRiskLevel.Low,
             "moderate" => OfferingRiskLevel.Moderate,
             "high" => OfferingRiskLevel.High,
             _ => null,
         };
+
+        return parsed.HasValue;
     }
 
     private static string ToRiskString(OfferingRiskLevel risk) =>

--- a/Antital.Application/Features/Investments/InvestmentMappers.cs
+++ b/Antital.Application/Features/Investments/InvestmentMappers.cs
@@ -1,0 +1,173 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+
+namespace Antital.Application.Features.Investments;
+
+internal static class InvestmentMappers
+{
+    public static InvestmentListItemDto ToListItem(InvestmentOffering offering)
+    {
+        var funding = offering.Funding!;
+        return new InvestmentListItemDto(
+            offering.Id,
+            offering.Slug,
+            offering.Name,
+            offering.Category,
+            offering.Tagline,
+            offering.CoverImageUrl,
+            ToRiskString(offering.RiskLevel),
+            funding.InvestorCount,
+            ComputeDaysLeft(offering.DealTerms?.Deadline),
+            funding.MinInvestment,
+            funding.RaisedAmount,
+            funding.FundingGoal,
+            ComputeFundingProgressPercent(funding.RaisedAmount, funding.FundingGoal));
+    }
+
+    public static OfferingShellResponse ToShellResponse(InvestmentOffering offering)
+    {
+        var funding = offering.Funding!;
+        var dealTerms = offering.DealTerms!;
+
+        return new OfferingShellResponse(
+            new OfferingSummaryDto(
+                offering.Id,
+                offering.Slug,
+                offering.Name,
+                offering.Category,
+                offering.Tagline,
+                offering.CoverImageUrl,
+                ToRiskString(offering.RiskLevel),
+                ComputeDaysLeft(dealTerms.Deadline),
+                offering.Status.ToString().ToLowerInvariant()),
+            new OfferingFundingDto(
+                funding.RaisedAmount,
+                funding.FundingGoal,
+                funding.InvestorCount,
+                funding.SharePrice,
+                funding.TargetRating,
+                funding.MinInvestment,
+                funding.MaxInvestment,
+                ComputeFundingProgressPercent(funding.RaisedAmount, funding.FundingGoal)),
+            new DealTermsDto(
+                dealTerms.TotalSharesOffered,
+                dealTerms.PricePerShare,
+                dealTerms.MinimumInvestment,
+                dealTerms.MaximumInvestment,
+                dealTerms.MinimumThreshold,
+                dealTerms.FundingGoal,
+                dealTerms.Deadline),
+            offering.CorporateProfile == null
+                ? null
+                : new CorporateProfileDto(
+                    offering.CorporateProfile.EntityType,
+                    offering.CorporateProfile.Jurisdiction,
+                    offering.CorporateProfile.IncorporationYear,
+                    offering.CorporateProfile.RegistrationId,
+                    offering.CorporateProfile.AdditionalNotes));
+    }
+
+    public static HighlightDto ToHighlightDto(Highlight highlight) =>
+        new(
+            highlight.Id,
+            highlight.Kind.ToString().ToLowerInvariant(),
+            highlight.Headline,
+            highlight.Body,
+            highlight.SortOrder);
+
+    public static ContentBlockDto ToContentBlockDto(OfferingContentBlock block) =>
+        new(
+            block.Id,
+            block.BlockType.ToString(),
+            block.Key,
+            block.Title,
+            block.Summary,
+            block.SortOrder,
+            block.Items
+                .OrderBy(i => i.SortOrder)
+                .Select(i => new ContentBlockItemDto(i.Id, i.Label, i.Body, i.SortOrder))
+                .ToList());
+
+    public static TeamMemberDto ToTeamMemberDto(TeamMember member) =>
+        new(member.Id, member.Name, member.Title, member.Bio, member.ImageUrl, member.SortOrder);
+
+    public static FinancialMetricDto ToFinancialMetricDto(FinancialMetric metric) =>
+        new(
+            metric.Id,
+            metric.MetricName,
+            metric.PeriodLabel,
+            metric.PeriodSortOrder,
+            metric.Value,
+            metric.Unit.ToString().ToLowerInvariant(),
+            metric.CurrencyCode,
+            metric.ValueType.ToString().ToLowerInvariant());
+
+    public static UseOfProceedsItemDto ToUseOfProceedsDto(UseOfProceedsItem item) =>
+        new(item.Id, item.AllocationPercent, item.Category, item.Description, item.SortOrder);
+
+    public static OfferingRiskDto ToRiskDto(OfferingRisk risk) =>
+        new(risk.Id, risk.Category, risk.Description, risk.Mitigation, risk.SortOrder);
+
+    public static OfferingDocumentDto ToDocumentDto(OfferingDocument document) =>
+        new(
+            document.Id,
+            document.Title,
+            document.FileUrl,
+            document.DocumentType.ToString(),
+            document.PageCount);
+
+    public static MediaAssetDto ToMediaAssetDto(MediaAsset asset) =>
+        new(asset.Id, asset.AssetType.ToString(), asset.Url, asset.SortOrder);
+
+    public static OfferingUpdateDto ToUpdateDto(OfferingUpdate update) =>
+        new(update.Id, update.PublishedAt, update.Title, update.Body, update.LikeCount);
+
+    public static TestimonialDto ToTestimonialDto(Testimonial testimonial) =>
+        new(
+            testimonial.Id,
+            testimonial.Quote,
+            testimonial.AuthorName,
+            testimonial.AuthorTitle,
+            testimonial.ImageUrl,
+            testimonial.SortOrder);
+
+    public static OfferingRiskLevel? ParseRiskFilter(string? risk)
+    {
+        if (string.IsNullOrWhiteSpace(risk))
+        {
+            return null;
+        }
+
+        return risk.Trim().ToLowerInvariant() switch
+        {
+            "low" => OfferingRiskLevel.Low,
+            "moderate" => OfferingRiskLevel.Moderate,
+            "high" => OfferingRiskLevel.High,
+            _ => null,
+        };
+    }
+
+    private static string ToRiskString(OfferingRiskLevel risk) =>
+        risk switch
+        {
+            OfferingRiskLevel.Low => "low",
+            OfferingRiskLevel.Moderate => "moderate",
+            OfferingRiskLevel.High => "high",
+            _ => risk.ToString().ToLowerInvariant(),
+        };
+
+    private static int ComputeFundingProgressPercent(decimal raised, decimal goal) =>
+        goal <= 0 ? 0 : (int)Math.Round(raised / goal * 100m, MidpointRounding.AwayFromZero);
+
+    private static int? ComputeDaysLeft(DateTime? deadline)
+    {
+        if (!deadline.HasValue)
+        {
+            return null;
+        }
+
+        var days = (int)Math.Ceiling((deadline.Value - DateTime.UtcNow).TotalDays);
+        return Math.Max(0, days);
+    }
+}

--- a/Antital.Application/Features/Investments/InvestmentOfferingAccess.cs
+++ b/Antital.Application/Features/Investments/InvestmentOfferingAccess.cs
@@ -1,0 +1,19 @@
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Resources;
+
+namespace Antital.Application.Features.Investments;
+
+public class InvestmentOfferingAccess(IInvestmentOfferingRepository repository)
+{
+    public async Task<int> RequirePublishedOfferingIdAsync(string idOrSlug, CancellationToken cancellationToken)
+    {
+        var offeringId = await repository.GetPublishedOfferingIdAsync(idOrSlug, cancellationToken);
+        if (!offeringId.HasValue)
+        {
+            throw new NotFoundException(Messages.NotFound);
+        }
+
+        return offeringId.Value;
+    }
+}

--- a/Antital.Application/Features/Investments/ListInvestments/ListInvestmentsQuery.cs
+++ b/Antital.Application/Features/Investments/ListInvestments/ListInvestmentsQuery.cs
@@ -1,0 +1,11 @@
+using Antital.Application.DTOs.Investments;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.ListInvestments;
+
+public record ListInvestmentsQuery(
+    int Page = 1,
+    int PageSize = 12,
+    string? Category = null,
+    string? Risk = null,
+    string? Search = null) : ICommandQuery<InvestmentListResponse>;

--- a/Antital.Application/Features/Investments/ListInvestments/ListInvestmentsQueryHandler.cs
+++ b/Antital.Application/Features/Investments/ListInvestments/ListInvestmentsQueryHandler.cs
@@ -1,0 +1,37 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.ListInvestments;
+
+public class ListInvestmentsQueryHandler(IInvestmentOfferingRepository repository)
+    : ICommandQueryHandler<ListInvestmentsQuery, InvestmentListResponse>
+{
+    private const int MaxPageSize = 50;
+
+    public async Task<Result<InvestmentListResponse>> Handle(ListInvestmentsQuery request, CancellationToken cancellationToken)
+    {
+        var page = request.Page < 1 ? 1 : request.Page;
+        var pageSize = request.PageSize < 1 ? 12 : Math.Min(request.PageSize, MaxPageSize);
+        var risk = InvestmentMappers.ParseRiskFilter(request.Risk);
+
+        var (items, totalCount) = await repository.ListPublishedAsync(
+            page,
+            pageSize,
+            request.Category,
+            risk,
+            request.Search,
+            cancellationToken);
+
+        var response = new InvestmentListResponse(
+            items.Select(InvestmentMappers.ToListItem).ToList(),
+            page,
+            pageSize,
+            totalCount);
+
+        var result = new Result<InvestmentListResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investments/ListInvestments/ListInvestmentsQueryHandler.cs
+++ b/Antital.Application/Features/Investments/ListInvestments/ListInvestmentsQueryHandler.cs
@@ -13,7 +13,18 @@ public class ListInvestmentsQueryHandler(IInvestmentOfferingRepository repositor
     {
         var page = request.Page < 1 ? 1 : request.Page;
         var pageSize = request.PageSize < 1 ? 12 : Math.Min(request.PageSize, MaxPageSize);
-        var risk = InvestmentMappers.ParseRiskFilter(request.Risk);
+
+        if (!InvestmentMappers.TryParseRiskFilter(request.Risk, out var risk))
+        {
+            var invalidResult = new Result<InvestmentListResponse>();
+            invalidResult.BadRequest(
+                "Invalid request.",
+                new Dictionary<string, string[]>
+                {
+                    ["risk"] = ["Risk must be one of: low, moderate, high."],
+                });
+            return invalidResult;
+        }
 
         var (items, totalCount) = await repository.ListPublishedAsync(
             page,

--- a/Antital.Domain/Enums/ContentBlockType.cs
+++ b/Antital.Domain/Enums/ContentBlockType.cs
@@ -1,0 +1,8 @@
+namespace Antital.Domain.Enums;
+
+public enum ContentBlockType
+{
+    ProblemStatement = 0,
+    Narrative = 1,
+    Tldr = 2
+}

--- a/Antital.Domain/Enums/DocumentType.cs
+++ b/Antital.Domain/Enums/DocumentType.cs
@@ -1,0 +1,8 @@
+namespace Antital.Domain.Enums;
+
+public enum DocumentType
+{
+    Prospectus = 0,
+    FinancialModel = 1,
+    Other = 2
+}

--- a/Antital.Domain/Enums/FinancialMetricUnit.cs
+++ b/Antital.Domain/Enums/FinancialMetricUnit.cs
@@ -1,0 +1,9 @@
+namespace Antital.Domain.Enums;
+
+public enum FinancialMetricUnit
+{
+    Currency = 0,
+    Percent = 1,
+    Ratio = 2,
+    Text = 3
+}

--- a/Antital.Domain/Enums/FinancialValueType.cs
+++ b/Antital.Domain/Enums/FinancialValueType.cs
@@ -1,0 +1,7 @@
+namespace Antital.Domain.Enums;
+
+public enum FinancialValueType
+{
+    Actual = 0,
+    Projected = 1
+}

--- a/Antital.Domain/Enums/HighlightKind.cs
+++ b/Antital.Domain/Enums/HighlightKind.cs
@@ -1,0 +1,7 @@
+namespace Antital.Domain.Enums;
+
+public enum HighlightKind
+{
+    Stat = 0,
+    Bullet = 1
+}

--- a/Antital.Domain/Enums/MediaAssetType.cs
+++ b/Antital.Domain/Enums/MediaAssetType.cs
@@ -1,0 +1,9 @@
+namespace Antital.Domain.Enums;
+
+public enum MediaAssetType
+{
+    CoverImage = 0,
+    Video = 1,
+    Thumbnail = 2,
+    Gallery = 3
+}

--- a/Antital.Domain/Enums/OfferingRiskLevel.cs
+++ b/Antital.Domain/Enums/OfferingRiskLevel.cs
@@ -1,0 +1,8 @@
+namespace Antital.Domain.Enums;
+
+public enum OfferingRiskLevel
+{
+    Low = 0,
+    Moderate = 1,
+    High = 2
+}

--- a/Antital.Domain/Enums/OfferingStatus.cs
+++ b/Antital.Domain/Enums/OfferingStatus.cs
@@ -1,0 +1,8 @@
+namespace Antital.Domain.Enums;
+
+public enum OfferingStatus
+{
+    Draft = 0,
+    Published = 1,
+    Closed = 2
+}

--- a/Antital.Domain/Interfaces/IAntitalUnitOfWork.cs
+++ b/Antital.Domain/Interfaces/IAntitalUnitOfWork.cs
@@ -8,4 +8,5 @@ public interface IAntitalUnitOfWork : IUnitOfWork
     IUserOnboardingRepository UserOnboardingRepository { get; init; }
     IUserInvestmentProfileRepository UserInvestmentProfileRepository { get; init; }
     IUserKycRepository UserKycRepository { get; init; }
+    IInvestmentOfferingRepository InvestmentOfferingRepository { get; init; }
 }

--- a/Antital.Domain/Interfaces/IInvestmentOfferingRepository.cs
+++ b/Antital.Domain/Interfaces/IInvestmentOfferingRepository.cs
@@ -1,0 +1,47 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+
+namespace Antital.Domain.Interfaces;
+
+public interface IInvestmentOfferingRepository
+{
+    Task<(IReadOnlyList<InvestmentOffering> Items, int TotalCount)> ListPublishedAsync(
+        int page,
+        int pageSize,
+        string? category,
+        OfferingRiskLevel? risk,
+        string? search,
+        CancellationToken cancellationToken);
+
+    Task<InvestmentOffering?> GetPublishedShellByIdAsync(int id, CancellationToken cancellationToken);
+
+    Task<InvestmentOffering?> GetPublishedShellBySlugAsync(string slug, CancellationToken cancellationToken);
+
+    Task<InvestmentOffering?> GetPublishedShellByIdOrSlugAsync(string idOrSlug, CancellationToken cancellationToken);
+
+    Task<int?> GetPublishedOfferingIdAsync(string idOrSlug, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<Highlight>> GetHighlightsAsync(int offeringId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<OfferingContentBlock>> GetContentBlocksAsync(int offeringId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<TeamMember>> GetTeamMembersAsync(int offeringId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<FinancialMetric>> GetFinancialMetricsAsync(int offeringId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<UseOfProceedsItem>> GetUseOfProceedsItemsAsync(int offeringId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<OfferingRisk>> GetRisksAsync(int offeringId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<OfferingDocument>> GetDocumentsAsync(int offeringId, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<MediaAsset>> GetMediaAssetsAsync(int offeringId, CancellationToken cancellationToken);
+
+    Task<(IReadOnlyList<OfferingUpdate> Items, int TotalCount)> GetUpdatesAsync(
+        int offeringId,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<Testimonial>> GetTestimonialsAsync(int offeringId, CancellationToken cancellationToken);
+}

--- a/Antital.Domain/Models/ContentBlockItem.cs
+++ b/Antital.Domain/Models/ContentBlockItem.cs
@@ -1,0 +1,13 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class ContentBlockItem : TrackableEntity
+{
+    public int ContentBlockId { get; set; }
+    public string Label { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+    public int SortOrder { get; set; }
+
+    public virtual OfferingContentBlock ContentBlock { get; set; } = null!;
+}

--- a/Antital.Domain/Models/DealTerms.cs
+++ b/Antital.Domain/Models/DealTerms.cs
@@ -1,0 +1,17 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class DealTerms : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public long TotalSharesOffered { get; set; }
+    public decimal PricePerShare { get; set; }
+    public decimal MinimumInvestment { get; set; }
+    public decimal MaximumInvestment { get; set; }
+    public decimal MinimumThreshold { get; set; }
+    public decimal FundingGoal { get; set; }
+    public DateTime Deadline { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Domain/Models/FinancialMetric.cs
+++ b/Antital.Domain/Models/FinancialMetric.cs
@@ -1,0 +1,18 @@
+using Antital.Domain.Enums;
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class FinancialMetric : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public string MetricName { get; set; } = string.Empty;
+    public string PeriodLabel { get; set; } = string.Empty;
+    public int PeriodSortOrder { get; set; }
+    public decimal? Value { get; set; }
+    public FinancialMetricUnit Unit { get; set; }
+    public string? CurrencyCode { get; set; }
+    public FinancialValueType ValueType { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Domain/Models/Highlight.cs
+++ b/Antital.Domain/Models/Highlight.cs
@@ -1,0 +1,15 @@
+using Antital.Domain.Enums;
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class Highlight : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public HighlightKind Kind { get; set; }
+    public string? Headline { get; set; }
+    public string Body { get; set; } = string.Empty;
+    public int SortOrder { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Domain/Models/InvestmentOffering.cs
+++ b/Antital.Domain/Models/InvestmentOffering.cs
@@ -1,0 +1,30 @@
+using Antital.Domain.Enums;
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class InvestmentOffering : TrackableEntity
+{
+    public string Slug { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public string Tagline { get; set; } = string.Empty;
+    public string CoverImageUrl { get; set; } = string.Empty;
+    public OfferingRiskLevel RiskLevel { get; set; }
+    public OfferingStatus Status { get; set; }
+    public DateTime? PublishedAt { get; set; }
+
+    public OfferingFunding? Funding { get; set; }
+    public DealTerms? DealTerms { get; set; }
+    public OfferingCorporateProfile? CorporateProfile { get; set; }
+    public ICollection<Highlight> Highlights { get; set; } = [];
+    public ICollection<OfferingContentBlock> ContentBlocks { get; set; } = [];
+    public ICollection<TeamMember> TeamMembers { get; set; } = [];
+    public ICollection<FinancialMetric> FinancialMetrics { get; set; } = [];
+    public ICollection<UseOfProceedsItem> UseOfProceedsItems { get; set; } = [];
+    public ICollection<OfferingRisk> Risks { get; set; } = [];
+    public ICollection<OfferingDocument> Documents { get; set; } = [];
+    public ICollection<MediaAsset> MediaAssets { get; set; } = [];
+    public ICollection<OfferingUpdate> Updates { get; set; } = [];
+    public ICollection<Testimonial> Testimonials { get; set; } = [];
+}

--- a/Antital.Domain/Models/MediaAsset.cs
+++ b/Antital.Domain/Models/MediaAsset.cs
@@ -1,0 +1,14 @@
+using Antital.Domain.Enums;
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class MediaAsset : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public MediaAssetType AssetType { get; set; }
+    public string Url { get; set; } = string.Empty;
+    public int SortOrder { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Domain/Models/OfferingContentBlock.cs
+++ b/Antital.Domain/Models/OfferingContentBlock.cs
@@ -1,0 +1,17 @@
+using Antital.Domain.Enums;
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class OfferingContentBlock : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public ContentBlockType BlockType { get; set; }
+    public string? Key { get; set; }
+    public string? Title { get; set; }
+    public string? Summary { get; set; }
+    public int SortOrder { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+    public ICollection<ContentBlockItem> Items { get; set; } = [];
+}

--- a/Antital.Domain/Models/OfferingCorporateProfile.cs
+++ b/Antital.Domain/Models/OfferingCorporateProfile.cs
@@ -1,0 +1,15 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class OfferingCorporateProfile : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public string EntityType { get; set; } = string.Empty;
+    public string Jurisdiction { get; set; } = string.Empty;
+    public int IncorporationYear { get; set; }
+    public string RegistrationId { get; set; } = string.Empty;
+    public string? AdditionalNotes { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Domain/Models/OfferingDocument.cs
+++ b/Antital.Domain/Models/OfferingDocument.cs
@@ -1,0 +1,15 @@
+using Antital.Domain.Enums;
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class OfferingDocument : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string FileUrl { get; set; } = string.Empty;
+    public DocumentType DocumentType { get; set; }
+    public int? PageCount { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Domain/Models/OfferingFunding.cs
+++ b/Antital.Domain/Models/OfferingFunding.cs
@@ -1,0 +1,18 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class OfferingFunding : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public decimal RaisedAmount { get; set; }
+    public decimal FundingGoal { get; set; }
+    public decimal? MinimumRaise { get; set; }
+    public int InvestorCount { get; set; }
+    public decimal SharePrice { get; set; }
+    public decimal? TargetRating { get; set; }
+    public decimal MinInvestment { get; set; }
+    public decimal MaxInvestment { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Domain/Models/OfferingRisk.cs
+++ b/Antital.Domain/Models/OfferingRisk.cs
@@ -1,0 +1,14 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class OfferingRisk : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public string Category { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Mitigation { get; set; } = string.Empty;
+    public int SortOrder { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Domain/Models/OfferingUpdate.cs
+++ b/Antital.Domain/Models/OfferingUpdate.cs
@@ -1,0 +1,14 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class OfferingUpdate : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public DateTime PublishedAt { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+    public int LikeCount { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Domain/Models/TeamMember.cs
+++ b/Antital.Domain/Models/TeamMember.cs
@@ -1,0 +1,15 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class TeamMember : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
+    public string Bio { get; set; } = string.Empty;
+    public string? ImageUrl { get; set; }
+    public int SortOrder { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Domain/Models/Testimonial.cs
+++ b/Antital.Domain/Models/Testimonial.cs
@@ -1,0 +1,15 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class Testimonial : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public string Quote { get; set; } = string.Empty;
+    public string AuthorName { get; set; } = string.Empty;
+    public string AuthorTitle { get; set; } = string.Empty;
+    public string? ImageUrl { get; set; }
+    public int SortOrder { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Domain/Models/UseOfProceedsItem.cs
+++ b/Antital.Domain/Models/UseOfProceedsItem.cs
@@ -1,0 +1,14 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class UseOfProceedsItem : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public decimal? AllocationPercent { get; set; }
+    public string Category { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public int SortOrder { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Infrastructure/AntitalDBContext.cs
+++ b/Antital.Infrastructure/AntitalDBContext.cs
@@ -13,6 +13,21 @@ public class AntitalDBContext(
     public DbSet<UserOnboarding> UserOnboardings { get; set; }
     public DbSet<UserInvestmentProfile> UserInvestmentProfiles { get; set; }
     public DbSet<UserKyc> UserKycs { get; set; }
+    public DbSet<InvestmentOffering> InvestmentOfferings { get; set; }
+    public DbSet<OfferingFunding> OfferingFundings { get; set; }
+    public DbSet<DealTerms> DealTerms { get; set; }
+    public DbSet<Highlight> Highlights { get; set; }
+    public DbSet<OfferingContentBlock> OfferingContentBlocks { get; set; }
+    public DbSet<ContentBlockItem> ContentBlockItems { get; set; }
+    public DbSet<TeamMember> TeamMembers { get; set; }
+    public DbSet<FinancialMetric> FinancialMetrics { get; set; }
+    public DbSet<UseOfProceedsItem> UseOfProceedsItems { get; set; }
+    public DbSet<OfferingRisk> OfferingRisks { get; set; }
+    public DbSet<OfferingDocument> OfferingDocuments { get; set; }
+    public DbSet<MediaAsset> MediaAssets { get; set; }
+    public DbSet<OfferingUpdate> OfferingUpdates { get; set; }
+    public DbSet<Testimonial> Testimonials { get; set; }
+    public DbSet<OfferingCorporateProfile> OfferingCorporateProfiles { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -128,6 +143,139 @@ public class AntitalDBContext(
         {
             entity.HasOne(e => e.User).WithMany().HasForeignKey(e => e.UserId).OnDelete(DeleteBehavior.Restrict);
             entity.HasIndex(e => e.UserId).IsUnique();
+        });
+
+        ConfigureInvestmentOfferings(modelBuilder);
+    }
+
+    private static void ConfigureInvestmentOfferings(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<InvestmentOffering>(entity =>
+        {
+            entity.HasIndex(e => e.Slug).IsUnique().HasFilter("\"IsDeleted\" = false");
+            entity.Property(e => e.Slug).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.Name).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.Category).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.Tagline).HasMaxLength(500).IsRequired();
+            entity.Property(e => e.CoverImageUrl).HasMaxLength(500).IsRequired();
+        });
+
+        modelBuilder.Entity<OfferingFunding>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithOne(o => o.Funding).HasForeignKey<OfferingFunding>(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasIndex(e => e.OfferingId).IsUnique();
+        });
+
+        modelBuilder.Entity<DealTerms>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithOne(o => o.DealTerms).HasForeignKey<DealTerms>(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasIndex(e => e.OfferingId).IsUnique();
+        });
+
+        modelBuilder.Entity<OfferingCorporateProfile>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithOne(o => o.CorporateProfile).HasForeignKey<OfferingCorporateProfile>(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasIndex(e => e.OfferingId).IsUnique();
+            entity.Property(e => e.EntityType).HasMaxLength(100);
+            entity.Property(e => e.Jurisdiction).HasMaxLength(100);
+            entity.Property(e => e.RegistrationId).HasMaxLength(100);
+        });
+
+        modelBuilder.Entity<Highlight>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithMany(o => o.Highlights).HasForeignKey(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(e => e.Headline).HasMaxLength(200);
+            entity.Property(e => e.Body).HasMaxLength(2000).IsRequired();
+        });
+
+        modelBuilder.Entity<OfferingContentBlock>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithMany(o => o.ContentBlocks).HasForeignKey(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(e => e.Key).HasMaxLength(100);
+            entity.Property(e => e.Title).HasMaxLength(300);
+            entity.Property(e => e.Summary).HasMaxLength(4000);
+        });
+
+        modelBuilder.Entity<ContentBlockItem>(entity =>
+        {
+            entity.HasOne(e => e.ContentBlock).WithMany(b => b.Items).HasForeignKey(e => e.ContentBlockId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(e => e.Label).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.Body).HasMaxLength(4000).IsRequired();
+        });
+
+        modelBuilder.Entity<TeamMember>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithMany(o => o.TeamMembers).HasForeignKey(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(e => e.Name).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.Title).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.Bio).HasMaxLength(4000).IsRequired();
+            entity.Property(e => e.ImageUrl).HasMaxLength(500);
+        });
+
+        modelBuilder.Entity<FinancialMetric>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithMany(o => o.FinancialMetrics).HasForeignKey(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(e => e.MetricName).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.PeriodLabel).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.CurrencyCode).HasMaxLength(10);
+        });
+
+        modelBuilder.Entity<UseOfProceedsItem>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithMany(o => o.UseOfProceedsItems).HasForeignKey(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(e => e.Category).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.Description).HasMaxLength(2000).IsRequired();
+        });
+
+        modelBuilder.Entity<OfferingRisk>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithMany(o => o.Risks).HasForeignKey(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(e => e.Category).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.Description).HasMaxLength(4000).IsRequired();
+            entity.Property(e => e.Mitigation).HasMaxLength(4000).IsRequired();
+        });
+
+        modelBuilder.Entity<OfferingDocument>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithMany(o => o.Documents).HasForeignKey(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(e => e.Title).HasMaxLength(300).IsRequired();
+            entity.Property(e => e.FileUrl).HasMaxLength(500).IsRequired();
+        });
+
+        modelBuilder.Entity<MediaAsset>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithMany(o => o.MediaAssets).HasForeignKey(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(e => e.Url).HasMaxLength(500).IsRequired();
+        });
+
+        modelBuilder.Entity<OfferingUpdate>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithMany(o => o.Updates).HasForeignKey(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(e => e.Title).HasMaxLength(300).IsRequired();
+            entity.Property(e => e.Body).HasMaxLength(8000).IsRequired();
+        });
+
+        modelBuilder.Entity<Testimonial>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithMany(o => o.Testimonials).HasForeignKey(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.Property(e => e.Quote).HasMaxLength(4000).IsRequired();
+            entity.Property(e => e.AuthorName).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.AuthorTitle).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.ImageUrl).HasMaxLength(500);
         });
     }
 }

--- a/Antital.Infrastructure/AntitalUnitOfWork.cs
+++ b/Antital.Infrastructure/AntitalUnitOfWork.cs
@@ -8,11 +8,13 @@ public class AntitalUnitOfWork(
     IUserRepository userRepository,
     IUserOnboardingRepository userOnboardingRepository,
     IUserInvestmentProfileRepository userInvestmentProfileRepository,
-    IUserKycRepository userKycRepository
+    IUserKycRepository userKycRepository,
+    IInvestmentOfferingRepository investmentOfferingRepository
 ) : UnitOfWork(dbContext), IAntitalUnitOfWork
 {
     public IUserRepository UserRepository { get; init; } = userRepository;
     public IUserOnboardingRepository UserOnboardingRepository { get; init; } = userOnboardingRepository;
     public IUserInvestmentProfileRepository UserInvestmentProfileRepository { get; init; } = userInvestmentProfileRepository;
     public IUserKycRepository UserKycRepository { get; init; } = userKycRepository;
+    public IInvestmentOfferingRepository InvestmentOfferingRepository { get; init; } = investmentOfferingRepository;
 }

--- a/Antital.Infrastructure/Migrations/20260530064517_AddInvestmentOfferings.Designer.cs
+++ b/Antital.Infrastructure/Migrations/20260530064517_AddInvestmentOfferings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Antital.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Antital.Infrastructure.Migrations
 {
     [DbContext(typeof(AntitalDBContext))]
-    partial class AntitalDBContextModelSnapshot : ModelSnapshot
+    [Migration("20260530064517_AddInvestmentOfferings")]
+    partial class AddInvestmentOfferings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Antital.Infrastructure/Migrations/20260530064517_AddInvestmentOfferings.cs
+++ b/Antital.Infrastructure/Migrations/20260530064517_AddInvestmentOfferings.cs
@@ -1,0 +1,604 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Antital.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInvestmentOfferings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InvestmentOfferings",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Slug = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Category = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Tagline = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    CoverImageUrl = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    RiskLevel = table.Column<int>(type: "integer", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    PublishedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InvestmentOfferings", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "DealTerms",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    TotalSharesOffered = table.Column<long>(type: "bigint", nullable: false),
+                    PricePerShare = table.Column<decimal>(type: "numeric", nullable: false),
+                    MinimumInvestment = table.Column<decimal>(type: "numeric", nullable: false),
+                    MaximumInvestment = table.Column<decimal>(type: "numeric", nullable: false),
+                    MinimumThreshold = table.Column<decimal>(type: "numeric", nullable: false),
+                    FundingGoal = table.Column<decimal>(type: "numeric", nullable: false),
+                    Deadline = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DealTerms", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DealTerms_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "FinancialMetrics",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    MetricName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    PeriodLabel = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    PeriodSortOrder = table.Column<int>(type: "integer", nullable: false),
+                    Value = table.Column<decimal>(type: "numeric", nullable: true),
+                    Unit = table.Column<int>(type: "integer", nullable: false),
+                    CurrencyCode = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: true),
+                    ValueType = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FinancialMetrics", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FinancialMetrics_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Highlights",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    Kind = table.Column<int>(type: "integer", nullable: false),
+                    Headline = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    Body = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Highlights", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Highlights_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MediaAssets",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    AssetType = table.Column<int>(type: "integer", nullable: false),
+                    Url = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MediaAssets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MediaAssets_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OfferingContentBlocks",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    BlockType = table.Column<int>(type: "integer", nullable: false),
+                    Key = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    Title = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: true),
+                    Summary = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OfferingContentBlocks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OfferingContentBlocks_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OfferingCorporateProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    EntityType = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Jurisdiction = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    IncorporationYear = table.Column<int>(type: "integer", nullable: false),
+                    RegistrationId = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    AdditionalNotes = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OfferingCorporateProfiles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OfferingCorporateProfiles_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OfferingDocuments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    Title = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    FileUrl = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    DocumentType = table.Column<int>(type: "integer", nullable: false),
+                    PageCount = table.Column<int>(type: "integer", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OfferingDocuments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OfferingDocuments_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OfferingFundings",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    RaisedAmount = table.Column<decimal>(type: "numeric", nullable: false),
+                    FundingGoal = table.Column<decimal>(type: "numeric", nullable: false),
+                    MinimumRaise = table.Column<decimal>(type: "numeric", nullable: true),
+                    InvestorCount = table.Column<int>(type: "integer", nullable: false),
+                    SharePrice = table.Column<decimal>(type: "numeric", nullable: false),
+                    TargetRating = table.Column<decimal>(type: "numeric", nullable: true),
+                    MinInvestment = table.Column<decimal>(type: "numeric", nullable: false),
+                    MaxInvestment = table.Column<decimal>(type: "numeric", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OfferingFundings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OfferingFundings_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OfferingRisks",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    Category = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
+                    Mitigation = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OfferingRisks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OfferingRisks_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OfferingUpdates",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    PublishedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Title = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    Body = table.Column<string>(type: "character varying(8000)", maxLength: 8000, nullable: false),
+                    LikeCount = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OfferingUpdates", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OfferingUpdates_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TeamMembers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Bio = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
+                    ImageUrl = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TeamMembers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TeamMembers_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Testimonials",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    Quote = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
+                    AuthorName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    AuthorTitle = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    ImageUrl = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Testimonials", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Testimonials_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UseOfProceedsItems",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    AllocationPercent = table.Column<decimal>(type: "numeric", nullable: true),
+                    Category = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UseOfProceedsItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UseOfProceedsItems_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ContentBlockItems",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ContentBlockId = table.Column<int>(type: "integer", nullable: false),
+                    Label = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Body = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ContentBlockItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ContentBlockItems_OfferingContentBlocks_ContentBlockId",
+                        column: x => x.ContentBlockId,
+                        principalTable: "OfferingContentBlocks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ContentBlockItems_ContentBlockId",
+                table: "ContentBlockItems",
+                column: "ContentBlockId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DealTerms_OfferingId",
+                table: "DealTerms",
+                column: "OfferingId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FinancialMetrics_OfferingId",
+                table: "FinancialMetrics",
+                column: "OfferingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Highlights_OfferingId",
+                table: "Highlights",
+                column: "OfferingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvestmentOfferings_Slug",
+                table: "InvestmentOfferings",
+                column: "Slug",
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MediaAssets_OfferingId",
+                table: "MediaAssets",
+                column: "OfferingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingContentBlocks_OfferingId",
+                table: "OfferingContentBlocks",
+                column: "OfferingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingCorporateProfiles_OfferingId",
+                table: "OfferingCorporateProfiles",
+                column: "OfferingId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingDocuments_OfferingId",
+                table: "OfferingDocuments",
+                column: "OfferingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingFundings_OfferingId",
+                table: "OfferingFundings",
+                column: "OfferingId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingRisks_OfferingId",
+                table: "OfferingRisks",
+                column: "OfferingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingUpdates_OfferingId",
+                table: "OfferingUpdates",
+                column: "OfferingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamMembers_OfferingId",
+                table: "TeamMembers",
+                column: "OfferingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Testimonials_OfferingId",
+                table: "Testimonials",
+                column: "OfferingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UseOfProceedsItems_OfferingId",
+                table: "UseOfProceedsItems",
+                column: "OfferingId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ContentBlockItems");
+
+            migrationBuilder.DropTable(
+                name: "DealTerms");
+
+            migrationBuilder.DropTable(
+                name: "FinancialMetrics");
+
+            migrationBuilder.DropTable(
+                name: "Highlights");
+
+            migrationBuilder.DropTable(
+                name: "MediaAssets");
+
+            migrationBuilder.DropTable(
+                name: "OfferingCorporateProfiles");
+
+            migrationBuilder.DropTable(
+                name: "OfferingDocuments");
+
+            migrationBuilder.DropTable(
+                name: "OfferingFundings");
+
+            migrationBuilder.DropTable(
+                name: "OfferingRisks");
+
+            migrationBuilder.DropTable(
+                name: "OfferingUpdates");
+
+            migrationBuilder.DropTable(
+                name: "TeamMembers");
+
+            migrationBuilder.DropTable(
+                name: "Testimonials");
+
+            migrationBuilder.DropTable(
+                name: "UseOfProceedsItems");
+
+            migrationBuilder.DropTable(
+                name: "OfferingContentBlocks");
+
+            migrationBuilder.DropTable(
+                name: "InvestmentOfferings");
+        }
+    }
+}

--- a/Antital.Infrastructure/Repositories/InvestmentOfferingRepository.cs
+++ b/Antital.Infrastructure/Repositories/InvestmentOfferingRepository.cs
@@ -1,0 +1,189 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using BuildingBlocks.Domain.Interfaces;
+using BuildingBlocks.Infrastructure.Implementations;
+using Microsoft.EntityFrameworkCore;
+
+namespace Antital.Infrastructure.Repositories;
+
+public class InvestmentOfferingRepository(
+    DBContext dbContext,
+    ICurrentUser currentUser
+) : Repository<InvestmentOffering>(dbContext, currentUser), IInvestmentOfferingRepository
+{
+    private IQueryable<InvestmentOffering> PublishedOfferings =>
+        SetAsNoTracking.Where(o => o.Status == OfferingStatus.Published && !o.IsDeleted);
+
+    public async Task<(IReadOnlyList<InvestmentOffering> Items, int TotalCount)> ListPublishedAsync(
+        int page,
+        int pageSize,
+        string? category,
+        OfferingRiskLevel? risk,
+        string? search,
+        CancellationToken cancellationToken)
+    {
+        var query = PublishedOfferings
+            .Include(o => o.Funding)
+            .Include(o => o.DealTerms)
+            .AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(category))
+        {
+            query = query.Where(o => o.Category == category);
+        }
+
+        if (risk.HasValue)
+        {
+            query = query.Where(o => o.RiskLevel == risk.Value);
+        }
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var term = search.Trim();
+            query = query.Where(o =>
+                o.Name.Contains(term) ||
+                o.Tagline.Contains(term) ||
+                o.Category.Contains(term));
+        }
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
+            .OrderByDescending(o => o.PublishedAt)
+            .ThenBy(o => o.Name)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return (items, totalCount);
+    }
+
+    public Task<InvestmentOffering?> GetPublishedShellByIdAsync(int id, CancellationToken cancellationToken) =>
+        GetPublishedShellQuery()
+            .FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
+
+    public Task<InvestmentOffering?> GetPublishedShellBySlugAsync(string slug, CancellationToken cancellationToken) =>
+        GetPublishedShellQuery()
+            .FirstOrDefaultAsync(o => o.Slug == slug, cancellationToken);
+
+    public async Task<InvestmentOffering?> GetPublishedShellByIdOrSlugAsync(
+        string idOrSlug,
+        CancellationToken cancellationToken)
+    {
+        if (int.TryParse(idOrSlug, out var id))
+        {
+            return await GetPublishedShellByIdAsync(id, cancellationToken);
+        }
+
+        return await GetPublishedShellBySlugAsync(idOrSlug, cancellationToken);
+    }
+
+    public async Task<int?> GetPublishedOfferingIdAsync(string idOrSlug, CancellationToken cancellationToken)
+    {
+        if (int.TryParse(idOrSlug, out var id))
+        {
+            return await PublishedOfferings
+                .Where(o => o.Id == id)
+                .Select(o => (int?)o.Id)
+                .FirstOrDefaultAsync(cancellationToken);
+        }
+
+        return await PublishedOfferings
+            .Where(o => o.Slug == idOrSlug)
+            .Select(o => (int?)o.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Highlight>> GetHighlightsAsync(int offeringId, CancellationToken cancellationToken) =>
+        await _dbContext.Set<Highlight>()
+            .AsNoTracking()
+            .Where(h => h.OfferingId == offeringId && !h.IsDeleted)
+            .OrderBy(h => h.SortOrder)
+            .ToListAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<OfferingContentBlock>> GetContentBlocksAsync(int offeringId, CancellationToken cancellationToken) =>
+        await _dbContext.Set<OfferingContentBlock>()
+            .AsNoTracking()
+            .Include(b => b.Items.Where(i => !i.IsDeleted))
+            .Where(b => b.OfferingId == offeringId && !b.IsDeleted)
+            .OrderBy(b => b.SortOrder)
+            .ToListAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<TeamMember>> GetTeamMembersAsync(int offeringId, CancellationToken cancellationToken) =>
+        await _dbContext.Set<TeamMember>()
+            .AsNoTracking()
+            .Where(m => m.OfferingId == offeringId && !m.IsDeleted)
+            .OrderBy(m => m.SortOrder)
+            .ToListAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<FinancialMetric>> GetFinancialMetricsAsync(int offeringId, CancellationToken cancellationToken) =>
+        await _dbContext.Set<FinancialMetric>()
+            .AsNoTracking()
+            .Where(m => m.OfferingId == offeringId && !m.IsDeleted)
+            .OrderBy(m => m.MetricName)
+            .ThenBy(m => m.PeriodSortOrder)
+            .ToListAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<UseOfProceedsItem>> GetUseOfProceedsItemsAsync(int offeringId, CancellationToken cancellationToken) =>
+        await _dbContext.Set<UseOfProceedsItem>()
+            .AsNoTracking()
+            .Where(i => i.OfferingId == offeringId && !i.IsDeleted)
+            .OrderBy(i => i.SortOrder)
+            .ToListAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<OfferingRisk>> GetRisksAsync(int offeringId, CancellationToken cancellationToken) =>
+        await _dbContext.Set<OfferingRisk>()
+            .AsNoTracking()
+            .Where(r => r.OfferingId == offeringId && !r.IsDeleted)
+            .OrderBy(r => r.SortOrder)
+            .ToListAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<OfferingDocument>> GetDocumentsAsync(int offeringId, CancellationToken cancellationToken) =>
+        await _dbContext.Set<OfferingDocument>()
+            .AsNoTracking()
+            .Where(d => d.OfferingId == offeringId && !d.IsDeleted)
+            .OrderBy(d => d.Title)
+            .ToListAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<MediaAsset>> GetMediaAssetsAsync(int offeringId, CancellationToken cancellationToken) =>
+        await _dbContext.Set<MediaAsset>()
+            .AsNoTracking()
+            .Where(m => m.OfferingId == offeringId && !m.IsDeleted)
+            .OrderBy(m => m.SortOrder)
+            .ToListAsync(cancellationToken);
+
+    public async Task<(IReadOnlyList<OfferingUpdate> Items, int TotalCount)> GetUpdatesAsync(
+        int offeringId,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        var query = _dbContext.Set<OfferingUpdate>()
+            .AsNoTracking()
+            .Where(u => u.OfferingId == offeringId && !u.IsDeleted);
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
+            .OrderByDescending(u => u.PublishedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return (items, totalCount);
+    }
+
+    public async Task<IReadOnlyList<Testimonial>> GetTestimonialsAsync(int offeringId, CancellationToken cancellationToken) =>
+        await _dbContext.Set<Testimonial>()
+            .AsNoTracking()
+            .Where(t => t.OfferingId == offeringId && !t.IsDeleted)
+            .OrderBy(t => t.SortOrder)
+            .ToListAsync(cancellationToken);
+
+    private IQueryable<InvestmentOffering> GetPublishedShellQuery() =>
+        PublishedOfferings
+            .Include(o => o.Funding)
+            .Include(o => o.DealTerms)
+            .Include(o => o.CorporateProfile);
+}

--- a/Antital.Infrastructure/Repositories/InvestmentOfferingRepository.cs
+++ b/Antital.Infrastructure/Repositories/InvestmentOfferingRepository.cs
@@ -26,6 +26,7 @@ public class InvestmentOfferingRepository(
         var query = PublishedOfferings
             .Include(o => o.Funding)
             .Include(o => o.DealTerms)
+            .Where(o => o.Funding != null && o.DealTerms != null)
             .AsQueryable();
 
         if (!string.IsNullOrWhiteSpace(category))
@@ -185,5 +186,6 @@ public class InvestmentOfferingRepository(
         PublishedOfferings
             .Include(o => o.Funding)
             .Include(o => o.DealTerms)
-            .Include(o => o.CorporateProfile);
+            .Include(o => o.CorporateProfile)
+            .Where(o => o.Funding != null && o.DealTerms != null);
 }

--- a/Antital.Infrastructure/Seed/InvestmentOfferingSeed.cs
+++ b/Antital.Infrastructure/Seed/InvestmentOfferingSeed.cs
@@ -1,0 +1,415 @@
+using System.Text.RegularExpressions;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Antital.Infrastructure.Seed;
+
+public static class InvestmentOfferingSeed
+{
+    private const string SeedUser = "system";
+
+    public static async Task SeedAsync(AntitalDBContext context, ILogger logger, CancellationToken cancellationToken = default)
+    {
+        if (await context.InvestmentOfferings.AnyAsync(cancellationToken))
+        {
+            return;
+        }
+
+        var publishedAt = DateTime.UtcNow.AddDays(-30);
+        var offerings = CreateListOfferings(publishedAt);
+        context.InvestmentOfferings.AddRange(offerings);
+        await context.SaveChangesAsync(cancellationToken);
+
+        var greenTech = offerings.First(o => o.Slug == "greentech-solutions");
+        SeedGreenTechDetail(context, greenTech, publishedAt);
+
+        await context.SaveChangesAsync(cancellationToken);
+        logger.LogInformation("Seeded {Count} investment offerings.", offerings.Count);
+    }
+
+    private static List<InvestmentOffering> CreateListOfferings(DateTime publishedAt)
+    {
+        var cards = new[]
+        {
+            new ListCard("GreenTech Solutions", "Clean Energy", "Revolutionary solar panel technology with 40% higher efficiency", "/investments/ayka_solar.jpg", OfferingRiskLevel.Low, 234, 234, 1000m, 450000m, 1100000m),
+            new ListCard("AgriTech Innovations", "Sustainable Farming", "High-yield crop technology, increasing production by 35%", "/investments/agri_tech.jpg", OfferingRiskLevel.Moderate, 567, 12, 5000m, 890000m, 1000000m),
+            new ListCard("Solaris Innovations", "Agriculture", "Next-gen solar tech: 50% more efficient & weather-resilient", "/investments/solar_innovations.jpg", OfferingRiskLevel.Low, 876, 21, 5000m, 890000m, 1000000m),
+            new ListCard("AquaPure Innovations", "Water Purification", "Next-gen filtration systems reducing contaminants by 90%", "/investments/aqua_pure.jpg", OfferingRiskLevel.Moderate, 150, 150, 500m, 300000m, 500000m),
+            new ListCard("EcoBuild Materials", "Sustainable Construction", "Biodegradable materials for eco-friendly building solutions", "/investments/eco_build.jpg", OfferingRiskLevel.High, 120, 120, 2000m, 600000m, 800000m),
+            new ListCard("SmartWaste Technologies", "Waste Management", "AI-powered sorting systems for efficient recycling", "/investments/smart_waste.jpg", OfferingRiskLevel.Low, 90, 90, 1500m, 250000m, 500000m),
+            new ListCard("FinTech Innovators", "Finance", "Blockchain-based banking solutions for seamless transactions", "/investments/fintech_innovators.jpg", OfferingRiskLevel.High, 75, 1200, 12000m, 1500000m, 1800000m),
+            new ListCard("TravelEasy Solutions", "Travel", "AI-powered travel itinerary planner for personalized experiences", "/investments/Travel_easy.jpg", OfferingRiskLevel.Low, 130, 700, 4000m, 350000m, 1000000m),
+            new ListCard("SmartHome Technologies", "Home Automation", "Integrated home automation system for security and energy efficiency", "/investments/smart_home_technologies.jpg", OfferingRiskLevel.Moderate, 200, 600, 8000m, 900000m, 1500000m),
+            new ListCard("EventTech Solutions", "Events", "Virtual reality event hosting platform for immersive experiences", "/investments/event_tech_solutions.jpg", OfferingRiskLevel.Moderate, 95, 1800, 6000m, 750000m, 1350000m),
+            new ListCard("EcoFashion Brands", "Fashion", "Sustainable clothing line made from recycled materials", "/investments/eco_fashion_brands.jpg", OfferingRiskLevel.High, 160, 800, 3500m, 500000m, 1200000m),
+            new ListCard("Wellness Apps", "Health & Wellness", "Mental health app with personalized resources and community support", "/investments/well_ness_apps.jpg", OfferingRiskLevel.Low, 100, 900, 2500m, 300000m, 1000000m),
+        };
+
+        return cards.Select(card =>
+        {
+            var offering = new InvestmentOffering
+            {
+                Slug = ToSlug(card.Name),
+                Name = card.Name,
+                Category = card.Category,
+                Tagline = card.Description,
+                CoverImageUrl = card.ImageUrl,
+                RiskLevel = card.Risk,
+                Status = OfferingStatus.Published,
+                PublishedAt = publishedAt,
+                Funding = new OfferingFunding
+                {
+                    RaisedAmount = card.Raised,
+                    FundingGoal = card.Goal,
+                    InvestorCount = card.Investors,
+                    SharePrice = card.MinInvestment,
+                    MinInvestment = card.MinInvestment,
+                    MaxInvestment = card.MinInvestment * 50,
+                },
+                DealTerms = new DealTerms
+                {
+                    MinimumInvestment = card.MinInvestment,
+                    MaximumInvestment = card.MinInvestment * 50,
+                    MinimumThreshold = card.Goal * 0.5m,
+                    FundingGoal = card.Goal,
+                    PricePerShare = Math.Max(1, card.MinInvestment / 10),
+                    TotalSharesOffered = (long)(card.Goal / Math.Max(1, card.MinInvestment / 10)),
+                    Deadline = DateTime.UtcNow.AddDays(card.DaysLeft),
+                },
+            };
+
+            offering.Created(SeedUser);
+            offering.Funding.Created(SeedUser);
+            offering.DealTerms.Created(SeedUser);
+            return offering;
+        }).ToList();
+    }
+
+    private static void SeedGreenTechDetail(AntitalDBContext context, InvestmentOffering offering, DateTime publishedAt)
+    {
+        offering.Funding!.RaisedAmount = 7_381_254m;
+        offering.Funding.FundingGoal = 25_000_000m;
+        offering.Funding.InvestorCount = 341;
+        offering.Funding.SharePrice = 720m;
+        offering.Funding.TargetRating = 4.5m;
+        offering.Funding.MinInvestment = 5000m;
+        offering.Funding.MaxInvestment = 250_000m;
+
+        offering.DealTerms!.TotalSharesOffered = 99_431_817;
+        offering.DealTerms.PricePerShare = 75m;
+        offering.DealTerms.MinimumInvestment = 5000m;
+        offering.DealTerms.MaximumInvestment = 250_000m;
+        offering.DealTerms.MinimumThreshold = 15_000_000m;
+        offering.DealTerms.FundingGoal = 25_000_000m;
+        offering.DealTerms.Deadline = new DateTime(2025, 10, 21, 6, 59, 0, DateTimeKind.Utc);
+
+        var corporateProfile = new OfferingCorporateProfile
+        {
+            OfferingId = offering.Id,
+            EntityType = "C-Corp",
+            Jurisdiction = "Nigeria",
+            IncorporationYear = 2024,
+            RegistrationId = "GTS-NG-800532",
+            AdditionalNotes = "Incorporated in Lagos, Nigeria. Primary jurisdiction: Nigeria.",
+        };
+        corporateProfile.Created(SeedUser);
+        context.OfferingCorporateProfiles.Add(corporateProfile);
+
+        AddHighlights(context, offering.Id);
+        AddContentBlocks(context, offering.Id);
+        AddTeam(context, offering.Id);
+        AddFinancials(context, offering.Id);
+        AddRisks(context, offering.Id);
+        AddDocuments(context, offering.Id);
+        AddMedia(context, offering.Id);
+        AddUpdates(context, offering.Id, publishedAt);
+    }
+
+    private static void AddHighlights(AntitalDBContext context, int offeringId)
+    {
+        var highlights = new (HighlightKind Kind, string? Headline, string Body, int Order)[]
+        {
+            (HighlightKind.Stat, "₦675M ARR", "Annual Recurring Revenue as of FY 2024", 1),
+            (HighlightKind.Stat, "50+ Clients", "Active clients across West African markets", 2),
+            (HighlightKind.Bullet, null, "Lifetime revenue of ₦2.1B across all clients", 3),
+            (HighlightKind.Bullet, null, "Average monthly revenue per client: ₦11.25M", 4),
+            (HighlightKind.Bullet, null, "Annual growth rate of 150% year-over-year", 5),
+            (HighlightKind.Bullet, null, "Customer acquisition cost (CAC) of ₦4.5M", 6),
+            (HighlightKind.Bullet, null, "Projected ARR for FY 2025: ₦2.25B", 7),
+        };
+
+        foreach (var h in highlights)
+        {
+            var entity = new Highlight
+            {
+                OfferingId = offeringId,
+                Kind = h.Kind,
+                Headline = h.Headline,
+                Body = h.Body,
+                SortOrder = h.Order,
+            };
+            entity.Created(SeedUser);
+            context.Highlights.Add(entity);
+        }
+    }
+
+    private static void AddContentBlocks(AntitalDBContext context, int offeringId)
+    {
+        var problem = new OfferingContentBlock
+        {
+            OfferingId = offeringId,
+            BlockType = ContentBlockType.ProblemStatement,
+            Title = "The Problem We Solve: Addressing Market Inefficiency",
+            Summary = "Current small and medium-sized enterprises (SMEs) struggle with a complex, fragmented supply chain management system, leading to an average 15% loss in operational efficiency and increased waste. GreenTech Solutions is changing this with accessible, cloud-based solar intelligence.",
+            SortOrder = 1,
+        };
+        problem.Created(SeedUser);
+        context.OfferingContentBlocks.Add(problem);
+
+        var proprietaryEdge = new OfferingContentBlock
+        {
+            OfferingId = offeringId,
+            BlockType = ContentBlockType.Narrative,
+            Key = "proprietary-edge",
+            Title = "Our Proprietary Edge: Technology & Scalability",
+            Summary = "At the core of GreenTech Solutions is a patent-pending solar efficiency engine that processes real-time irradiance and weather data to optimize panel output with 98.5% forecast accuracy.",
+            SortOrder = 2,
+            Items =
+            [
+                CreateBlockItem("Scalability", "Our platform uses modular microservices architecture, allowing expansion into new sectors with minimal friction.", 1),
+                CreateBlockItem("Defensible Moat", "Three years of pilot data across 50 companies improves model accuracy with every deployment.", 2),
+            ],
+        };
+        proprietaryEdge.Created(SeedUser);
+        context.OfferingContentBlocks.Add(proprietaryEdge);
+
+        var marketTraction = new OfferingContentBlock
+        {
+            OfferingId = offeringId,
+            BlockType = ContentBlockType.Narrative,
+            Key = "market-traction",
+            Title = "Strong Market Traction & Financials",
+            Summary = "GreenTech Solutions has demonstrated exceptional market traction with consistent revenue growth and expanding market presence.",
+            SortOrder = 3,
+            Items =
+            [
+                CreateBlockItem("Revenue Growth", "150% year-over-year revenue growth with 95% client retention.", 1),
+                CreateBlockItem("Market Expansion", "Operating in three West African markets with 120+ qualified leads in pipeline.", 2),
+            ],
+        };
+        marketTraction.Created(SeedUser);
+        context.OfferingContentBlocks.Add(marketTraction);
+
+        var useOfProceedsIntro = new OfferingContentBlock
+        {
+            OfferingId = offeringId,
+            BlockType = ContentBlockType.Narrative,
+            Key = "use-of-proceeds-intro",
+            Title = "Use of Proceeds",
+            Summary = "This section details how the capital being raised will be strategically allocated to achieve product and market acceleration.",
+            SortOrder = 4,
+        };
+        useOfProceedsIntro.Created(SeedUser);
+        context.OfferingContentBlocks.Add(useOfProceedsIntro);
+
+        var tldr = new OfferingContentBlock
+        {
+            OfferingId = offeringId,
+            BlockType = ContentBlockType.Tldr,
+            Summary = "GreenTech Solutions transforms solar deployment for SMEs through advanced efficiency optimization, improving output while minimizing waste and operational cost.",
+            SortOrder = 5,
+        };
+        tldr.Created(SeedUser);
+        context.OfferingContentBlocks.Add(tldr);
+    }
+
+    private static ContentBlockItem CreateBlockItem(string label, string body, int order)
+    {
+        var item = new ContentBlockItem { Label = label, Body = body, SortOrder = order };
+        item.Created(SeedUser);
+        return item;
+    }
+
+    private static void AddTeam(AntitalDBContext context, int offeringId)
+    {
+        var members = new (string Name, string Title, string Bio, string Image, int Order)[]
+        {
+            ("Dr. Eleanor Vance", "CEO & Co-founder", "20 years in global logistics and clean energy optimization. Former VP of Operations at TransGlobal Freight. Ph.D. in Operations Research from MIT.", "/avatars/dr_eleanor.jpg", 1),
+            ("Alex Chen", "CTO & Co-founder", "15 years building scalable machine learning platforms. Architect of the core efficiency engine. M.S. in Computer Science.", "/avatars/alex_chen.jpg", 2),
+        };
+
+        foreach (var m in members)
+        {
+            var entity = new TeamMember
+            {
+                OfferingId = offeringId,
+                Name = m.Name,
+                Title = m.Title,
+                Bio = m.Bio,
+                ImageUrl = m.Image,
+                SortOrder = m.Order,
+            };
+            entity.Created(SeedUser);
+            context.TeamMembers.Add(entity);
+        }
+    }
+
+    private static void AddFinancials(AntitalDBContext context, int offeringId)
+    {
+        var metrics = new (string Name, string Period, int PeriodOrder, decimal? Value, FinancialMetricUnit Unit, FinancialValueType ValueType)[]
+        {
+            ("Annual Recurring Revenue (ARR)", "FY 2024 (Actual)", 1, 675_000_000m, FinancialMetricUnit.Currency, FinancialValueType.Actual),
+            ("Annual Recurring Revenue (ARR)", "FY 2025 (Projected)", 2, 2_250_000_000m, FinancialMetricUnit.Currency, FinancialValueType.Projected),
+            ("Annual Recurring Revenue (ARR)", "FY 2027 (Projected)", 3, 15_750_000_000m, FinancialMetricUnit.Currency, FinancialValueType.Projected),
+            ("Gross Margin (%)", "FY 2024 (Actual)", 1, 78m, FinancialMetricUnit.Percent, FinancialValueType.Actual),
+            ("Gross Margin (%)", "FY 2025 (Projected)", 2, 82m, FinancialMetricUnit.Percent, FinancialValueType.Projected),
+            ("Gross Margin (%)", "FY 2027 (Projected)", 3, 86m, FinancialMetricUnit.Percent, FinancialValueType.Projected),
+            ("Customer Acquisition Cost (CAC)", "FY 2024 (Actual)", 1, 4_500_000m, FinancialMetricUnit.Currency, FinancialValueType.Actual),
+            ("Customer Acquisition Cost (CAC)", "FY 2025 (Projected)", 2, 3_750_000m, FinancialMetricUnit.Currency, FinancialValueType.Projected),
+            ("Customer Acquisition Cost (CAC)", "FY 2027 (Projected)", 3, 2_250_000m, FinancialMetricUnit.Currency, FinancialValueType.Projected),
+            ("Cash-Flow Positive Target", "FY 2024 (Actual)", 1, null, FinancialMetricUnit.Text, FinancialValueType.Actual),
+            ("Cash-Flow Positive Target", "FY 2025 (Projected)", 2, null, FinancialMetricUnit.Text, FinancialValueType.Projected),
+            ("Cash-Flow Positive Target", "FY 2027 (Projected)", 3, null, FinancialMetricUnit.Text, FinancialValueType.Projected),
+        };
+
+        foreach (var m in metrics)
+        {
+            var entity = new FinancialMetric
+            {
+                OfferingId = offeringId,
+                MetricName = m.Name,
+                PeriodLabel = m.Period,
+                PeriodSortOrder = m.PeriodOrder,
+                Value = m.Value,
+                Unit = m.Unit,
+                CurrencyCode = m.Unit == FinancialMetricUnit.Currency ? "NGN" : null,
+                ValueType = m.ValueType,
+            };
+            entity.Created(SeedUser);
+            context.FinancialMetrics.Add(entity);
+        }
+
+        var proceeds = new (decimal Percent, string Category, string Description, int Order)[]
+        {
+            (50m, "R&D", "Scaling the engineering team and accelerating next-gen panel software.", 1),
+            (30m, "Sales & Marketing", "Expanding into Kenya and South Africa with dedicated sales hires.", 2),
+            (20m, "Operations & Working Capital", "Securing key data licenses and general operational expenses.", 3),
+        };
+
+        foreach (var p in proceeds)
+        {
+            var entity = new UseOfProceedsItem
+            {
+                OfferingId = offeringId,
+                AllocationPercent = p.Percent,
+                Category = p.Category,
+                Description = p.Description,
+                SortOrder = p.Order,
+            };
+            entity.Created(SeedUser);
+            context.UseOfProceedsItems.Add(entity);
+        }
+    }
+
+    private static void AddRisks(AntitalDBContext context, int offeringId)
+    {
+        var risks = new (string Category, string Description, string Mitigation, int Order)[]
+        {
+            ("Market Risk", "Larger competitors could develop similar solar optimization capabilities.", "Focus on underserved SME segment and maintain rapid release cycles with defensible IP.", 1),
+            ("Technology Risk", "Model accuracy relies on uninterrupted external weather data feeds.", "Diversified data ingestion pipeline with redundant data lake backup.", 2),
+            ("Regulatory Risk", "Cross-border data privacy laws may require platform changes.", "Compliance-first modular architecture with ongoing legal review.", 3),
+        };
+
+        foreach (var r in risks)
+        {
+            var entity = new OfferingRisk
+            {
+                OfferingId = offeringId,
+                Category = r.Category,
+                Description = r.Description,
+                Mitigation = r.Mitigation,
+                SortOrder = r.Order,
+            };
+            entity.Created(SeedUser);
+            context.OfferingRisks.Add(entity);
+        }
+    }
+
+    private static void AddDocuments(AntitalDBContext context, int offeringId)
+    {
+        var doc = new OfferingDocument
+        {
+            OfferingId = offeringId,
+            Title = "Official Prospectus & Financial Model",
+            FileUrl = "/documents/greentech-prospectus.pdf",
+            DocumentType = DocumentType.Prospectus,
+            PageCount = 45,
+        };
+        doc.Created(SeedUser);
+        context.OfferingDocuments.Add(doc);
+    }
+
+    private static void AddMedia(AntitalDBContext context, int offeringId)
+    {
+        var assets = new (MediaAssetType Type, string Url, int Order)[]
+        {
+            (MediaAssetType.Thumbnail, "/investments/thumb1.jpg", 1),
+            (MediaAssetType.Thumbnail, "/investments/thumb2.jpg", 2),
+            (MediaAssetType.Thumbnail, "/investments/thumb3.jpg", 3),
+        };
+
+        foreach (var a in assets)
+        {
+            var entity = new MediaAsset
+            {
+                OfferingId = offeringId,
+                AssetType = a.Type,
+                Url = a.Url,
+                SortOrder = a.Order,
+            };
+            entity.Created(SeedUser);
+            context.MediaAssets.Add(entity);
+        }
+    }
+
+    private static void AddUpdates(AntitalDBContext context, int offeringId, DateTime publishedAt)
+    {
+        var updates = new (DateTime At, string Title, string Body, int Likes)[]
+        {
+            (DateTime.UtcNow, "75% Goal Reached!", "Thank you to our investors who have joined us. Founder AMA this Friday.", 45),
+            (publishedAt.AddDays(-26), "Efficiency Engine V3.0 is Live", "Predictive rerouting reduces client delay costs by an average of 18%.", 90),
+            (publishedAt.AddDays(-33), "Major Client Acquisition", "Signed a 3-year contract validating cold-chain expansion. ARR impact: +₦120M.", 2),
+        };
+
+        foreach (var u in updates)
+        {
+            var entity = new OfferingUpdate
+            {
+                OfferingId = offeringId,
+                PublishedAt = u.At,
+                Title = u.Title,
+                Body = u.Body,
+                LikeCount = u.Likes,
+            };
+            entity.Created(SeedUser);
+            context.OfferingUpdates.Add(entity);
+        }
+    }
+
+    private static string ToSlug(string name) =>
+        Regex.Replace(name.ToLowerInvariant(), @"[^a-z0-9]+", "-").Trim('-');
+
+    private sealed record ListCard(
+        string Name,
+        string Category,
+        string Description,
+        string ImageUrl,
+        OfferingRiskLevel Risk,
+        int Investors,
+        int DaysLeft,
+        decimal MinInvestment,
+        decimal Raised,
+        decimal Goal);
+}

--- a/Antital.Infrastructure/Seed/InvestmentOfferingSeed.cs
+++ b/Antital.Infrastructure/Seed/InvestmentOfferingSeed.cs
@@ -103,7 +103,7 @@ public static class InvestmentOfferingSeed
         offering.DealTerms.MaximumInvestment = 250_000m;
         offering.DealTerms.MinimumThreshold = 15_000_000m;
         offering.DealTerms.FundingGoal = 25_000_000m;
-        offering.DealTerms.Deadline = new DateTime(2025, 10, 21, 6, 59, 0, DateTimeKind.Utc);
+        offering.DealTerms.Deadline = DateTime.UtcNow.AddDays(234);
 
         var corporateProfile = new OfferingCorporateProfile
         {

--- a/Antital.Test/Infrastructure/Repositories/InvestmentOfferingRepositoryTests.cs
+++ b/Antital.Test/Infrastructure/Repositories/InvestmentOfferingRepositoryTests.cs
@@ -1,0 +1,166 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Infrastructure.Repositories;
+using BuildingBlocks.Domain.Interfaces;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Antital.Test.Infrastructure.Repositories;
+
+public class InvestmentOfferingRepositoryTests : IDisposable
+{
+    private readonly AntitalDBContext _dbContext;
+    private readonly InvestmentOfferingRepository _repository;
+
+    public InvestmentOfferingRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<AntitalDBContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _dbContext = new AntitalDBContext(options);
+        var currentUser = new Mock<ICurrentUser>();
+        currentUser.Setup(x => x.UserName).Returns("TestUser");
+        _repository = new InvestmentOfferingRepository(_dbContext, currentUser.Object);
+    }
+
+    [Fact]
+    public async Task ListPublishedAsync_ReturnsOnlyPublishedOfferings()
+    {
+        await SeedOfferingAsync("published-co", OfferingStatus.Published);
+        await SeedOfferingAsync("draft-co", OfferingStatus.Draft);
+
+        var (items, total) = await _repository.ListPublishedAsync(1, 10, null, null, null, CancellationToken.None);
+
+        total.Should().Be(1);
+        items.Should().ContainSingle().Which.Slug.Should().Be("published-co");
+    }
+
+    [Fact]
+    public async Task GetPublishedShellBySlugAsync_IncludesFundingAndDealTerms()
+    {
+        var offering = await SeedOfferingAsync("shell-co", OfferingStatus.Published);
+
+        var result = await _repository.GetPublishedShellBySlugAsync("shell-co", CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Funding.Should().NotBeNull();
+        result.DealTerms.Should().NotBeNull();
+        result.Funding!.RaisedAmount.Should().Be(offering.Funding!.RaisedAmount);
+    }
+
+    [Fact]
+    public async Task GetPublishedShellByIdOrSlugAsync_ResolvesNumericId()
+    {
+        var offering = await SeedOfferingAsync("by-id-co", OfferingStatus.Published);
+
+        var result = await _repository.GetPublishedShellByIdOrSlugAsync(offering.Id.ToString(), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Slug.Should().Be("by-id-co");
+    }
+
+    [Fact]
+    public async Task GetHighlightsAsync_ReturnsOrderedHighlights()
+    {
+        var offering = await SeedOfferingAsync("highlights-co", OfferingStatus.Published);
+        AddHighlight(offering.Id, HighlightKind.Stat, "₦1M ARR", "Revenue", 2);
+        AddHighlight(offering.Id, HighlightKind.Bullet, null, "First bullet", 1);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repository.GetHighlightsAsync(offering.Id, CancellationToken.None);
+
+        result.Should().HaveCount(2);
+        result[0].SortOrder.Should().Be(1);
+        result[1].SortOrder.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetContentBlocksAsync_IncludesItems()
+    {
+        var offering = await SeedOfferingAsync("blocks-co", OfferingStatus.Published);
+        var block = new OfferingContentBlock
+        {
+            OfferingId = offering.Id,
+            BlockType = ContentBlockType.Narrative,
+            Key = "edge",
+            Title = "Edge",
+            SortOrder = 1,
+            Items =
+            [
+                new ContentBlockItem { Label = "Moat", Body = "Data advantage", SortOrder = 1 },
+            ],
+        };
+        block.Created("TestUser");
+        block.Items.First().Created("TestUser");
+        _dbContext.OfferingContentBlocks.Add(block);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repository.GetContentBlocksAsync(offering.Id, CancellationToken.None);
+
+        result.Should().ContainSingle();
+        result[0].Items.Should().ContainSingle().Which.Label.Should().Be("Moat");
+    }
+
+    private async Task<InvestmentOffering> SeedOfferingAsync(string slug, OfferingStatus status)
+    {
+        var offering = new InvestmentOffering
+        {
+            Slug = slug,
+            Name = slug,
+            Category = "Tech",
+            Tagline = "Tagline",
+            CoverImageUrl = "/img.jpg",
+            RiskLevel = OfferingRiskLevel.Low,
+            Status = status,
+            PublishedAt = DateTime.UtcNow,
+            Funding = new OfferingFunding
+            {
+                RaisedAmount = 1000,
+                FundingGoal = 5000,
+                InvestorCount = 10,
+                SharePrice = 100,
+                MinInvestment = 100,
+                MaxInvestment = 1000,
+            },
+            DealTerms = new DealTerms
+            {
+                TotalSharesOffered = 1000,
+                PricePerShare = 100,
+                MinimumInvestment = 100,
+                MaximumInvestment = 1000,
+                MinimumThreshold = 500,
+                FundingGoal = 5000,
+                Deadline = DateTime.UtcNow.AddDays(30),
+            },
+        };
+        offering.Created("TestUser");
+        offering.Funding.Created("TestUser");
+        offering.DealTerms.Created("TestUser");
+        _dbContext.InvestmentOfferings.Add(offering);
+        await _dbContext.SaveChangesAsync();
+        return offering;
+    }
+
+    private void AddHighlight(int offeringId, HighlightKind kind, string? headline, string body, int sortOrder)
+    {
+        var highlight = new Highlight
+        {
+            OfferingId = offeringId,
+            Kind = kind,
+            Headline = headline,
+            Body = body,
+            SortOrder = sortOrder,
+        };
+        highlight.Created("TestUser");
+        _dbContext.Highlights.Add(highlight);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/InvestmentsControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestmentsControllerTests.cs
@@ -1,0 +1,245 @@
+using System.Net;
+using System.Net.Http.Json;
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Test.Integration;
+using BuildingBlocks.Application.Features;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Antital.Test.Integration.API.Controllers;
+
+[Collection("IntegrationTests")]
+public class InvestmentsControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>, IDisposable
+{
+    private readonly CustomWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+    private readonly IServiceScope _scope;
+    private readonly AntitalDBContext _context;
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    public InvestmentsControllerTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+        _scope = _factory.Services.CreateScope();
+        _context = _scope.ServiceProvider.GetRequiredService<AntitalDBContext>();
+        CleanupDatabase();
+    }
+
+    [Fact]
+    public async Task List_ReturnsPublishedOfferingsWithoutAuth()
+    {
+        await SeedOfferingAsync("alpha-co", OfferingRiskLevel.Low, OfferingStatus.Published, "Clean Energy");
+        await SeedOfferingAsync("beta-co", OfferingRiskLevel.High, OfferingStatus.Draft, "Finance");
+
+        var response = await _client.GetAsync("/api/investments");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestmentListResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Should().ContainSingle(i => i.Slug == "alpha-co");
+        result.Value.TotalCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task List_FiltersByRisk()
+    {
+        await SeedOfferingAsync("low-co", OfferingRiskLevel.Low, OfferingStatus.Published, "Tech");
+        await SeedOfferingAsync("high-co", OfferingRiskLevel.High, OfferingStatus.Published, "Tech");
+
+        var response = await _client.GetAsync("/api/investments?risk=low");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestmentListResponse>>(JsonOptions);
+        result!.Value!.Items.Should().ContainSingle(i => i.Slug == "low-co");
+    }
+
+    [Fact]
+    public async Task GetShell_BySlug_ReturnsOfferingFundingAndDealTerms()
+    {
+        var offering = await SeedOfferingAsync("shell-co", OfferingRiskLevel.Moderate, OfferingStatus.Published, "Agri");
+
+        var response = await _client.GetAsync("/api/investments/shell-co");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<OfferingShellResponse>>(JsonOptions);
+        result!.Value!.Offering.Slug.Should().Be("shell-co");
+        result.Value.Funding.RaisedAmount.Should().Be(offering.Funding!.RaisedAmount);
+        result.Value.DealTerms.FundingGoal.Should().Be(offering.DealTerms!.FundingGoal);
+    }
+
+    [Fact]
+    public async Task GetShell_ByNumericId_ReturnsOffering()
+    {
+        var offering = await SeedOfferingAsync("by-id-co", OfferingRiskLevel.Low, OfferingStatus.Published, "Tech");
+
+        var response = await _client.GetAsync($"/api/investments/{offering.Id}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<OfferingShellResponse>>(JsonOptions);
+        result!.Value!.Offering.Id.Should().Be(offering.Id);
+    }
+
+    [Fact]
+    public async Task GetShell_UnknownSlug_Returns404()
+    {
+        var response = await _client.GetAsync("/api/investments/does-not-exist");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetHighlights_ReturnsDomainCollection()
+    {
+        var offering = await SeedOfferingAsync("highlights-co", OfferingRiskLevel.Low, OfferingStatus.Published, "Tech");
+        var highlight = new Highlight
+        {
+            OfferingId = offering.Id,
+            Kind = HighlightKind.Stat,
+            Headline = "₦1M ARR",
+            Body = "Annual revenue",
+            SortOrder = 1,
+        };
+        highlight.Created("TestUser");
+        _context.Highlights.Add(highlight);
+        await _context.SaveChangesAsync();
+
+        var response = await _client.GetAsync("/api/investments/highlights-co/highlights");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<List<HighlightDto>>>(JsonOptions);
+        result!.Value!.Should().ContainSingle(h => h.Headline == "₦1M ARR");
+    }
+
+    [Fact]
+    public async Task GetFinancials_ReturnsMetricsAndUseOfProceeds()
+    {
+        var offering = await SeedOfferingAsync("financials-co", OfferingRiskLevel.Low, OfferingStatus.Published, "Tech");
+        var metric = new FinancialMetric
+        {
+            OfferingId = offering.Id,
+            MetricName = "ARR",
+            PeriodLabel = "FY 2024 (Actual)",
+            PeriodSortOrder = 1,
+            Value = 1000m,
+            Unit = FinancialMetricUnit.Currency,
+            CurrencyCode = "NGN",
+            ValueType = FinancialValueType.Actual,
+        };
+        metric.Created("TestUser");
+        var proceeds = new UseOfProceedsItem
+        {
+            OfferingId = offering.Id,
+            AllocationPercent = 50m,
+            Category = "R&D",
+            Description = "Engineering",
+            SortOrder = 1,
+        };
+        proceeds.Created("TestUser");
+        _context.FinancialMetrics.Add(metric);
+        _context.UseOfProceedsItems.Add(proceeds);
+        await _context.SaveChangesAsync();
+
+        var response = await _client.GetAsync("/api/investments/financials-co/financials");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<OfferingFinancialsResponse>>(JsonOptions);
+        result!.Value!.Metrics.Should().ContainSingle(m => m.MetricName == "ARR");
+        result.Value.UseOfProceeds.Should().ContainSingle(p => p.Category == "R&D");
+    }
+
+    [Fact]
+    public async Task GetContentBlocks_ReturnsBlocksWithItems()
+    {
+        var offering = await SeedOfferingAsync("blocks-co", OfferingRiskLevel.Low, OfferingStatus.Published, "Tech");
+        var block = new OfferingContentBlock
+        {
+            OfferingId = offering.Id,
+            BlockType = ContentBlockType.Narrative,
+            Key = "edge",
+            Title = "Edge",
+            SortOrder = 1,
+            Items =
+            [
+                new ContentBlockItem { Label = "Moat", Body = "Data advantage", SortOrder = 1 },
+            ],
+        };
+        block.Created("TestUser");
+        block.Items.First().Created("TestUser");
+        _context.OfferingContentBlocks.Add(block);
+        await _context.SaveChangesAsync();
+
+        var response = await _client.GetAsync("/api/investments/blocks-co/content-blocks");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<List<ContentBlockDto>>>(JsonOptions);
+        result!.Value.Should().NotBeNull();
+        result.Value!.Should().ContainSingle(b => b.Key == "edge");
+        result.Value[0].Items.Should().ContainSingle(i => i.Label == "Moat");
+    }
+
+    private async Task<InvestmentOffering> SeedOfferingAsync(
+        string slug,
+        OfferingRiskLevel risk,
+        OfferingStatus status,
+        string category)
+    {
+        var offering = new InvestmentOffering
+        {
+            Slug = slug,
+            Name = slug,
+            Category = category,
+            Tagline = "Tagline for " + slug,
+            CoverImageUrl = "/img.jpg",
+            RiskLevel = risk,
+            Status = status,
+            PublishedAt = DateTime.UtcNow,
+            Funding = new OfferingFunding
+            {
+                RaisedAmount = 100_000m,
+                FundingGoal = 500_000m,
+                InvestorCount = 25,
+                SharePrice = 100m,
+                MinInvestment = 1000m,
+                MaxInvestment = 50_000m,
+            },
+            DealTerms = new DealTerms
+            {
+                TotalSharesOffered = 10_000,
+                PricePerShare = 100m,
+                MinimumInvestment = 1000m,
+                MaximumInvestment = 50_000m,
+                MinimumThreshold = 250_000m,
+                FundingGoal = 500_000m,
+                Deadline = DateTime.UtcNow.AddDays(30),
+            },
+        };
+        offering.Created("TestUser");
+        offering.Funding.Created("TestUser");
+        offering.DealTerms.Created("TestUser");
+        _context.InvestmentOfferings.Add(offering);
+        await _context.SaveChangesAsync();
+        return offering;
+    }
+
+    private void CleanupDatabase()
+    {
+        _context.InvestmentOfferings.RemoveRange(_context.InvestmentOfferings.IgnoreQueryFilters());
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        CleanupDatabase();
+        _scope.Dispose();
+        _client.Dispose();
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/InvestmentsControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestmentsControllerTests.cs
@@ -64,6 +64,17 @@ public class InvestmentsControllerTests : IClassFixture<CustomWebApplicationFact
     }
 
     [Fact]
+    public async Task List_InvalidRisk_ReturnsValidationError()
+    {
+        var response = await _client.GetAsync("/api/investments?risk=foo");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestmentListResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeFalse();
+        result.ValidationErrors.Should().ContainKey("risk");
+    }
+
+    [Fact]
     public async Task GetShell_BySlug_ReturnsOfferingFundingAndDealTerms()
     {
         var offering = await SeedOfferingAsync("shell-co", OfferingRiskLevel.Moderate, OfferingStatus.Published, "Agri");

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,491 @@
+# Investment / Startup Explore API
+
+## Goal
+
+Provide public backend endpoints that power the marketing **Explore** flow: investment cards on the landing page and the full startup detail page at `/explore/{id}`.
+
+## Scope
+
+- Public read APIs backed by **domain resources** (not UI page sections).
+- Normalized domain models, EF migration, seed data derived from current mock content.
+- Integration tests for list + detail endpoints.
+
+## Out Of Scope
+
+- UI integration (React `antital-ui` still uses `investments.json` until a later checkpoint).
+- Authenticated actions: invest, watchlist, ask question, like update (future work).
+- Admin/fund-raiser CRUD for creating/editing listings.
+- Secondary market endpoints.
+
+---
+
+## Design principle: domain-first, UI-agnostic
+
+The API must **not** mirror frontend tabs (`overview`, `details`) or component names (`proprietaryEdge`, `marketTraction`). Those are presentation choices that will change.
+
+Instead:
+
+1. **Expose stable domain entities** — `TeamMember`, `FinancialMetric`, `Highlight`, `Risk`, etc.
+2. **Let the UI compose pages** — today's "Overview" tab might tomorrow pull from `highlights` + `contentBlocks` + `financials`; the API shape stays the same.
+3. **Store structured facts, not rendered layout** — e.g. financial metrics as `(name, period, value, currency)` not pre-built table columns/rows.
+4. **Use generic content blocks** for narrative copy — problem statement, TL;DR, feature narratives share one model with a `blockType` / `key`, not one DTO per React component.
+
+```mermaid
+flowchart LR
+  subgraph API["API domain resources"]
+    O[Offering]
+    F[Funding]
+    D[DealTerms]
+    H[Highlights]
+    C[ContentBlocks]
+    T[Team]
+    FM[FinancialMetrics]
+    R[Risks]
+    DOC[Documents]
+    U[Updates]
+  end
+  subgraph UI["UI composes freely"]
+    P1[Overview tab today]
+    P2[Different layout tomorrow]
+  end
+  H --> P1
+  C --> P1
+  FM --> P1
+  T --> P2
+  FM --> P2
+```
+
+---
+
+## Domain model (normalized)
+
+### `InvestmentOffering` (aggregate root)
+
+Core identity and list-card fields only.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| Id | Guid | |
+| Slug | string | unique, URL-safe |
+| Name | string | |
+| Category | string | |
+| Tagline | string | short description for cards |
+| CoverImageUrl | string | |
+| RiskLevel | enum | Low, Moderate, High |
+| Status | enum | Draft, Published, Closed |
+| DaysLeft | int | computed or stored campaign field |
+| PublishedAt | DateTime? | |
+
+List-card aggregates (`investors`, `raised`, `goal`, `percentage`, `minInvestment`) come from **Funding** (see below), not duplicated on the offering root.
+
+### `OfferingFunding`
+
+Campaign / raise mechanics (1:1 with offering).
+
+| Field | Type |
+|-------|------|
+| OfferingId | Guid |
+| RaisedAmount | decimal |
+| FundingGoal | decimal |
+| MinimumRaise | decimal? |
+| InvestorCount | int |
+| SharePrice | decimal |
+| TargetRating | decimal? |
+| MinInvestment | decimal |
+| MaxInvestment | decimal |
+
+`percentage` and `daysLeft` are **derived in the API layer** from funding + deadline, not stored as presentation fields.
+
+### `DealTerms` (1:1)
+
+| Field | Type |
+|-------|------|
+| TotalSharesOffered | long |
+| PricePerShare | decimal |
+| MinimumInvestment | decimal |
+| MaximumInvestment | decimal |
+| MinimumThreshold | decimal |
+| FundingGoal | decimal |
+| Deadline | DateTime |
+
+### `Highlight` (1:many)
+
+Reusable stat cards **and** bullet points — UI filters by `Kind`.
+
+| Field | Type |
+|-------|------|
+| Id | Guid |
+| OfferingId | Guid |
+| Kind | enum | `Stat`, `Bullet` |
+| Headline | string? | e.g. "₦675M ARR" — null for bullets |
+| Body | string | description or bullet text |
+| SortOrder | int |
+
+Today's Overview tab uses `Kind=Stat` for cards and `Kind=Bullet` for numbered items. A future UI could show bullets elsewhere without an API change.
+
+### `OfferingContentBlock` (1:many)
+
+Generic narrative sections — replaces hardcoded `proprietaryEdge`, `marketTraction`, `problemTitle`, `tldr` DTOs.
+
+| Field | Type |
+|-------|------|
+| Id | Guid |
+| OfferingId | Guid |
+| BlockType | enum | `ProblemStatement`, `Narrative`, `Tldr` |
+| Key | string? | stable identifier e.g. `proprietary-edge`, `market-traction` — not tied to UI tab |
+| Title | string? | |
+| Summary | string? | intro paragraph |
+| SortOrder | int |
+
+### `ContentBlockItem` (1:many, child of block)
+
+For narrative blocks with sub-points (today's FeaturePoint rows).
+
+| Field | Type |
+|-------|------|
+| Id | Guid |
+| ContentBlockId | Guid |
+| Label | string |
+| Body | string |
+| SortOrder | int |
+
+### `TeamMember` (1:many)
+
+| Field | Type |
+|-------|------|
+| Id | Guid |
+| OfferingId | Guid |
+| Name | string |
+| Title | string |
+| Bio | string |
+| ImageUrl | string? |
+| SortOrder | int |
+
+### `FinancialMetric` (1:many)
+
+Structured facts — **UI builds tables/charts**.
+
+| Field | Type |
+|-------|------|
+| Id | Guid |
+| OfferingId | Guid |
+| MetricName | string | e.g. "Annual Recurring Revenue (ARR)" |
+| PeriodLabel | string | e.g. "FY 2024", "FY 2025 (Projected)" |
+| PeriodSortOrder | int | column ordering hint |
+| Value | decimal? | null → display "N/A" |
+| Unit | enum | `Currency`, `Percent`, `Ratio`, `Text` |
+| CurrencyCode | string? | e.g. NGN |
+| ValueType | enum | `Actual`, `Projected` |
+
+### `UseOfProceedsItem` (1:many)
+
+| Field | Type |
+|-------|------|
+| Id | Guid |
+| OfferingId | Guid |
+| AllocationPercent | decimal? |
+| Category | string |
+| Description | string |
+| SortOrder | int |
+
+Optional `UseOfProceedsIntro` as a `ContentBlock` with `BlockType=Narrative`, `Key=use-of-proceeds-intro`.
+
+### `Risk` (1:many)
+
+| Field | Type |
+|-------|------|
+| Category | string |
+| Description | string |
+| Mitigation | string |
+| SortOrder | int |
+
+### `OfferingDocument` (1:many)
+
+| Field | Type |
+|-------|------|
+| Title | string |
+| FileUrl | string |
+| DocumentType | enum | `Prospectus`, `FinancialModel`, `Other` |
+| PageCount | int? |
+
+### `MediaAsset` (1:many)
+
+| Field | Type |
+|-------|------|
+| AssetType | enum | `CoverImage`, `Video`, `Thumbnail`, `Gallery` |
+| Url | string |
+| SortOrder | int |
+
+### `OfferingUpdate` (1:many)
+
+| Field | Type |
+|-------|------|
+| PublishedAt | DateTime |
+| Title | string |
+| Body | string |
+| LikeCount | int |
+
+### `Testimonial` (1:many)
+
+| Field | Type |
+|-------|------|
+| Quote | string |
+| AuthorName | string |
+| AuthorTitle | string |
+| ImageUrl | string? |
+| SortOrder | int |
+
+### `CorporateProfile` (1:1)
+
+| Field | Type |
+|-------|------|
+| EntityType | string |
+| Jurisdiction | string |
+| IncorporationYear | int |
+| RegistrationId | string |
+| AdditionalNotes | string? |
+
+---
+
+## API contracts and endpoints available
+
+### Response envelope (existing pattern)
+
+```json
+{
+  "isSuccess": true,
+  "value": { },
+  "errors": []
+}
+```
+
+### `GET /api/investments` — list offerings (public)
+
+- **Auth**: none
+- **Query**: `page`, `pageSize`, `category`, `risk`, `search`
+- **Response**: paginated **list projection** only (denormalized for cards — acceptable here because it's a read-optimized view, not a page layout).
+
+```json
+{
+  "items": [
+    {
+      "id": "uuid",
+      "slug": "greentech-solutions",
+      "name": "GreenTech Solutions",
+      "category": "Clean Energy",
+      "tagline": "Revolutionary solar panel technology with 40% higher efficiency",
+      "coverImageUrl": "/investments/ayka_solar.jpg",
+      "risk": "low",
+      "investorCount": 234,
+      "daysLeft": 234,
+      "minInvestment": 1000,
+      "raisedAmount": 450000,
+      "fundingGoal": 1100000,
+      "fundingProgressPercent": 45
+    }
+  ],
+  "page": 1,
+  "pageSize": 12,
+  "totalCount": 12
+}
+```
+
+### `GET /api/investments/{idOrSlug}` — offering shell (public)
+
+Returns the **aggregate root + 1:1 children** needed for page chrome (header, funding panel, deal terms). Does **not** embed tab content.
+
+```json
+{
+  "offering": {
+    "id": "uuid",
+    "slug": "greentech-solutions",
+    "name": "GreenTech Solutions",
+    "category": "Clean Energy",
+    "tagline": "...",
+    "coverImageUrl": "...",
+    "risk": "low",
+    "daysLeft": 14,
+    "status": "published"
+  },
+  "funding": {
+    "raisedAmount": 7381254,
+    "fundingGoal": 25000000,
+    "investorCount": 341,
+    "sharePrice": 720,
+    "targetRating": 4.5,
+    "minInvestment": 5000,
+    "maxInvestment": 250000,
+    "fundingProgressPercent": 48
+  },
+  "dealTerms": {
+    "totalSharesOffered": 99431817,
+    "pricePerShare": 75,
+    "minimumInvestment": 5000,
+    "maximumInvestment": 250000,
+    "minimumThreshold": 15000000,
+    "fundingGoal": 25000000,
+    "deadline": "2025-10-21T06:59:00Z"
+  },
+  "corporateProfile": {
+    "entityType": "C-Corp",
+    "jurisdiction": "Nigeria",
+    "incorporationYear": 2024,
+    "registrationId": "NEX-NG-800532"
+  }
+}
+```
+
+### Sub-resource endpoints (public)
+
+Each returns a **domain collection**, independent of which UI tab consumes it.
+
+| Method | Route | Returns |
+|--------|-------|---------|
+| GET | `/api/investments/{idOrSlug}/highlights` | `Highlight[]` |
+| GET | `/api/investments/{idOrSlug}/content-blocks` | `OfferingContentBlock[]` (includes nested `items[]`) |
+| GET | `/api/investments/{idOrSlug}/team` | `TeamMember[]` |
+| GET | `/api/investments/{idOrSlug}/financials` | `{ metrics: FinancialMetric[], useOfProceeds: UseOfProceedsItem[] }` |
+| GET | `/api/investments/{idOrSlug}/risks` | `Risk[]` |
+| GET | `/api/investments/{idOrSlug}/documents` | `OfferingDocument[]` |
+| GET | `/api/investments/{idOrSlug}/media` | `MediaAsset[]` |
+| GET | `/api/investments/{idOrSlug}/updates?page=` | paginated `OfferingUpdate[]` |
+| GET | `/api/investments/{idOrSlug}/testimonials` | `Testimonial[]` |
+
+**UI mapping example (today's Overview tab — can change without API changes):**
+
+| UI section | Domain source |
+|------------|---------------|
+| Problem statement | `content-blocks?` → `BlockType=ProblemStatement` |
+| Highlights cards + bullets | `highlights` filtered by `kind` |
+| Proprietary edge | `content-blocks` → `key=proprietary-edge` |
+| Market traction | `content-blocks` → `key=market-traction` |
+| TL;DR | `content-blocks` → `BlockType=Tldr` |
+| Team | `team` |
+| Financials table | `financials.metrics` grouped by `periodLabel` in UI |
+| Risks | `risks` |
+
+**Optional convenience (not required for v1):**
+
+`GET /api/investments/{idOrSlug}?include=highlights,team,financials,...` — bundles sub-resources in one round trip while keeping **top-level domain keys**, never `overview` / `details`.
+
+### Future authenticated endpoints
+
+| Method | Route | Purpose |
+|--------|-------|---------|
+| POST | `/api/investments/{id}/watchlist` | Auth watchlist |
+| POST | `/api/investments/{id}/invest` | Auth invest flow |
+| GET/POST | `/api/investments/{id}/questions` | Q&A |
+
+---
+
+## Current observed behavior (pre-integration baseline)
+
+- Landing renders cards from static `antital-ui/src/data/investments.json`.
+- Detail page at `/explore/1` ignores card data; shows hardcoded NEXUS AI content per React component.
+- No offering entities in `AntitalDBContext`.
+
+## Checkpoints
+
+| # | Checkpoint | Status |
+|---|------------|--------|
+| 1 | Domain models + migration + seed (normalized entities) | completed |
+| 2 | `GET /api/investments` list endpoint + tests | completed |
+| 3 | Offering shell + sub-resource read endpoints + tests | completed |
+
+## Permission rule
+
+Implement only the next `pending` checkpoint. Stop and request approval before continuing.
+
+---
+
+## Checkpoint 1 — Domain models + migration + seed
+
+- [x] Status: completed
+
+**UI trigger / entry point**
+
+- Data layer for landing cards and detail page resources.
+
+**API contract needed**
+
+- Entity shapes above (not UI-shaped DTOs).
+
+**Files to change**
+
+- `Antital.Domain/Enums/` — `OfferingRiskLevel`, `OfferingStatus`, `HighlightKind`, `ContentBlockType`, `FinancialMetricUnit`, `FinancialValueType`, `MediaAssetType`, `DocumentType`
+- `Antital.Domain/Models/` — entities listed in Domain Model section
+- `Antital.Domain/Interfaces/IInvestmentOfferingRepository.cs`
+- `Antital.Infrastructure/Repositories/InvestmentOfferingRepository.cs`
+- `Antital.Infrastructure/AntitalDBContext.cs`
+- `Antital.Infrastructure/Migrations/*AddInvestmentOfferings*.cs`
+- `Antital.Infrastructure/Seed/InvestmentOfferingSeed.cs`
+
+**Code plan**
+
+1. Create normalized tables with FK to `InvestmentOffering` (no JSON blobs mirroring UI tabs).
+2. Seed 6 list cards from `investments.json` + full detail data for at least one offering (GreenTech / NEXUS AI content mapped into domain entities).
+3. Repository methods: list published, get shell by id/slug, get each child collection by offering id.
+
+**Done criteria**
+
+- Migration applies; seed data queryable per entity.
+- Changing which tab a highlight appears on requires **zero** backend changes.
+
+---
+
+## Checkpoint 2 — List endpoint
+
+- [x] Status: completed
+
+**API contract needed**
+
+- `GET /api/investments`
+
+**Files to change**
+
+- `Antital.Application/DTOs/Investments/*List*`
+- `Antital.Application/Features/Investments/ListInvestments/*`
+- `Antital.API/Controllers/InvestmentsController.cs`
+- `Antital.Test/Integration/API/Controllers/InvestmentsControllerTests.cs`
+
+**Done criteria**
+
+- Returns card projection from `Offering` + `Funding`.
+- Filter/pagination tests pass.
+
+---
+
+## Checkpoint 3 — Shell + sub-resource endpoints
+
+- [x] Status: completed
+
+**API contract needed**
+
+- `GET /api/investments/{idOrSlug}`
+- Sub-routes for highlights, content-blocks, team, financials, risks, documents, media, updates, testimonials
+
+**Files to change**
+
+- `Antital.Application/DTOs/Investments/*` (one DTO per domain entity)
+- `Antital.Application/Features/Investments/GetOffering/*`
+- `Antital.Application/Features/Investments/GetOfferingHighlights/*` (etc.)
+- `Antital.API/Controllers/InvestmentsController.cs`
+- Integration tests per route + 404 cases
+
+**Done criteria**
+
+- No response property named `overview` or `details`.
+- UI can fetch shell + parallel sub-resources, or shell alone for SSR then hydrate tabs.
+- Financial response uses `FinancialMetric[]` — not pre-rendered table rows.
+
+---
+
+## Readiness checklist
+
+- [x] UI flow inspected (landing → detail → tabs).
+- [x] API design revised to domain-first (not UI-mocked).
+- [x] Normalized tables (not JSON UI blobs).
+- [x] Branch: `features/fundraiser-listing-and-details`.
+- [x] Checkpoint 1 completed.
+- [x] Checkpoint 2 completed.
+- [x] Checkpoint 3 completed.


### PR DESCRIPTION
## Summary
- Adds normalized investment offering entities, EF migration, and seed data (12 list cards + full GreenTech detail).
- Exposes `GET /api/investments` (paginated list) and composable detail sub-resources (shell, highlights, content-blocks, team, financials, risks, documents, media, updates, testimonials).
- Includes repository and integration tests for core list/detail flows.

## Test plan
- [x] `dotnet test Antital.Test/Antital.Test.csproj --filter "FullyQualifiedName~InvestmentOffering"` (33 tests)
- [x] Manual: `GET /api/investments?page=1&pageSize=6` returns 6 items, total 12
- [x] Manual: `GET /api/investments/greentech-solutions` + sub-resources return seeded GreenTech data


Made with [Cursor](https://cursor.com)