### PR TITLE
Add investor dashboard API

### DIFF
--- a/Antital.API/Configs/AppUseExtensions.cs
+++ b/Antital.API/Configs/AppUseExtensions.cs
@@ -117,6 +117,7 @@ public static class AppUseExtensions
                 if (!env.IsEnvironment("Testing"))
                 {
                     InvestmentOfferingSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
+                    InvestorDashboardSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
                 }
             }
             catch (Exception ex)

--- a/Antital.API/Configs/DependencyInjection.cs
+++ b/Antital.API/Configs/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using Antital.Application.Features.Investments;
+using Antital.Application.Features.Investors;
 using Antital.Application.Features.Onboarding;
 using Antital.Application.Services;
 using Antital.Domain.Interfaces;
@@ -57,6 +58,7 @@ public static class DependencyInjection
         services.AddScoped(typeof(IUserInvestmentProfileRepository), typeof(UserInvestmentProfileRepository));
         services.AddScoped(typeof(IUserKycRepository), typeof(UserKycRepository));
         services.AddScoped(typeof(IInvestmentOfferingRepository), typeof(InvestmentOfferingRepository));
+        services.AddScoped(typeof(IInvestorDashboardRepository), typeof(InvestorDashboardRepository));
 
         return services;
     }
@@ -101,6 +103,7 @@ public static class DependencyInjection
         services.AddScoped<IAntitalCurrentUser, AntitalCurrentUser>();
         services.AddScoped<IKycVerificationService, PassThroughKycVerificationService>();
         services.AddScoped<IOnboardingUserAccess, OnboardingUserAccess>();
+        services.AddScoped<IInvestorUserAccess, InvestorUserAccess>();
         services.AddScoped<InvestmentOfferingAccess>();
 
         return services;

--- a/Antital.API/Controllers/InvestorsController.cs
+++ b/Antital.API/Controllers/InvestorsController.cs
@@ -1,0 +1,30 @@
+using Antital.Application.DTOs.Investors;
+using Antital.Application.Features.Investors.GetInvestorDashboard;
+using BuildingBlocks.API.Controllers;
+using BuildingBlocks.Application.Features;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Antital.API.Controllers;
+
+[SwaggerTag("Investors")]
+[Route("api/investors")]
+[Authorize]
+[ApiController]
+public class InvestorsController(IMediator mediator) : BaseController
+{
+    [HttpGet("me/dashboard")]
+    [SwaggerOperation("Get Investor Dashboard", "Returns dashboard summary, performance, watchlist preview, and holdings for the authenticated investor.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<InvestorDashboardResponse>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid period", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    public async Task<IActionResult> GetDashboard(
+        [FromQuery] string period = "this-month",
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(new GetInvestorDashboardQuery(period), cancellationToken);
+        return ApiResult(result);
+    }
+}

--- a/Antital.Application/DTOs/Investors/InvestorDashboardDtos.cs
+++ b/Antital.Application/DTOs/Investors/InvestorDashboardDtos.cs
@@ -1,0 +1,35 @@
+namespace Antital.Application.DTOs.Investors;
+
+public record InvestorDashboardSummaryDto(
+    decimal AvailableBalance,
+    decimal TotalInvested,
+    decimal TotalReturns,
+    string Currency);
+
+public record InvestorDashboardPerformancePointDto(string PeriodLabel, decimal Value);
+
+public record InvestorDashboardActiveDealDto(
+    int OfferingId,
+    string Slug,
+    string Name,
+    string LogoUrl,
+    decimal Price,
+    decimal ChangePercent);
+
+public record InvestorDashboardHoldingDto(
+    int OfferingId,
+    string Slug,
+    string Name,
+    string Sector,
+    string Risk,
+    decimal Invested,
+    decimal CurrentValue,
+    decimal Returns,
+    int UnitHolding,
+    DateTime Date);
+
+public record InvestorDashboardResponse(
+    InvestorDashboardSummaryDto Summary,
+    IReadOnlyList<InvestorDashboardPerformancePointDto> PortfolioPerformance,
+    IReadOnlyList<InvestorDashboardActiveDealDto> ActiveDeals,
+    IReadOnlyList<InvestorDashboardHoldingDto> Holdings);

--- a/Antital.Application/Features/Investors/DashboardPeriodResolver.cs
+++ b/Antital.Application/Features/Investors/DashboardPeriodResolver.cs
@@ -1,0 +1,83 @@
+using System.Globalization;
+
+namespace Antital.Application.Features.Investors;
+
+public readonly record struct DashboardPeriodRange(DateTime StartUtc, DateTime EndUtc);
+
+public static class DashboardPeriodResolver
+{
+    private static readonly HashSet<string> RollingMonthPeriods = new(StringComparer.Ordinal)
+    {
+        "last-3-months",
+        "last-6-months",
+        "last-12-months",
+    };
+
+    public static bool TryResolve(string? period, out DashboardPeriodRange range, out string? errorMessage)
+    {
+        range = default;
+        errorMessage = null;
+
+        var normalized = string.IsNullOrWhiteSpace(period)
+            ? "this-month"
+            : period.Trim().ToLowerInvariant();
+
+        var nowLagos = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, LagosTimeZone);
+
+        DateTime startLagos;
+        DateTime endLagos;
+
+        if (normalized == "this-month")
+        {
+            startLagos = new DateTime(nowLagos.Year, nowLagos.Month, 1);
+            endLagos = startLagos.AddMonths(1);
+        }
+        else if (normalized == "last-month")
+        {
+            var lastMonth = nowLagos.AddMonths(-1);
+            startLagos = new DateTime(lastMonth.Year, lastMonth.Month, 1);
+            endLagos = startLagos.AddMonths(1);
+        }
+        else if (RollingMonthPeriods.Contains(normalized))
+        {
+            var monthCount = normalized switch
+            {
+                "last-3-months" => 3,
+                "last-6-months" => 6,
+                "last-12-months" => 12,
+                _ => 0,
+            };
+
+            startLagos = new DateTime(nowLagos.Year, nowLagos.Month, 1).AddMonths(-(monthCount - 1));
+            endLagos = new DateTime(nowLagos.Year, nowLagos.Month, 1).AddMonths(1);
+        }
+        else
+        {
+            errorMessage = "Period must be this-month, last-month, last-3-months, last-6-months, or last-12-months.";
+            return false;
+        }
+
+        range = new DashboardPeriodRange(
+            TimeZoneInfo.ConvertTimeToUtc(startLagos, LagosTimeZone),
+            TimeZoneInfo.ConvertTimeToUtc(endLagos, LagosTimeZone));
+
+        return true;
+    }
+
+    public static string ToPeriodLabel(int year, int month) =>
+        new DateTime(year, month, 1).ToString("MMM yyyy", CultureInfo.InvariantCulture);
+
+    private static TimeZoneInfo LagosTimeZone => ResolveLagosTimeZone();
+
+    private static TimeZoneInfo ResolveLagosTimeZone()
+    {
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById("Africa/Lagos");
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById("W. Central Africa Standard Time");
+        }
+    }
+}

--- a/Antital.Application/Features/Investors/GetInvestorDashboard/GetInvestorDashboardQuery.cs
+++ b/Antital.Application/Features/Investors/GetInvestorDashboard/GetInvestorDashboardQuery.cs
@@ -1,0 +1,6 @@
+using Antital.Application.DTOs.Investors;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investors.GetInvestorDashboard;
+
+public record GetInvestorDashboardQuery(string Period = "this-month") : ICommandQuery<InvestorDashboardResponse>;

--- a/Antital.Application/Features/Investors/GetInvestorDashboard/GetInvestorDashboardQueryHandler.cs
+++ b/Antital.Application/Features/Investors/GetInvestorDashboard/GetInvestorDashboardQueryHandler.cs
@@ -1,0 +1,65 @@
+using Antital.Application.DTOs.Investors;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investors.GetInvestorDashboard;
+
+public class GetInvestorDashboardQueryHandler(
+    IInvestorUserAccess investorUserAccess,
+    IInvestorDashboardRepository dashboardRepository
+) : ICommandQueryHandler<GetInvestorDashboardQuery, InvestorDashboardResponse>
+{
+    public async Task<Result<InvestorDashboardResponse>> Handle(
+        GetInvestorDashboardQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (!DashboardPeriodResolver.TryResolve(request.Period, out var periodRange, out var periodError))
+        {
+            var invalidResult = new Result<InvestorDashboardResponse>();
+            invalidResult.BadRequest(
+                "Invalid period.",
+                new Dictionary<string, string[]>
+                {
+                    ["period"] = [periodError ?? "Period must be this-month, last-month, last-3-months, last-6-months, or last-12-months."],
+                });
+            return invalidResult;
+        }
+
+        var (userId, _) = await investorUserAccess.RequireAuthenticatedUserAsync(cancellationToken);
+
+        var wallet = await dashboardRepository.GetWalletAsync(userId, cancellationToken);
+        var holdings = await dashboardRepository.GetHoldingsAsync(
+            userId,
+            periodRange.StartUtc,
+            periodRange.EndUtc,
+            cancellationToken);
+        var watchlist = await dashboardRepository.GetWatchlistAsync(userId, cancellationToken);
+        var performancePoints = await dashboardRepository.GetPerformancePointsAsync(
+            userId,
+            periodRange.StartUtc,
+            periodRange.EndUtc,
+            cancellationToken);
+
+        var totalInvested = holdings.Sum(h => h.InvestedAmount);
+        var totalReturns = holdings.Sum(h => h.Returns);
+
+        var response = new InvestorDashboardResponse(
+            new InvestorDashboardSummaryDto(
+                wallet?.AvailableBalance ?? 0m,
+                totalInvested,
+                totalReturns,
+                wallet?.Currency ?? "NGN"),
+            performancePoints
+                .Select(p => new InvestorDashboardPerformancePointDto(
+                    DashboardPeriodResolver.ToPeriodLabel(p.Year, p.Month),
+                    p.Value))
+                .ToList(),
+            watchlist.Select(InvestorDashboardMappers.ToActiveDeal).ToList(),
+            holdings.Select(InvestorDashboardMappers.ToHolding).ToList());
+
+        var result = new Result<InvestorDashboardResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investors/GetInvestorDashboard/InvestorDashboardMappers.cs
+++ b/Antital.Application/Features/Investors/GetInvestorDashboard/InvestorDashboardMappers.cs
@@ -1,0 +1,48 @@
+using Antital.Application.DTOs.Investors;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+
+namespace Antital.Application.Features.Investors.GetInvestorDashboard;
+
+internal static class InvestorDashboardMappers
+{
+    public static InvestorDashboardActiveDealDto ToActiveDeal(InvestorWatchlistItem item)
+    {
+        var offering = item.Offering;
+        var price = offering.Funding?.SharePrice ?? 0m;
+
+        return new InvestorDashboardActiveDealDto(
+            offering.Id,
+            offering.Slug,
+            offering.Name,
+            offering.CoverImageUrl,
+            price,
+            item.ChangePercent);
+    }
+
+    public static InvestorDashboardHoldingDto ToHolding(InvestorHolding holding)
+    {
+        var offering = holding.Offering;
+
+        return new InvestorDashboardHoldingDto(
+            offering.Id,
+            offering.Slug,
+            offering.Name,
+            offering.Category,
+            ToRiskString(offering.RiskLevel),
+            holding.InvestedAmount,
+            holding.CurrentValue,
+            holding.Returns,
+            holding.UnitHolding,
+            holding.InvestedAt);
+    }
+
+    private static string ToRiskString(OfferingRiskLevel risk) =>
+        risk switch
+        {
+            OfferingRiskLevel.Low => "low",
+            OfferingRiskLevel.Moderate => "moderate",
+            OfferingRiskLevel.High => "high",
+            _ => risk.ToString().ToLowerInvariant(),
+        };
+}

--- a/Antital.Application/Features/Investors/InvestorUserAccess.cs
+++ b/Antital.Application/Features/Investors/InvestorUserAccess.cs
@@ -1,0 +1,33 @@
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using BuildingBlocks.Application.Exceptions;
+
+namespace Antital.Application.Features.Investors;
+
+public interface IInvestorUserAccess
+{
+    Task<(int UserId, User User)> RequireAuthenticatedUserAsync(CancellationToken cancellationToken = default);
+}
+
+public class InvestorUserAccess(
+    IAntitalCurrentUser currentUser,
+    IUserRepository userRepository
+) : IInvestorUserAccess
+{
+    public async Task<(int UserId, User User)> RequireAuthenticatedUserAsync(CancellationToken cancellationToken = default)
+    {
+        var userId = currentUser.UserId;
+        if (!userId.HasValue)
+        {
+            throw new UnauthorizedException("User is not authenticated.");
+        }
+
+        var user = await userRepository.GetByIdAsync(userId.Value, cancellationToken);
+        if (user == null)
+        {
+            throw new NotFoundException("User not found.");
+        }
+
+        return (userId.Value, user);
+    }
+}

--- a/Antital.Domain/Interfaces/IInvestorDashboardRepository.cs
+++ b/Antital.Domain/Interfaces/IInvestorDashboardRepository.cs
@@ -1,0 +1,24 @@
+using Antital.Domain.Models;
+
+namespace Antital.Domain.Interfaces;
+
+public interface IInvestorDashboardRepository
+{
+    Task<InvestorWallet?> GetWalletAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<InvestorHolding>> GetHoldingsAsync(
+        int userId,
+        DateTime periodStartUtc,
+        DateTime periodEndUtc,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<InvestorWatchlistItem>> GetWatchlistAsync(
+        int userId,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<InvestorPortfolioPerformancePoint>> GetPerformancePointsAsync(
+        int userId,
+        DateTime periodStartUtc,
+        DateTime periodEndUtc,
+        CancellationToken cancellationToken = default);
+}

--- a/Antital.Domain/Models/InvestorHolding.cs
+++ b/Antital.Domain/Models/InvestorHolding.cs
@@ -1,0 +1,17 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class InvestorHolding : TrackableEntity
+{
+    public int UserId { get; set; }
+    public int OfferingId { get; set; }
+    public decimal InvestedAmount { get; set; }
+    public decimal CurrentValue { get; set; }
+    public decimal Returns { get; set; }
+    public int UnitHolding { get; set; }
+    public DateTime InvestedAt { get; set; }
+
+    public virtual User User { get; set; } = null!;
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Domain/Models/InvestorPortfolioPerformancePoint.cs
+++ b/Antital.Domain/Models/InvestorPortfolioPerformancePoint.cs
@@ -1,0 +1,13 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class InvestorPortfolioPerformancePoint : TrackableEntity
+{
+    public int UserId { get; set; }
+    public int Year { get; set; }
+    public int Month { get; set; }
+    public decimal Value { get; set; }
+
+    public virtual User User { get; set; } = null!;
+}

--- a/Antital.Domain/Models/InvestorWallet.cs
+++ b/Antital.Domain/Models/InvestorWallet.cs
@@ -1,0 +1,12 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class InvestorWallet : TrackableEntity
+{
+    public int UserId { get; set; }
+    public decimal AvailableBalance { get; set; }
+    public string Currency { get; set; } = "NGN";
+
+    public virtual User User { get; set; } = null!;
+}

--- a/Antital.Domain/Models/InvestorWatchlistItem.cs
+++ b/Antital.Domain/Models/InvestorWatchlistItem.cs
@@ -1,0 +1,14 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class InvestorWatchlistItem : TrackableEntity
+{
+    public int UserId { get; set; }
+    public int OfferingId { get; set; }
+    public decimal ChangePercent { get; set; }
+    public DateTime AddedAt { get; set; }
+
+    public virtual User User { get; set; } = null!;
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Infrastructure/AntitalDBContext.cs
+++ b/Antital.Infrastructure/AntitalDBContext.cs
@@ -28,6 +28,10 @@ public class AntitalDBContext(
     public DbSet<OfferingUpdate> OfferingUpdates { get; set; }
     public DbSet<Testimonial> Testimonials { get; set; }
     public DbSet<OfferingCorporateProfile> OfferingCorporateProfiles { get; set; }
+    public DbSet<InvestorWallet> InvestorWallets { get; set; }
+    public DbSet<InvestorHolding> InvestorHoldings { get; set; }
+    public DbSet<InvestorWatchlistItem> InvestorWatchlistItems { get; set; }
+    public DbSet<InvestorPortfolioPerformancePoint> InvestorPortfolioPerformancePoints { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -145,7 +149,38 @@ public class AntitalDBContext(
             entity.HasIndex(e => e.UserId).IsUnique();
         });
 
+        ConfigureInvestorDashboard(modelBuilder);
         ConfigureInvestmentOfferings(modelBuilder);
+    }
+
+    private static void ConfigureInvestorDashboard(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<InvestorWallet>(entity =>
+        {
+            entity.HasOne(e => e.User).WithMany().HasForeignKey(e => e.UserId).OnDelete(DeleteBehavior.Restrict);
+            entity.HasIndex(e => e.UserId).IsUnique().HasFilter("\"IsDeleted\" = false");
+            entity.Property(e => e.Currency).HasMaxLength(10).IsRequired();
+        });
+
+        modelBuilder.Entity<InvestorHolding>(entity =>
+        {
+            entity.HasOne(e => e.User).WithMany().HasForeignKey(e => e.UserId).OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(e => e.Offering).WithMany().HasForeignKey(e => e.OfferingId).OnDelete(DeleteBehavior.Restrict);
+            entity.HasIndex(e => new { e.UserId, e.OfferingId, e.InvestedAt });
+        });
+
+        modelBuilder.Entity<InvestorWatchlistItem>(entity =>
+        {
+            entity.HasOne(e => e.User).WithMany().HasForeignKey(e => e.UserId).OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(e => e.Offering).WithMany().HasForeignKey(e => e.OfferingId).OnDelete(DeleteBehavior.Restrict);
+            entity.HasIndex(e => new { e.UserId, e.OfferingId }).IsUnique().HasFilter("\"IsDeleted\" = false");
+        });
+
+        modelBuilder.Entity<InvestorPortfolioPerformancePoint>(entity =>
+        {
+            entity.HasOne(e => e.User).WithMany().HasForeignKey(e => e.UserId).OnDelete(DeleteBehavior.Restrict);
+            entity.HasIndex(e => new { e.UserId, e.Year, e.Month }).IsUnique().HasFilter("\"IsDeleted\" = false");
+        });
     }
 
     private static void ConfigureInvestmentOfferings(ModelBuilder modelBuilder)

--- a/Antital.Infrastructure/Migrations/20260608052911_AddInvestorDashboard.Designer.cs
+++ b/Antital.Infrastructure/Migrations/20260608052911_AddInvestorDashboard.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Antital.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Antital.Infrastructure.Migrations
 {
     [DbContext(typeof(AntitalDBContext))]
-    partial class AntitalDBContextModelSnapshot : ModelSnapshot
+    [Migration("20260608052911_AddInvestorDashboard")]
+    partial class AddInvestorDashboard
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Antital.Infrastructure/Migrations/20260608052911_AddInvestorDashboard.cs
+++ b/Antital.Infrastructure/Migrations/20260608052911_AddInvestorDashboard.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Antital.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInvestorDashboard : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InvestorHoldings",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    InvestedAmount = table.Column<decimal>(type: "numeric", nullable: false),
+                    CurrentValue = table.Column<decimal>(type: "numeric", nullable: false),
+                    Returns = table.Column<decimal>(type: "numeric", nullable: false),
+                    UnitHolding = table.Column<int>(type: "integer", nullable: false),
+                    InvestedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InvestorHoldings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_InvestorHoldings_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_InvestorHoldings_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "InvestorPortfolioPerformancePoints",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    Year = table.Column<int>(type: "integer", nullable: false),
+                    Month = table.Column<int>(type: "integer", nullable: false),
+                    Value = table.Column<decimal>(type: "numeric", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InvestorPortfolioPerformancePoints", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_InvestorPortfolioPerformancePoints_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "InvestorWallets",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    AvailableBalance = table.Column<decimal>(type: "numeric", nullable: false),
+                    Currency = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InvestorWallets", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_InvestorWallets_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "InvestorWatchlistItems",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    ChangePercent = table.Column<decimal>(type: "numeric", nullable: false),
+                    AddedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InvestorWatchlistItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_InvestorWatchlistItems_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_InvestorWatchlistItems_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvestorHoldings_OfferingId",
+                table: "InvestorHoldings",
+                column: "OfferingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvestorHoldings_UserId_OfferingId_InvestedAt",
+                table: "InvestorHoldings",
+                columns: new[] { "UserId", "OfferingId", "InvestedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvestorPortfolioPerformancePoints_UserId_Year_Month",
+                table: "InvestorPortfolioPerformancePoints",
+                columns: new[] { "UserId", "Year", "Month" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvestorWallets_UserId",
+                table: "InvestorWallets",
+                column: "UserId",
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvestorWatchlistItems_OfferingId",
+                table: "InvestorWatchlistItems",
+                column: "OfferingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvestorWatchlistItems_UserId_OfferingId",
+                table: "InvestorWatchlistItems",
+                columns: new[] { "UserId", "OfferingId" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "InvestorHoldings");
+
+            migrationBuilder.DropTable(
+                name: "InvestorPortfolioPerformancePoints");
+
+            migrationBuilder.DropTable(
+                name: "InvestorWallets");
+
+            migrationBuilder.DropTable(
+                name: "InvestorWatchlistItems");
+        }
+    }
+}

--- a/Antital.Infrastructure/Repositories/InvestorDashboardRepository.cs
+++ b/Antital.Infrastructure/Repositories/InvestorDashboardRepository.cs
@@ -1,0 +1,62 @@
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Antital.Infrastructure.Repositories;
+
+public class InvestorDashboardRepository(AntitalDBContext context) : IInvestorDashboardRepository
+{
+    public Task<InvestorWallet?> GetWalletAsync(int userId, CancellationToken cancellationToken = default) =>
+        context.InvestorWallets
+            .AsNoTracking()
+            .FirstOrDefaultAsync(w => w.UserId == userId && !w.IsDeleted, cancellationToken);
+
+    public async Task<IReadOnlyList<InvestorHolding>> GetHoldingsAsync(
+        int userId,
+        DateTime periodStartUtc,
+        DateTime periodEndUtc,
+        CancellationToken cancellationToken = default) =>
+        await context.InvestorHoldings
+            .AsNoTracking()
+            .Include(h => h.Offering)
+            .ThenInclude(o => o.Funding)
+            .Where(h =>
+                h.UserId == userId
+                && !h.IsDeleted
+                && h.InvestedAt >= periodStartUtc
+                && h.InvestedAt < periodEndUtc)
+            .OrderByDescending(h => h.InvestedAt)
+            .ToListAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<InvestorWatchlistItem>> GetWatchlistAsync(
+        int userId,
+        CancellationToken cancellationToken = default) =>
+        await context.InvestorWatchlistItems
+            .AsNoTracking()
+            .Include(w => w.Offering)
+            .ThenInclude(o => o.Funding)
+            .Where(w => w.UserId == userId && !w.IsDeleted)
+            .OrderByDescending(w => w.AddedAt)
+            .ToListAsync(cancellationToken);
+
+    public async Task<IReadOnlyList<InvestorPortfolioPerformancePoint>> GetPerformancePointsAsync(
+        int userId,
+        DateTime periodStartUtc,
+        DateTime periodEndUtc,
+        CancellationToken cancellationToken = default)
+    {
+        var start = periodStartUtc;
+        var end = periodEndUtc;
+
+        return await context.InvestorPortfolioPerformancePoints
+            .AsNoTracking()
+            .Where(p =>
+                p.UserId == userId
+                && !p.IsDeleted
+                && new DateTime(p.Year, p.Month, 1, 0, 0, 0, DateTimeKind.Utc) >= new DateTime(start.Year, start.Month, 1, 0, 0, 0, DateTimeKind.Utc)
+                && new DateTime(p.Year, p.Month, 1, 0, 0, 0, DateTimeKind.Utc) < new DateTime(end.Year, end.Month, 1, 0, 0, 0, DateTimeKind.Utc).AddMonths(1))
+            .OrderBy(p => p.Year)
+            .ThenBy(p => p.Month)
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Antital.Infrastructure/Seed/InvestorDashboardSeed.cs
+++ b/Antital.Infrastructure/Seed/InvestorDashboardSeed.cs
@@ -1,0 +1,128 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Antital.Infrastructure.Seed;
+
+public static class InvestorDashboardSeed
+{
+    private const string SeedUser = "system";
+
+    public static async Task SeedAsync(
+        AntitalDBContext context,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        if (await context.InvestorWallets.AnyAsync(cancellationToken))
+        {
+            return;
+        }
+
+        var offerings = await context.InvestmentOfferings
+            .Include(o => o.Funding)
+            .Where(o => o.Status == OfferingStatus.Published && !o.IsDeleted)
+            .OrderBy(o => o.Id)
+            .Take(4)
+            .ToListAsync(cancellationToken);
+
+        if (offerings.Count == 0)
+        {
+            return;
+        }
+
+        var demoUser = await context.Users
+            .Where(u => u.IsEmailVerified && u.UserType == UserTypeEnum.IndividualInvestor && !u.IsDeleted)
+            .OrderBy(u => u.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (demoUser == null)
+        {
+            logger.LogInformation("Investor dashboard seed skipped: no verified individual investor user found.");
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        var wallet = new InvestorWallet
+        {
+            UserId = demoUser.Id,
+            AvailableBalance = 5_325_400m,
+            Currency = "NGN",
+        };
+        wallet.Created(SeedUser);
+        context.InvestorWallets.Add(wallet);
+
+        var holdings = new List<InvestorHolding>
+        {
+            CreateHolding(demoUser.Id, offerings[0], 25_400_000m, 1_250m, 432_650m, 1234, now.AddDays(-14)),
+            CreateHolding(demoUser.Id, offerings[1], 25_400_000m, 959m, 50_567m, 1245, now.AddDays(-16)),
+        };
+        context.InvestorHoldings.AddRange(holdings);
+
+        foreach (var (offering, changePercent, addedDaysAgo) in new[]
+        {
+            (offerings[0], 4.22m, 2),
+            (offerings[1], 4.13m, 3),
+            (offerings.Count > 2 ? offerings[2] : offerings[0], 6.20m, 4),
+            (offerings.Count > 3 ? offerings[3] : offerings[1], -3.00m, 5),
+        })
+        {
+            var watchlistItem = new InvestorWatchlistItem
+            {
+                UserId = demoUser.Id,
+                OfferingId = offering.Id,
+                ChangePercent = changePercent,
+                AddedAt = now.AddDays(-addedDaysAgo),
+            };
+            watchlistItem.Created(SeedUser);
+            context.InvestorWatchlistItems.Add(watchlistItem);
+        }
+
+        var performanceMonths = Enumerable.Range(0, 7)
+            .Select(offset =>
+            {
+                var monthDate = now.AddMonths(-6 + offset);
+                var point = new InvestorPortfolioPerformancePoint
+                {
+                    UserId = demoUser.Id,
+                    Year = monthDate.Year,
+                    Month = monthDate.Month,
+                    Value = 10m + offset * 8m,
+                };
+                point.Created(SeedUser);
+                return point;
+            })
+            .ToList();
+
+        context.InvestorPortfolioPerformancePoints.AddRange(performanceMonths);
+        await context.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation(
+            "Seeded investor dashboard data for user {UserId} ({Email}).",
+            demoUser.Id,
+            demoUser.Email);
+    }
+
+    private static InvestorHolding CreateHolding(
+        int userId,
+        InvestmentOffering offering,
+        decimal invested,
+        decimal currentValue,
+        decimal returns,
+        int units,
+        DateTime investedAt)
+    {
+        var holding = new InvestorHolding
+        {
+            UserId = userId,
+            OfferingId = offering.Id,
+            InvestedAmount = invested,
+            CurrentValue = currentValue,
+            Returns = returns,
+            UnitHolding = units,
+            InvestedAt = investedAt,
+        };
+        holding.Created(SeedUser);
+        return holding;
+    }
+}

--- a/Antital.Test/Application/Features/Investors/DashboardPeriodResolverTests.cs
+++ b/Antital.Test/Application/Features/Investors/DashboardPeriodResolverTests.cs
@@ -1,0 +1,36 @@
+using Antital.Application.Features.Investors;
+using FluentAssertions;
+using Xunit;
+
+namespace Antital.Test.Application.Features.Investors;
+
+public class DashboardPeriodResolverTests
+{
+    [Theory]
+    [InlineData("this-month")]
+    [InlineData("last-month")]
+    [InlineData("last-3-months")]
+    [InlineData("last-6-months")]
+    [InlineData("last-12-months")]
+    public void TryResolve_ValidPeriods_ReturnsTrue(string period)
+    {
+        var success = DashboardPeriodResolver.TryResolve(period, out var range, out var error);
+
+        success.Should().BeTrue();
+        error.Should().BeNull();
+        range.StartUtc.Should().BeBefore(range.EndUtc);
+    }
+
+    [Theory]
+    [InlineData("active")]
+    [InlineData("5")]
+    [InlineData("2026-05")]
+    [InlineData("last-3-month")]
+    public void TryResolve_InvalidPeriods_ReturnsFalse(string period)
+    {
+        var success = DashboardPeriodResolver.TryResolve(period, out _, out var error);
+
+        success.Should().BeFalse();
+        error.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/InvestorsControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestorsControllerTests.cs
@@ -1,0 +1,264 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using Antital.Application.DTOs.Investors;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Test.Integration;
+using BuildingBlocks.Application.Features;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Antital.Test.Integration.API.Controllers;
+
+[Collection("IntegrationTests")]
+public class InvestorsControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>, IDisposable
+{
+    private readonly CustomWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+    private readonly IServiceScope _scope;
+    private readonly AntitalDBContext _context;
+    private readonly IConfiguration _config;
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    public InvestorsControllerTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+        _scope = _factory.Services.CreateScope();
+        _context = _scope.ServiceProvider.GetRequiredService<AntitalDBContext>();
+        _config = _scope.ServiceProvider.GetRequiredService<IConfiguration>();
+        CleanupDatabase();
+    }
+
+    [Fact]
+    public async Task GetDashboard_WithoutAuth_Returns401()
+    {
+        var response = await _client.GetAsync("/api/investors/me/dashboard");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetDashboard_InvalidPeriod_ReturnsValidationError()
+    {
+        var user = SeedUser("dashboard@example.com");
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+
+        var response = await authClient.GetAsync("/api/investors/me/dashboard?period=active");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorDashboardResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeFalse();
+        result.ValidationErrors.Should().ContainKey("period");
+    }
+
+    [Fact]
+    public async Task GetDashboard_AuthenticatedUser_ReturnsDashboardBundle()
+    {
+        var user = SeedUser("dashboard@example.com");
+        var offering = await SeedOfferingAsync("greentech-solutions");
+        await SeedDashboardDataAsync(user.Id, offering);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+
+        var response = await authClient.GetAsync("/api/investors/me/dashboard?period=this-month");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorDashboardResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Summary.AvailableBalance.Should().Be(5_325_400m);
+        result.Value.Summary.TotalInvested.Should().Be(25_400_000m);
+        result.Value.Summary.Currency.Should().Be("NGN");
+        result.Value.Holdings.Should().ContainSingle(h => h.Slug == "greentech-solutions");
+        result.Value.ActiveDeals.Should().ContainSingle(d => d.Slug == "greentech-solutions");
+        result.Value.PortfolioPerformance.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task GetDashboard_NewInvestor_ReturnsEmptyArraysAndZeroSummary()
+    {
+        var user = SeedUser("empty@example.com");
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+
+        var response = await authClient.GetAsync("/api/investors/me/dashboard?period=this-month");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorDashboardResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Summary.AvailableBalance.Should().Be(0m);
+        result.Value.Summary.TotalInvested.Should().Be(0m);
+        result.Value.Holdings.Should().BeEmpty();
+        result.Value.ActiveDeals.Should().BeEmpty();
+        result.Value.PortfolioPerformance.Should().BeEmpty();
+    }
+
+    private User SeedUser(string email, string? preferredName = null)
+    {
+        var user = new User
+        {
+            Email = email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
+            UserType = UserTypeEnum.IndividualInvestor,
+            IsEmailVerified = true,
+            FirstName = "Jane",
+            LastName = "Okonkwo",
+            PreferredName = preferredName,
+            PhoneNumber = "+2348012345678",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            Nationality = "Nigerian",
+            CountryOfResidence = "Nigeria",
+            StateOfResidence = "Lagos",
+            ResidentialAddress = "123 Main Street",
+            HasAgreedToTerms = true,
+        };
+        _context.Users.Add(user);
+        return user;
+    }
+
+    private async Task<InvestmentOffering> SeedOfferingAsync(string slug)
+    {
+        var offering = new InvestmentOffering
+        {
+            Slug = slug,
+            Name = "GreenTech Solutions",
+            Category = "Energy",
+            Tagline = "Solar innovation",
+            CoverImageUrl = "/investments/ayka_solar.jpg",
+            RiskLevel = OfferingRiskLevel.Low,
+            Status = OfferingStatus.Published,
+            PublishedAt = DateTime.UtcNow,
+            Funding = new OfferingFunding
+            {
+                RaisedAmount = 450_000m,
+                FundingGoal = 1_100_000m,
+                InvestorCount = 25,
+                SharePrice = 22_400m,
+                MinInvestment = 1000m,
+                MaxInvestment = 50_000m,
+            },
+            DealTerms = new DealTerms
+            {
+                TotalSharesOffered = 10_000,
+                PricePerShare = 100m,
+                MinimumInvestment = 1000m,
+                MaximumInvestment = 50_000m,
+                MinimumThreshold = 250_000m,
+                FundingGoal = 1_100_000m,
+                Deadline = DateTime.UtcNow.AddDays(30),
+            },
+        };
+        offering.Created("TestUser");
+        offering.Funding.Created("TestUser");
+        offering.DealTerms.Created("TestUser");
+        _context.InvestmentOfferings.Add(offering);
+        await _context.SaveChangesAsync();
+        return offering;
+    }
+
+    private async Task SeedDashboardDataAsync(int userId, InvestmentOffering offering)
+    {
+        var wallet = new InvestorWallet
+        {
+            UserId = userId,
+            AvailableBalance = 5_325_400m,
+            Currency = "NGN",
+        };
+        wallet.Created("TestUser");
+        _context.InvestorWallets.Add(wallet);
+
+        var holding = new InvestorHolding
+        {
+            UserId = userId,
+            OfferingId = offering.Id,
+            InvestedAmount = 25_400_000m,
+            CurrentValue = 1_250m,
+            Returns = 432_650m,
+            UnitHolding = 1234,
+            InvestedAt = DateTime.UtcNow.AddDays(-3),
+        };
+        holding.Created("TestUser");
+        _context.InvestorHoldings.Add(holding);
+
+        var watchlist = new InvestorWatchlistItem
+        {
+            UserId = userId,
+            OfferingId = offering.Id,
+            ChangePercent = 4.22m,
+            AddedAt = DateTime.UtcNow.AddDays(-1),
+        };
+        watchlist.Created("TestUser");
+        _context.InvestorWatchlistItems.Add(watchlist);
+
+        var now = DateTime.UtcNow;
+        var performance = new InvestorPortfolioPerformancePoint
+        {
+            UserId = userId,
+            Year = now.Year,
+            Month = now.Month,
+            Value = 48m,
+        };
+        performance.Created("TestUser");
+        _context.InvestorPortfolioPerformancePoints.Add(performance);
+        await _context.SaveChangesAsync();
+    }
+
+    private HttpClient CreateAuthorizedClient(int userId, string email)
+    {
+        var client = _factory.CreateClient();
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_config["Jwt:Key"]!);
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _config["Jwt:Issuer"],
+            Audience = _config["Jwt:Audience"],
+            Expires = DateTime.UtcNow.AddHours(1),
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim("UserId", userId.ToString()),
+                new Claim(ClaimTypes.Email, email),
+            }),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256),
+        };
+
+        var token = tokenHandler.CreateToken(descriptor);
+        var jwt = tokenHandler.WriteToken(token);
+
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+        return client;
+    }
+
+    private void CleanupDatabase()
+    {
+        _context.InvestorPortfolioPerformancePoints.RemoveRange(_context.InvestorPortfolioPerformancePoints);
+        _context.InvestorWatchlistItems.RemoveRange(_context.InvestorWatchlistItems);
+        _context.InvestorHoldings.RemoveRange(_context.InvestorHoldings);
+        _context.InvestorWallets.RemoveRange(_context.InvestorWallets);
+        _context.InvestmentOfferings.RemoveRange(_context.InvestmentOfferings.IgnoreQueryFilters());
+        _context.Users.RemoveRange(_context.Users);
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        CleanupDatabase();
+        _scope.Dispose();
+        _client.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/investors/me/dashboard?period=...` for authenticated individual investors
- Returns summary, portfolio performance, active deals, and holdings with Lagos-timezone period resolution (`this-month`, `last-month`, `last-3-months`, `last-6-months`, `last-12-months`)
- Includes EF migration, repository, seed data for demo investor, and integration/unit tests

## Test plan
- [x] Run `dotnet test` — all tests pass locally
- [x] Apply migration on staging DB
- [x] `GET /api/investors/me/dashboard?period=this-month` with valid investor JWT returns `isSuccess: true`
- [x] Verify period filters return expected date ranges

Closes BloydIntel/antital-ui#169 (backend half)

Made with [Cursor](https://cursor.com)