### PR TITLE
Add funding fields to dashboard holdings for portfolio

### DIFF
--- a/Antital.Application/DTOs/Investors/InvestorDashboardDtos.cs
+++ b/Antital.Application/DTOs/Investors/InvestorDashboardDtos.cs
@@ -26,7 +26,9 @@ public record InvestorDashboardHoldingDto(
     decimal CurrentValue,
     decimal Returns,
     int UnitHolding,
-    DateTime Date);
+    DateTime Date,
+    decimal FundingGoal,
+    decimal RaisedAmount);
 
 public record InvestorDashboardResponse(
     InvestorDashboardSummaryDto Summary,

--- a/Antital.Application/Features/Investors/GetInvestorDashboard/InvestorDashboardMappers.cs
+++ b/Antital.Application/Features/Investors/GetInvestorDashboard/InvestorDashboardMappers.cs
@@ -34,7 +34,9 @@ internal static class InvestorDashboardMappers
             holding.CurrentValue,
             holding.Returns,
             holding.UnitHolding,
-            holding.InvestedAt);
+            holding.InvestedAt,
+            offering.Funding?.FundingGoal ?? 0m,
+            offering.Funding?.RaisedAmount ?? 0m);
     }
 
     private static string ToRiskString(OfferingRiskLevel risk) =>

--- a/Antital.Test/Integration/API/Controllers/InvestorsControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestorsControllerTests.cs
@@ -83,7 +83,10 @@ public class InvestorsControllerTests : IClassFixture<CustomWebApplicationFactor
         result.Value!.Summary.AvailableBalance.Should().Be(5_325_400m);
         result.Value.Summary.TotalInvested.Should().Be(25_400_000m);
         result.Value.Summary.Currency.Should().Be("NGN");
-        result.Value.Holdings.Should().ContainSingle(h => h.Slug == "greentech-solutions");
+        result.Value.Holdings.Should().ContainSingle(h =>
+            h.Slug == "greentech-solutions"
+            && h.FundingGoal == 1_100_000m
+            && h.RaisedAmount == 450_000m);
         result.Value.ActiveDeals.Should().ContainSingle(d => d.Slug == "greentech-solutions");
         result.Value.PortfolioPerformance.Should().NotBeEmpty();
     }


### PR DESCRIPTION
## Summary
- Extends `InvestorDashboardHoldingDto` with `fundingGoal` and `raisedAmount` mapped from `OfferingFunding`
- Enables portfolio page table columns (Funding Goal / Amount raised) without a new endpoint
- Updates investor dashboard integration tests

## Test plan
- [x] `dotnet test --filter InvestorsControllerTests` — 4/4 pass
- [x] Merge before antital-ui portfolio PR
- [x] `GET /api/investors/me/dashboard` returns funding fields on holdings

Part of BloydIntel/antital-ui#173 (backend)

Made with [Cursor](https://cursor.com)