### PR TITLE
Switch email delivery to Mailgun HTTP API

### DIFF
--- a/Antital.API/Configs/DependencyInjection.cs
+++ b/Antital.API/Configs/DependencyInjection.cs
@@ -91,7 +91,8 @@ public static class DependencyInjection
     {
         // Register EmailSettings
         services.Configure<EmailSettings>(configuration.GetSection("EmailSettings"));
-        
+        services.AddHttpClient(EmailService.MailgunHttpClientName);
+
         // Register authentication services
         services.AddSingleton<IPasswordHasher, PasswordHasher>();
         services.AddSingleton<IJwtTokenService, JwtTokenService>();

--- a/Antital.API/appsettings.Development.json
+++ b/Antital.API/appsettings.Development.json
@@ -42,10 +42,13 @@
     "Password": "password"
   },
   "EmailSettings": {
-    "SmtpHost": "smtp.mailgun.org",
+    "MailgunDomain": "www.thekyub.com",
+    "MailgunApiKey": "",
+    "MailgunApiBaseUrl": "https://api.mailgun.net",
+    "SmtpHost": "",
     "SmtpPort": 587,
-    "SmtpUser": "crownedprinz@www.thekyub.com",
-    "SmtpPassword": "CHANGEME_DEV_SMTP_PASSWORD",
+    "SmtpUser": "",
+    "SmtpPassword": "",
     "SmtpSsl": false,
     "SmtpTls": true,
     "FromEmail": "crownedprinz@www.thekyub.com",

--- a/Antital.API/appsettings.Production.json
+++ b/Antital.API/appsettings.Production.json
@@ -41,6 +41,9 @@
     "Password": ""
   },
   "EmailSettings": {
+    "MailgunDomain": "www.thekyub.com",
+    "MailgunApiKey": "",
+    "MailgunApiBaseUrl": "https://api.mailgun.net",
     "SmtpHost": "",
     "SmtpPort": 587,
     "SmtpUser": "",

--- a/Antital.API/appsettings.Staging.json
+++ b/Antital.API/appsettings.Staging.json
@@ -41,14 +41,17 @@
     "Password": ""
   },
   "EmailSettings": {
+    "MailgunDomain": "www.thekyub.com",
+    "MailgunApiKey": "",
+    "MailgunApiBaseUrl": "https://api.mailgun.net",
     "SmtpHost": "",
     "SmtpPort": 587,
     "SmtpUser": "",
     "SmtpPassword": "",
     "SmtpSsl": false,
     "SmtpTls": true,
-    "FromEmail": "support@xxx.com",
-    "FromName": "xxx",
-    "BaseUrl": "https://antital.com"
+    "FromEmail": "crownedprinz@www.thekyub.com",
+    "FromName": "Antital",
+    "BaseUrl": "https://antital-ui.netlify.app"
   }
 }

--- a/Antital.Infrastructure/Antital.Infrastructure.csproj
+++ b/Antital.Infrastructure/Antital.Infrastructure.csproj
@@ -14,6 +14,7 @@
 	  <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
 	  <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.1.2" />
   </ItemGroup>

--- a/Antital.Infrastructure/Services/EmailService.cs
+++ b/Antital.Infrastructure/Services/EmailService.cs
@@ -2,25 +2,36 @@ using Antital.Domain.Enums;
 using Antital.Domain.Interfaces;
 using System.IO;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Mail;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Http;
 
 namespace Antital.Infrastructure.Services;
 
 public class EmailService : IEmailService
 {
+    public const string MailgunHttpClientName = "Mailgun";
+
     private readonly ILogger<EmailService> _logger;
     private readonly EmailSettings _settings;
     private readonly IHostEnvironment _env;
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly string _templatesRoot;
 
-    public EmailService(ILogger<EmailService> logger, IOptions<EmailSettings> options, IHostEnvironment env)
+    public EmailService(
+        ILogger<EmailService> logger,
+        IOptions<EmailSettings> options,
+        IHostEnvironment env,
+        IHttpClientFactory httpClientFactory)
     {
         _logger = logger;
         _settings = options.Value;
         _env = env;
+        _httpClientFactory = httpClientFactory;
         _templatesRoot = Path.Combine(AppContext.BaseDirectory, "EmailTemplates");
     }
 
@@ -167,11 +178,70 @@ public class EmailService : IEmailService
 
     private async Task SendEmailAsync(string to, string subject, string htmlBody, CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(_settings.SmtpHost))
+        if (_settings.UseMailgunApi)
         {
+            await SendViaMailgunAsync(to, subject, htmlBody, cancellationToken);
             return;
         }
 
+        if (string.IsNullOrWhiteSpace(_settings.SmtpHost))
+        {
+            _logger.LogWarning("Email to {Email} skipped: configure Mailgun API or SMTP.", to);
+            return;
+        }
+
+        await SendViaSmtpAsync(to, subject, htmlBody, cancellationToken);
+    }
+
+    private async Task SendViaMailgunAsync(string to, string subject, string htmlBody, CancellationToken cancellationToken)
+    {
+        var from = string.IsNullOrWhiteSpace(_settings.FromName)
+            ? _settings.FromEmail
+            : $"{_settings.FromName} <{_settings.FromEmail}>";
+
+        using var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["from"] = from,
+            ["to"] = to,
+            ["subject"] = subject,
+            ["html"] = htmlBody
+        });
+
+        var baseUrl = _settings.MailgunApiBaseUrl.TrimEnd('/');
+        var requestUri = $"{baseUrl}/v3/{_settings.MailgunDomain}/messages";
+        using var request = new HttpRequestMessage(HttpMethod.Post, requestUri)
+        {
+            Content = content
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            "Basic",
+            Convert.ToBase64String(Encoding.ASCII.GetBytes($"api:{_settings.MailgunApiKey}")));
+
+        try
+        {
+            var client = _httpClientFactory.CreateClient(MailgunHttpClientName);
+            using var response = await client.SendAsync(request, cancellationToken);
+            if (response.IsSuccessStatusCode)
+            {
+                _logger.LogInformation("Email sent to {Email} via Mailgun.", to);
+                return;
+            }
+
+            var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogError(
+                "Mailgun returned {StatusCode} sending email to {Email}: {ResponseBody}",
+                (int)response.StatusCode,
+                to,
+                responseBody);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to send email to {Email} via Mailgun.", to);
+        }
+    }
+
+    private async Task SendViaSmtpAsync(string to, string subject, string htmlBody, CancellationToken cancellationToken)
+    {
         using var message = new MailMessage
         {
             From = new MailAddress(_settings.FromEmail, _settings.FromName),
@@ -192,11 +262,11 @@ public class EmailService : IEmailService
         try
         {
             await client.SendMailAsync(message, cancellationToken);
-            _logger.LogInformation("Verification email sent to {Email}.", to);
+            _logger.LogInformation("Email sent to {Email} via SMTP.", to);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to send email to {Email}.", to);
+            _logger.LogError(ex, "Failed to send email to {Email} via SMTP.", to);
         }
     }
 

--- a/Antital.Infrastructure/Services/EmailSettings.cs
+++ b/Antital.Infrastructure/Services/EmailSettings.cs
@@ -2,6 +2,15 @@ namespace Antital.Infrastructure.Services;
 
 public class EmailSettings
 {
+    /// <summary>Mailgun sending domain (e.g. www.thekyub.com). Used with HTTPS API on Render.</summary>
+    public string MailgunDomain { get; set; } = string.Empty;
+
+    /// <summary>Mailgun private API key. Set via environment variable — never commit.</summary>
+    public string MailgunApiKey { get; set; } = string.Empty;
+
+    /// <summary>Mailgun API base URL. Defaults to US region.</summary>
+    public string MailgunApiBaseUrl { get; set; } = "https://api.mailgun.net";
+
     public string SmtpHost { get; set; } = string.Empty;
     public int SmtpPort { get; set; } = 587;
     public string SmtpUser { get; set; } = string.Empty;
@@ -11,4 +20,7 @@ public class EmailSettings
     public string FromEmail { get; set; } = string.Empty;
     public string FromName { get; set; } = string.Empty;
     public string BaseUrl { get; set; } = string.Empty;
+
+    public bool UseMailgunApi =>
+        !string.IsNullOrWhiteSpace(MailgunApiKey) && !string.IsNullOrWhiteSpace(MailgunDomain);
 }

--- a/Antital.Test/Infrastructure/Services/EmailServiceTests.cs
+++ b/Antital.Test/Infrastructure/Services/EmailServiceTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
+using System.Net.Http;
 
 namespace Antital.Test.Infrastructure.Services;
 
@@ -28,7 +29,16 @@ public class EmailServiceTests
         _envMock = new Mock<IHostEnvironment>();
         _envMock.SetupGet(x => x.EnvironmentName).Returns("Testing");
 
-        _emailService = new EmailService(_loggerMock.Object, _optionsMock.Object, _envMock.Object);
+        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+        httpClientFactoryMock
+            .Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(new HttpClient());
+
+        _emailService = new EmailService(
+            _loggerMock.Object,
+            _optionsMock.Object,
+            _envMock.Object,
+            httpClientFactoryMock.Object);
     }
 
     [Fact]
@@ -69,7 +79,11 @@ public class EmailServiceTests
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
             .Callback<LogLevel, EventId, object, Exception, Delegate>((level, eventId, state, exception, formatter) =>
             {
-                capturedLogMessage = state.ToString() ?? string.Empty;
+                var message = state.ToString() ?? string.Empty;
+                if (message.Contains("Verification Email"))
+                {
+                    capturedLogMessage = message;
+                }
             });
 
         // Act
@@ -98,7 +112,11 @@ public class EmailServiceTests
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
             .Callback<LogLevel, EventId, object, Exception, Delegate>((level, eventId, state, exception, formatter) =>
             {
-                capturedLogMessage = state.ToString() ?? string.Empty;
+                var message = state.ToString() ?? string.Empty;
+                if (message.Contains("Verification Email"))
+                {
+                    capturedLogMessage = message;
+                }
             });
 
         // Act

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,11 +21,11 @@ services:
       ASPNETCORE_HTTP_PORTS: 8001
       ConnectionStrings__DefaultConnection: ${ConnectionStrings__DefaultConnection}
       Jwt__Key: ${Jwt__Key}
-      EmailSettings__SmtpHost: ${EmailSettings__SmtpHost}
-      EmailSettings__SmtpPort: ${EmailSettings__SmtpPort}
-      EmailSettings__SmtpUser: ${EmailSettings__SmtpUser}
-      EmailSettings__SmtpPassword: ${EmailSettings__SmtpPassword}
-      EmailSettings__EnableSsl: ${EmailSettings__EnableSsl}
+      EmailSettings__MailgunDomain: ${EmailSettings__MailgunDomain}
+      EmailSettings__MailgunApiKey: ${EmailSettings__MailgunApiKey}
+      EmailSettings__MailgunApiBaseUrl: ${EmailSettings__MailgunApiBaseUrl:-https://api.mailgun.net}
+      EmailSettings__FromEmail: ${EmailSettings__FromEmail}
+      EmailSettings__FromName: ${EmailSettings__FromName:-Antital}
       EmailSettings__BaseUrl: ${EmailSettings__BaseUrl}
     depends_on:
       - db


### PR DESCRIPTION
## Summary
- Send transactional email via Mailgun HTTPS API when `MailgunApiKey` and `MailgunDomain` are configured, so email works on Render where SMTP is blocked.
- Keep SMTP as a local fallback; auto-enable Mailgun when both settings are present (`UseMailgunApi`).
- Update staging/production appsettings and docker-compose env vars for Mailgun configuration.

## Test plan
- [x] `dotnet test Antital.Test/Antital.Test.csproj` — 338 passed
- [x] Set Render env vars: `EmailSettings__MailgunDomain`, `EmailSettings__MailgunApiKey`, `EmailSettings__FromEmail`, `EmailSettings__BaseUrl`
- [x] Remove old `EmailSettings__SmtpHost` from Render staging
- [x] Sign up on staging and confirm verification email sends without ~2min timeout


Made with [Cursor](https://cursor.com)