### PR TITLE
Add investment checkout API with Paystack

### DIFF
--- a/Antital.API/Configs/DependencyInjection.cs
+++ b/Antital.API/Configs/DependencyInjection.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using Antital.Domain.Configuration;
 using Antital.Application.Features.Investments;
 using Antital.Application.Features.Investments.Checkout;
@@ -120,9 +121,15 @@ public static class DependencyInjection
         services.AddScoped<PaystackSignatureValidator>();
         services.AddScoped<InvestmentOfferingAccess>();
 
-        services.AddHttpClient<IPaystackClient, PaystackClient>(client =>
+        services.AddHttpClient<IPaystackClient, PaystackClient>((serviceProvider, client) =>
         {
             client.BaseAddress = new Uri("https://api.paystack.co/");
+
+            var secretKey = serviceProvider.GetRequiredService<IOptions<PaystackSettings>>().Value.SecretKey;
+            if (!string.IsNullOrWhiteSpace(secretKey))
+            {
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", secretKey);
+            }
         });
 
         return services;

--- a/Antital.API/Configs/DependencyInjection.cs
+++ b/Antital.API/Configs/DependencyInjection.cs
@@ -1,4 +1,9 @@
+using Antital.Domain.Configuration;
 using Antital.Application.Features.Investments;
+using Antital.Application.Features.Investments.Checkout;
+using Antital.Application.Features.Investments.ConfirmInvestmentOrder;
+using Antital.Application.Features.Investments.ProcessPaystackWebhook;
+using Antital.Infrastructure.Integrations.Paystack;
 using Antital.Application.Features.Investors;
 using Antital.Application.Features.Onboarding;
 using Antital.Application.Services;
@@ -13,7 +18,9 @@ using Antital.Application.DTOs;
 using FluentValidation;
 using BuildingBlocks.Application.Behaviours;
 using MediatR;
+using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Filters;
+using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Antital.API.Configs;
 
@@ -59,6 +66,7 @@ public static class DependencyInjection
         services.AddScoped(typeof(IUserKycRepository), typeof(UserKycRepository));
         services.AddScoped(typeof(IInvestmentOfferingRepository), typeof(InvestmentOfferingRepository));
         services.AddScoped(typeof(IInvestorDashboardRepository), typeof(InvestorDashboardRepository));
+        services.AddScoped(typeof(IInvestmentOrderRepository), typeof(InvestmentOrderRepository));
 
         return services;
     }
@@ -85,6 +93,7 @@ public static class DependencyInjection
     private static IServiceCollection RegisterSwagger(this IServiceCollection services)
     {
         services.AddSwaggerExamplesFromAssemblyOf(typeof(UserDto));
+        services.AddTransient<IConfigureOptions<SwaggerGenOptions>, InvestmentCheckoutSwaggerOptions>();
 
         return services;
     }
@@ -93,6 +102,7 @@ public static class DependencyInjection
     {
         // Register EmailSettings
         services.Configure<EmailSettings>(configuration.GetSection("EmailSettings"));
+        services.Configure<PaystackSettings>(configuration.GetSection(PaystackSettings.SectionName));
         services.AddHttpClient(EmailService.MailgunHttpClientName);
 
         // Register authentication services
@@ -104,7 +114,16 @@ public static class DependencyInjection
         services.AddScoped<IKycVerificationService, PassThroughKycVerificationService>();
         services.AddScoped<IOnboardingUserAccess, OnboardingUserAccess>();
         services.AddScoped<IInvestorUserAccess, InvestorUserAccess>();
+        services.AddScoped<IInvestmentCheckoutAccess, InvestmentCheckoutAccess>();
+        services.AddScoped<IInvestmentPaymentConfirmationService, InvestmentPaymentConfirmationService>();
+        services.AddScoped<IConfirmInvestmentOrderService, ConfirmInvestmentOrderService>();
+        services.AddScoped<PaystackSignatureValidator>();
         services.AddScoped<InvestmentOfferingAccess>();
+
+        services.AddHttpClient<IPaystackClient, PaystackClient>(client =>
+        {
+            client.BaseAddress = new Uri("https://api.paystack.co/");
+        });
 
         return services;
     }

--- a/Antital.API/Configs/InvestmentCheckoutSwaggerOptions.cs
+++ b/Antital.API/Configs/InvestmentCheckoutSwaggerOptions.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Options;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Antital.API.Configs;
+
+public class InvestmentCheckoutSwaggerOptions : IConfigureOptions<SwaggerGenOptions>
+{
+    public void Configure(SwaggerGenOptions options)
+    {
+        options.OperationFilter<PaystackWebhookOperationFilter>();
+    }
+}

--- a/Antital.API/Configs/PaystackWebhookOperationFilter.cs
+++ b/Antital.API/Configs/PaystackWebhookOperationFilter.cs
@@ -1,0 +1,50 @@
+using Antital.Application.DTOs.Investments;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Antital.API.Configs;
+
+public class PaystackWebhookOperationFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        if (context.MethodInfo.Name != "PaystackWebhook")
+        {
+            return;
+        }
+
+        operation.RequestBody = new OpenApiRequestBody
+        {
+            Required = true,
+            Content =
+            {
+                ["application/json"] = new OpenApiMediaType
+                {
+                    Schema = context.SchemaGenerator.GenerateSchema(typeof(PaystackWebhookPayloadDto), context.SchemaRepository),
+                    Example = new OpenApiObject
+                    {
+                        ["event"] = new OpenApiString("charge.success"),
+                        ["data"] = new OpenApiObject
+                        {
+                            ["reference"] = new OpenApiString("ANT-ORD-42-a1b2c3d4e5f6"),
+                            ["amount"] = new OpenApiInteger(102_500),
+                            ["channel"] = new OpenApiString("card"),
+                            ["status"] = new OpenApiString("success"),
+                        },
+                    },
+                },
+            },
+        };
+
+        operation.Parameters ??= [];
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = "x-paystack-signature",
+            In = ParameterLocation.Header,
+            Required = true,
+            Schema = new OpenApiSchema { Type = "string" },
+            Description = "HMAC SHA512 signature of the raw request body.",
+        });
+    }
+}

--- a/Antital.API/Controllers/InvestmentOrdersController.cs
+++ b/Antital.API/Controllers/InvestmentOrdersController.cs
@@ -1,0 +1,69 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Application.Features.Investments.GetInvestmentOrder;
+using Antital.Application.Features.Investments.InitializeInvestmentPayment;
+using Antital.Application.Features.Investments.VerifyInvestmentPayment;
+using Antital.Application.Features.Investments.Paystack;
+using Antital.Application.Features.Investments.Swagger;
+using BuildingBlocks.API.Controllers;
+using BuildingBlocks.Application.Features;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Antital.API.Controllers;
+
+[SwaggerTag("Investment Orders")]
+[Route("api/investments/orders")]
+[Authorize]
+[ApiController]
+public class InvestmentOrdersController(IMediator mediator) : BaseController
+{
+    [HttpGet("{orderId:int}")]
+    [SwaggerOperation("Get Investment Order", "Returns checkout order status for polling after Paystack payment.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<GetInvestmentOrderResponse>))]
+    [SwaggerResponseExample(StatusCodes.Status200OK, typeof(GetInvestmentOrderResponseExample))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Onboarding incomplete", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Order not found", typeof(void))]
+    public async Task<IActionResult> GetOrder(int orderId, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetInvestmentOrderQuery(orderId), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpPost("{orderId:int}/pay")]
+    [SwaggerOperation("Initialize Investment Payment", "Initializes Paystack checkout for a pending investment order.")]
+    [SwaggerRequestExample(typeof(InitializeInvestmentPaymentRequest), typeof(InitializeInvestmentPaymentRequestExample))]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<InitializeInvestmentPaymentResponse>))]
+    [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitializeInvestmentPaymentResponseExample))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid order or payment configuration", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Onboarding incomplete", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Order not found", typeof(void))]
+    public async Task<IActionResult> InitializePayment(
+        int orderId,
+        [FromBody] InitializeInvestmentPaymentRequest request,
+        CancellationToken cancellationToken)
+    {
+        var channel = PaystackChannelMapper.ParseChannel(request.Channel);
+        var result = await mediator.Send(new InitializeInvestmentPaymentCommand(orderId, channel), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpPost("{orderId:int}/verify")]
+    [SwaggerOperation(
+        "Verify Investment Payment",
+        "Verifies Paystack payment status and confirms the order. Use after redirect when webhooks cannot reach localhost.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<GetInvestmentOrderResponse>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Payment not complete or invalid order", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Onboarding incomplete", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Order not found", typeof(void))]
+    public async Task<IActionResult> VerifyPayment(int orderId, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new VerifyInvestmentPaymentCommand(orderId), cancellationToken);
+        return ApiResult(result);
+    }
+}

--- a/Antital.API/Controllers/InvestmentsController.cs
+++ b/Antital.API/Controllers/InvestmentsController.cs
@@ -1,4 +1,5 @@
 using Antital.Application.DTOs.Investments;
+using Antital.Application.Features.Investments.CreateInvestmentOrder;
 using Antital.Application.Features.Investments.GetOfferingContentBlocks;
 using Antital.Application.Features.Investments.GetOfferingDocuments;
 using Antital.Application.Features.Investments.GetOfferingFinancials;
@@ -16,6 +17,8 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
+using Swashbuckle.AspNetCore.Filters;
+using Antital.Application.Features.Investments.Swagger;
 
 namespace Antital.API.Controllers;
 
@@ -109,4 +112,27 @@ public class InvestmentsController(IMediator mediator) : BaseController
     [SwaggerResponse(StatusCodes.Status404NotFound, "Not found", typeof(void))]
     public async Task<IActionResult> GetTestimonials(string idOrSlug, CancellationToken cancellationToken) =>
         ApiResult(await mediator.Send(new GetOfferingTestimonialsQuery(idOrSlug), cancellationToken));
+
+    [HttpPost("{offeringId:int}/orders")]
+    [Authorize]
+    [SwaggerOperation(
+        "Create Investment Order",
+        "Creates or refreshes a pending checkout order for the authenticated investor. Requires submitted onboarding.")]
+    [SwaggerRequestExample(typeof(CreateInvestmentOrderRequest), typeof(CreateInvestmentOrderRequestExample))]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<CreateInvestmentOrderResponse>))]
+    [SwaggerResponseExample(StatusCodes.Status200OK, typeof(CreateInvestmentOrderResponseExample))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid units or offering closed", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Onboarding incomplete", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Offering not found", typeof(void))]
+    public async Task<IActionResult> CreateOrder(
+        int offeringId,
+        [FromBody] CreateInvestmentOrderRequest request,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(
+            new CreateInvestmentOrderCommand(offeringId, request.Units),
+            cancellationToken);
+        return ApiResult(result);
+    }
 }

--- a/Antital.API/Controllers/PaymentsController.cs
+++ b/Antital.API/Controllers/PaymentsController.cs
@@ -1,0 +1,39 @@
+using Antital.Application.Features.Investments.ProcessPaystackWebhook;
+using Antital.Infrastructure.Integrations.Paystack;
+using BuildingBlocks.API.Controllers;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Antital.API.Controllers;
+
+[SwaggerTag("Payments")]
+[Route("api/payments")]
+[ApiController]
+public class PaymentsController(
+    IMediator mediator,
+    PaystackSignatureValidator signatureValidator) : BaseController
+{
+    [HttpPost("paystack/webhook")]
+    [AllowAnonymous]
+    [SwaggerOperation(
+        "Paystack Webhook",
+        "Receives Paystack charge events and confirms investment orders. Requires the x-paystack-signature header.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Accepted")]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid signature")]
+    public async Task<IActionResult> PaystackWebhook(CancellationToken cancellationToken)
+    {
+        using var reader = new StreamReader(Request.Body);
+        var rawBody = await reader.ReadToEndAsync(cancellationToken);
+        var signature = Request.Headers["x-paystack-signature"].FirstOrDefault();
+
+        if (!signatureValidator.IsValid(rawBody, signature))
+        {
+            return BadRequest();
+        }
+
+        await mediator.Send(new ProcessPaystackWebhookCommand(rawBody), cancellationToken);
+        return Ok();
+    }
+}

--- a/Antital.API/Program.cs
+++ b/Antital.API/Program.cs
@@ -4,6 +4,11 @@ using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.Configuration.AddJsonFile(
+    $"appsettings.{builder.Environment.EnvironmentName}.local.json",
+    optional: true,
+    reloadOnChange: true);
+
 builder.Services.BaseRegister(builder.Configuration, builder.Host).Register(builder.Configuration);
 builder.Host.UseSerilog();
 

--- a/Antital.API/appsettings.Staging.json
+++ b/Antital.API/appsettings.Staging.json
@@ -53,5 +53,13 @@
     "FromEmail": "crownedprinz@www.thekyub.com",
     "FromName": "Antital",
     "BaseUrl": "https://antital-ui.netlify.app"
+  },
+  "Paystack": {
+    "SecretKey": "sk_test_1d38668a56a7a442f893e26817bc6e87e41151d8",
+    "PublicKey": "pk_test_388f35589b6fa63e562b8910782758ce72da7f6f",
+    "WebhookSecret": "",
+    "CallbackUrl": "https://antital-ui.netlify.app/marketplace/invest/callback",
+    "PlatformFeePercent": 2.5,
+    "OrderExpiryMinutes": 30
   }
 }

--- a/Antital.API/appsettings.Staging.json
+++ b/Antital.API/appsettings.Staging.json
@@ -53,13 +53,5 @@
     "FromEmail": "crownedprinz@www.thekyub.com",
     "FromName": "Antital",
     "BaseUrl": "https://antital-ui.netlify.app"
-  },
-  "Paystack": {
-    "SecretKey": "sk_test_1d38668a56a7a442f893e26817bc6e87e41151d8",
-    "PublicKey": "pk_test_388f35589b6fa63e562b8910782758ce72da7f6f",
-    "WebhookSecret": "",
-    "CallbackUrl": "https://antital-ui.netlify.app/marketplace/invest/callback",
-    "PlatformFeePercent": 2.5,
-    "OrderExpiryMinutes": 30
   }
 }

--- a/Antital.Application/DTOs/Investments/InvestmentOrderDtos.cs
+++ b/Antital.Application/DTOs/Investments/InvestmentOrderDtos.cs
@@ -1,0 +1,42 @@
+namespace Antital.Application.DTOs.Investments;
+
+public record CreateInvestmentOrderRequest(int Units);
+
+public record CreateInvestmentOrderResponse(
+    int OrderId,
+    int OfferingId,
+    int Units,
+    decimal SharePrice,
+    decimal Subtotal,
+    decimal PlatformFeePercent,
+    decimal PlatformFee,
+    decimal TotalAmount,
+    string Currency,
+    string Status,
+    decimal MinInvestment,
+    decimal MaxInvestment,
+    DateTime ExpiresAt);
+
+public record InitializeInvestmentPaymentRequest(string Channel);
+
+public record InitializeInvestmentPaymentResponse(
+    string AuthorizationUrl,
+    string AccessCode,
+    string Reference,
+    string PublicKey);
+
+public record GetInvestmentOrderResponse(
+    int OrderId,
+    int OfferingId,
+    int Units,
+    decimal SharePrice,
+    decimal Subtotal,
+    decimal PlatformFeePercent,
+    decimal PlatformFee,
+    decimal TotalAmount,
+    string Currency,
+    string Status,
+    string? PaystackReference,
+    DateTime? ExpiresAt,
+    DateTime? PaidAt,
+    int? InvestorHoldingId);

--- a/Antital.Application/DTOs/Investments/PaystackWebhookDtos.cs
+++ b/Antital.Application/DTOs/Investments/PaystackWebhookDtos.cs
@@ -1,0 +1,11 @@
+namespace Antital.Application.DTOs.Investments;
+
+public record PaystackChargeDataDto(
+    string Reference,
+    int Amount,
+    string Channel,
+    string Status);
+
+public record PaystackWebhookPayloadDto(
+    string Event,
+    PaystackChargeDataDto Data);

--- a/Antital.Application/Features/Investments/Checkout/InvestmentCheckoutAccess.cs
+++ b/Antital.Application/Features/Investments/Checkout/InvestmentCheckoutAccess.cs
@@ -1,0 +1,36 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using Antital.Application.Features.Onboarding;
+using BuildingBlocks.Application.Exceptions;
+
+namespace Antital.Application.Features.Investments.Checkout;
+
+public interface IInvestmentCheckoutAccess
+{
+    Task<(int UserId, User User)> RequireEligibleInvestorAsync(CancellationToken cancellationToken = default);
+}
+
+public class InvestmentCheckoutAccess(
+    IOnboardingUserAccess onboardingUserAccess,
+    IUserOnboardingRepository onboardingRepository
+) : IInvestmentCheckoutAccess
+{
+    public async Task<(int UserId, User User)> RequireEligibleInvestorAsync(CancellationToken cancellationToken = default)
+    {
+        var (userId, user) = await onboardingUserAccess.RequireVerifiedUserAsync(cancellationToken);
+
+        var onboarding = await onboardingRepository.GetByUserIdAsync(userId, cancellationToken);
+        if (onboarding == null || !IsOnboardingCompleteEnoughToInvest(onboarding.Status))
+        {
+            throw new ForbiddenException("Complete and submit onboarding before investing.");
+        }
+
+        return (userId, user);
+    }
+
+    private static bool IsOnboardingCompleteEnoughToInvest(OnboardingStatus status) =>
+        status is OnboardingStatus.Submitted
+            or OnboardingStatus.UnderReview
+            or OnboardingStatus.Activated;
+}

--- a/Antital.Application/Features/Investments/ConfirmInvestmentOrder/ConfirmInvestmentOrderService.cs
+++ b/Antital.Application/Features/Investments/ConfirmInvestmentOrder/ConfirmInvestmentOrderService.cs
@@ -1,0 +1,73 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+
+namespace Antital.Application.Features.Investments.ConfirmInvestmentOrder;
+
+public class ConfirmInvestmentOrderService(IInvestmentOrderRepository orderRepository) : IConfirmInvestmentOrderService
+{
+    public async Task<bool> TryFulfillAsync(
+        InvestmentOrder order,
+        string actor,
+        CancellationToken cancellationToken = default)
+    {
+        if (order.Status != InvestmentOrderStatus.Paid)
+        {
+            return false;
+        }
+
+        if (order.InvestorHoldingId.HasValue)
+        {
+            return true;
+        }
+
+        var funding = await orderRepository.GetOfferingFundingForUpdateAsync(order.OfferingId, cancellationToken);
+        if (funding == null)
+        {
+            return false;
+        }
+
+        var investedAt = order.PaidAt ?? DateTime.UtcNow;
+        var existingHolding = await orderRepository.GetHoldingByUserAndOfferingAsync(
+            order.UserId,
+            order.OfferingId,
+            cancellationToken);
+
+        InvestorHolding holding;
+        if (existingHolding == null)
+        {
+            holding = new InvestorHolding
+            {
+                UserId = order.UserId,
+                OfferingId = order.OfferingId,
+                InvestedAmount = order.Subtotal,
+                CurrentValue = order.Subtotal,
+                Returns = 0m,
+                UnitHolding = order.Units,
+                InvestedAt = investedAt,
+            };
+            holding.Created(actor);
+            await orderRepository.AddInvestorHoldingAsync(holding, cancellationToken);
+            funding.InvestorCount += 1;
+        }
+        else
+        {
+            existingHolding.InvestedAmount += order.Subtotal;
+            existingHolding.CurrentValue += order.Subtotal;
+            existingHolding.UnitHolding += order.Units;
+            existingHolding.Updated(actor);
+            await orderRepository.UpdateInvestorHoldingAsync(existingHolding, cancellationToken);
+            holding = existingHolding;
+        }
+
+        funding.RaisedAmount += order.Subtotal;
+        funding.Updated(actor);
+        await orderRepository.UpdateOfferingFundingAsync(funding, cancellationToken);
+
+        order.InvestorHolding = holding;
+        order.Updated(actor);
+        await orderRepository.UpdateAsync(order, cancellationToken);
+
+        return true;
+    }
+}

--- a/Antital.Application/Features/Investments/ConfirmInvestmentOrder/IConfirmInvestmentOrderService.cs
+++ b/Antital.Application/Features/Investments/ConfirmInvestmentOrder/IConfirmInvestmentOrderService.cs
@@ -1,0 +1,8 @@
+using Antital.Domain.Models;
+
+namespace Antital.Application.Features.Investments.ConfirmInvestmentOrder;
+
+public interface IConfirmInvestmentOrderService
+{
+    Task<bool> TryFulfillAsync(InvestmentOrder order, string actor, CancellationToken cancellationToken = default);
+}

--- a/Antital.Application/Features/Investments/CreateInvestmentOrder/CreateInvestmentOrderCommand.cs
+++ b/Antital.Application/Features/Investments/CreateInvestmentOrder/CreateInvestmentOrderCommand.cs
@@ -1,0 +1,7 @@
+using Antital.Application.DTOs.Investments;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.CreateInvestmentOrder;
+
+public record CreateInvestmentOrderCommand(int OfferingId, int Units)
+    : ICommandQuery<CreateInvestmentOrderResponse>;

--- a/Antital.Application/Features/Investments/CreateInvestmentOrder/CreateInvestmentOrderCommandHandler.cs
+++ b/Antital.Application/Features/Investments/CreateInvestmentOrder/CreateInvestmentOrderCommandHandler.cs
@@ -1,0 +1,200 @@
+using Antital.Domain.Configuration;
+using Antital.Application.DTOs.Investments;
+using Antital.Application.Features.Investments.Checkout;
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using BuildingBlocks.Domain.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace Antital.Application.Features.Investments.CreateInvestmentOrder;
+
+public class CreateInvestmentOrderCommandHandler(
+    IInvestmentCheckoutAccess checkoutAccess,
+    IInvestmentOfferingRepository offeringRepository,
+    IInvestmentOrderRepository orderRepository,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser,
+    IOptions<PaystackSettings> paystackOptions
+) : ICommandQueryHandler<CreateInvestmentOrderCommand, CreateInvestmentOrderResponse>
+{
+    public async Task<Result<CreateInvestmentOrderResponse>> Handle(
+        CreateInvestmentOrderCommand request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, _) = await checkoutAccess.RequireEligibleInvestorAsync(cancellationToken);
+
+        var offering = await offeringRepository.GetPublishedShellByIdAsync(request.OfferingId, cancellationToken);
+        if (offering?.Funding == null || offering.DealTerms == null)
+        {
+            throw new NotFoundException("Investment offering not found.");
+        }
+
+        ValidateOfferingOpen(offering);
+
+        var settings = paystackOptions.Value;
+        var sharePrice = offering.Funding.SharePrice;
+        var (subtotal, platformFee, totalAmount) = InvestmentOrderCalculator.Calculate(
+            request.Units,
+            sharePrice,
+            settings.PlatformFeePercent);
+
+        ValidateAmounts(subtotal, offering.Funding.MinInvestment, offering.Funding.MaxInvestment);
+
+        var createdBy = ResolveCreatedBy();
+        var expiresAt = DateTime.UtcNow.AddMinutes(settings.OrderExpiryMinutes);
+
+        var order = await ResolveOrCreatePendingOrderAsync(
+            userId,
+            offering.Id,
+            request.Units,
+            sharePrice,
+            subtotal,
+            platformFee,
+            totalAmount,
+            settings.PlatformFeePercent,
+            expiresAt,
+            createdBy,
+            cancellationToken);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        var response = MapToResponse(order, offering.Funding.MinInvestment, offering.Funding.MaxInvestment);
+        var result = new Result<CreateInvestmentOrderResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+
+    private async Task<InvestmentOrder> ResolveOrCreatePendingOrderAsync(
+        int userId,
+        int offeringId,
+        int units,
+        decimal sharePrice,
+        decimal subtotal,
+        decimal platformFee,
+        decimal totalAmount,
+        decimal platformFeePercent,
+        DateTime expiresAt,
+        string createdBy,
+        CancellationToken cancellationToken)
+    {
+        var existing = await orderRepository.GetPendingByUserAndOfferingAsync(userId, offeringId, cancellationToken);
+        if (existing != null)
+        {
+            if (existing.ExpiresAt <= DateTime.UtcNow)
+            {
+                existing.Status = InvestmentOrderStatus.Expired;
+                existing.Updated(createdBy);
+                await orderRepository.UpdateAsync(existing, cancellationToken);
+            }
+            else
+            {
+                ApplyOrderAmounts(existing, units, sharePrice, subtotal, platformFee, totalAmount, platformFeePercent, expiresAt, createdBy);
+                await orderRepository.UpdateAsync(existing, cancellationToken);
+                return existing;
+            }
+        }
+
+        var order = new InvestmentOrder
+        {
+            UserId = userId,
+            OfferingId = offeringId,
+            Status = InvestmentOrderStatus.PendingPayment,
+            Currency = "NGN",
+        };
+        ApplyOrderAmounts(order, units, sharePrice, subtotal, platformFee, totalAmount, platformFeePercent, expiresAt, createdBy);
+        order.Created(createdBy);
+        await orderRepository.AddAsync(order, cancellationToken);
+        return order;
+    }
+
+    private static void ApplyOrderAmounts(
+        InvestmentOrder order,
+        int units,
+        decimal sharePrice,
+        decimal subtotal,
+        decimal platformFee,
+        decimal totalAmount,
+        decimal platformFeePercent,
+        DateTime expiresAt,
+        string createdBy)
+    {
+        order.Units = units;
+        order.SharePrice = sharePrice;
+        order.Subtotal = subtotal;
+        order.PlatformFeePercent = platformFeePercent;
+        order.PlatformFee = platformFee;
+        order.TotalAmount = totalAmount;
+        order.ExpiresAt = expiresAt;
+        order.PaystackReference = null;
+        order.PaymentChannel = null;
+        order.Updated(createdBy);
+    }
+
+    private static void ValidateOfferingOpen(InvestmentOffering offering)
+    {
+        if (offering.Status != OfferingStatus.Published)
+        {
+            throw new BadRequestException(
+                "This offering is not open for investment.",
+                new Dictionary<string, string[]> { ["offering"] = ["Offering is not published."] });
+        }
+
+        if (offering.DealTerms!.Deadline <= DateTime.UtcNow)
+        {
+            throw new BadRequestException(
+                "This offering has closed.",
+                new Dictionary<string, string[]> { ["offering"] = ["Funding deadline has passed."] });
+        }
+    }
+
+    private static void ValidateAmounts(decimal subtotal, decimal minInvestment, decimal maxInvestment)
+    {
+        if (subtotal < minInvestment)
+        {
+            throw new BadRequestException(
+                $"Minimum investment is ₦{minInvestment:N0}.",
+                new Dictionary<string, string[]>
+                {
+                    ["units"] = [$"Investment amount must be at least ₦{minInvestment:N0}."],
+                });
+        }
+
+        if (subtotal > maxInvestment)
+        {
+            throw new BadRequestException(
+                $"Maximum investment per order is ₦{maxInvestment:N0}.",
+                new Dictionary<string, string[]>
+                {
+                    ["units"] = [$"Investment amount cannot exceed ₦{maxInvestment:N0}."],
+                });
+        }
+    }
+
+    private string ResolveCreatedBy() =>
+        !string.IsNullOrEmpty(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrEmpty(currentUser.IPAddress) ? currentUser.IPAddress : "System");
+
+    private static CreateInvestmentOrderResponse MapToResponse(
+        InvestmentOrder order,
+        decimal minInvestment,
+        decimal maxInvestment) =>
+        new(
+            order.Id,
+            order.OfferingId,
+            order.Units,
+            order.SharePrice,
+            order.Subtotal,
+            order.PlatformFeePercent,
+            order.PlatformFee,
+            order.TotalAmount,
+            order.Currency,
+            order.Status.ToString(),
+            minInvestment,
+            maxInvestment,
+            order.ExpiresAt!.Value);
+}

--- a/Antital.Application/Features/Investments/CreateInvestmentOrder/CreateInvestmentOrderCommandValidator.cs
+++ b/Antital.Application/Features/Investments/CreateInvestmentOrder/CreateInvestmentOrderCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace Antital.Application.Features.Investments.CreateInvestmentOrder;
+
+public class CreateInvestmentOrderCommandValidator : AbstractValidator<CreateInvestmentOrderCommand>
+{
+    public CreateInvestmentOrderCommandValidator()
+    {
+        RuleFor(x => x.OfferingId).GreaterThan(0);
+        RuleFor(x => x.Units).GreaterThan(0);
+    }
+}

--- a/Antital.Application/Features/Investments/CreateInvestmentOrder/InvestmentOrderCalculator.cs
+++ b/Antital.Application/Features/Investments/CreateInvestmentOrder/InvestmentOrderCalculator.cs
@@ -1,0 +1,15 @@
+namespace Antital.Application.Features.Investments.CreateInvestmentOrder;
+
+internal static class InvestmentOrderCalculator
+{
+    public static (decimal Subtotal, decimal PlatformFee, decimal TotalAmount) Calculate(
+        int units,
+        decimal sharePrice,
+        decimal platformFeePercent)
+    {
+        var subtotal = units * sharePrice;
+        var platformFee = Math.Round(subtotal * platformFeePercent / 100m, 2, MidpointRounding.AwayFromZero);
+        var total = subtotal + platformFee;
+        return (subtotal, platformFee, total);
+    }
+}

--- a/Antital.Application/Features/Investments/GetInvestmentOrder/GetInvestmentOrderQuery.cs
+++ b/Antital.Application/Features/Investments/GetInvestmentOrder/GetInvestmentOrderQuery.cs
@@ -1,0 +1,6 @@
+using Antital.Application.DTOs.Investments;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.GetInvestmentOrder;
+
+public record GetInvestmentOrderQuery(int OrderId) : ICommandQuery<GetInvestmentOrderResponse>;

--- a/Antital.Application/Features/Investments/GetInvestmentOrder/GetInvestmentOrderQueryHandler.cs
+++ b/Antital.Application/Features/Investments/GetInvestmentOrder/GetInvestmentOrderQueryHandler.cs
@@ -1,0 +1,47 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Application.Features.Investments.Checkout;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.GetInvestmentOrder;
+
+public class GetInvestmentOrderQueryHandler(
+    IInvestmentCheckoutAccess checkoutAccess,
+    IInvestmentOrderRepository orderRepository
+) : ICommandQueryHandler<GetInvestmentOrderQuery, GetInvestmentOrderResponse>
+{
+    public async Task<Result<GetInvestmentOrderResponse>> Handle(
+        GetInvestmentOrderQuery request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, _) = await checkoutAccess.RequireEligibleInvestorAsync(cancellationToken);
+
+        var order = await orderRepository.GetByIdForUserAsync(request.OrderId, userId, cancellationToken);
+        if (order == null)
+        {
+            throw new NotFoundException("Investment order not found.");
+        }
+
+        var response = new GetInvestmentOrderResponse(
+            order.Id,
+            order.OfferingId,
+            order.Units,
+            order.SharePrice,
+            order.Subtotal,
+            order.PlatformFeePercent,
+            order.PlatformFee,
+            order.TotalAmount,
+            order.Currency,
+            order.Status.ToString(),
+            order.PaystackReference,
+            order.ExpiresAt,
+            order.PaidAt,
+            order.InvestorHoldingId);
+
+        var result = new Result<GetInvestmentOrderResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investments/InitializeInvestmentPayment/InitializeInvestmentPaymentCommand.cs
+++ b/Antital.Application/Features/Investments/InitializeInvestmentPayment/InitializeInvestmentPaymentCommand.cs
@@ -1,0 +1,8 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Enums;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.InitializeInvestmentPayment;
+
+public record InitializeInvestmentPaymentCommand(int OrderId, PaymentChannel Channel)
+    : ICommandQuery<InitializeInvestmentPaymentResponse>;

--- a/Antital.Application/Features/Investments/InitializeInvestmentPayment/InitializeInvestmentPaymentCommandHandler.cs
+++ b/Antital.Application/Features/Investments/InitializeInvestmentPayment/InitializeInvestmentPaymentCommandHandler.cs
@@ -1,0 +1,115 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Application.Features.Investments.Checkout;
+using Antital.Application.Features.Investments.Paystack;
+using Antital.Domain.Configuration;
+using Antital.Domain.Enums;
+using Antital.Domain.Integrations.Paystack;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using BuildingBlocks.Domain.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace Antital.Application.Features.Investments.InitializeInvestmentPayment;
+
+public class InitializeInvestmentPaymentCommandHandler(
+    IInvestmentCheckoutAccess checkoutAccess,
+    IInvestmentOrderRepository orderRepository,
+    IUserRepository userRepository,
+    IPaystackClient paystackClient,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser,
+    IOptions<PaystackSettings> paystackOptions
+) : ICommandQueryHandler<InitializeInvestmentPaymentCommand, InitializeInvestmentPaymentResponse>
+{
+    public async Task<Result<InitializeInvestmentPaymentResponse>> Handle(
+        InitializeInvestmentPaymentCommand request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, _) = await checkoutAccess.RequireEligibleInvestorAsync(cancellationToken);
+
+        var order = await orderRepository.GetByIdForUserAsync(request.OrderId, userId, cancellationToken);
+        if (order == null)
+        {
+            throw new NotFoundException("Investment order not found.");
+        }
+
+        EnsureOrderPayable(order);
+
+        var user = await userRepository.GetByIdAsync(userId, cancellationToken);
+        if (user == null)
+        {
+            throw new NotFoundException("User not found.");
+        }
+
+        var settings = paystackOptions.Value;
+        if (string.IsNullOrWhiteSpace(settings.SecretKey) || string.IsNullOrWhiteSpace(settings.CallbackUrl))
+        {
+            throw new BadRequestException(
+                "Payment is not configured.",
+                new Dictionary<string, string[]> { ["payment"] = ["Paystack is not configured."] });
+        }
+
+        var reference = PaystackReferenceGenerator.CreateForOrder(order.Id);
+        var amountKobo = PaystackAmountConverter.ToKobo(order.TotalAmount);
+        var initializeResult = await paystackClient.InitializeTransactionAsync(
+            new PaystackInitializeRequest(
+                user.Email,
+                amountKobo,
+                reference,
+                settings.CallbackUrl,
+                PaystackChannelMapper.ToPaystackChannels(request.Channel)),
+            cancellationToken);
+
+        if (!initializeResult.Success
+            || string.IsNullOrWhiteSpace(initializeResult.AuthorizationUrl)
+            || string.IsNullOrWhiteSpace(initializeResult.AccessCode)
+            || string.IsNullOrWhiteSpace(initializeResult.Reference))
+        {
+            throw new BadRequestException(
+                initializeResult.Message ?? "Unable to initialize payment.",
+                new Dictionary<string, string[]> { ["payment"] = ["Paystack initialization failed."] });
+        }
+
+        var createdBy = ResolveCreatedBy();
+        order.PaymentChannel = request.Channel;
+        order.PaystackReference = initializeResult.Reference;
+        order.Updated(createdBy);
+        await orderRepository.UpdateAsync(order, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        var response = new InitializeInvestmentPaymentResponse(
+            initializeResult.AuthorizationUrl,
+            initializeResult.AccessCode,
+            initializeResult.Reference,
+            settings.PublicKey);
+
+        var result = new Result<InitializeInvestmentPaymentResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+
+    private static void EnsureOrderPayable(InvestmentOrder order)
+    {
+        if (order.Status != InvestmentOrderStatus.PendingPayment)
+        {
+            throw new BadRequestException(
+                "Order is not awaiting payment.",
+                new Dictionary<string, string[]> { ["order"] = [$"Order status is {order.Status}."] });
+        }
+
+        if (order.ExpiresAt <= DateTime.UtcNow)
+        {
+            throw new BadRequestException(
+                "Order has expired. Create a new order.",
+                new Dictionary<string, string[]> { ["order"] = ["Order expired."] });
+        }
+    }
+
+    private string ResolveCreatedBy() =>
+        !string.IsNullOrEmpty(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrEmpty(currentUser.IPAddress) ? currentUser.IPAddress : "System");
+}

--- a/Antital.Application/Features/Investments/InitializeInvestmentPayment/InitializeInvestmentPaymentCommandValidator.cs
+++ b/Antital.Application/Features/Investments/InitializeInvestmentPayment/InitializeInvestmentPaymentCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace Antital.Application.Features.Investments.InitializeInvestmentPayment;
+
+public class InitializeInvestmentPaymentCommandValidator : AbstractValidator<InitializeInvestmentPaymentCommand>
+{
+    public InitializeInvestmentPaymentCommandValidator()
+    {
+        RuleFor(x => x.OrderId).GreaterThan(0);
+        RuleFor(x => x.Channel).IsInEnum();
+    }
+}

--- a/Antital.Application/Features/Investments/Paystack/PaystackAmountConverter.cs
+++ b/Antital.Application/Features/Investments/Paystack/PaystackAmountConverter.cs
@@ -1,0 +1,9 @@
+namespace Antital.Application.Features.Investments.Paystack;
+
+public static class PaystackAmountConverter
+{
+    public static int ToKobo(decimal nairaAmount) =>
+        (int)Math.Round(nairaAmount * 100m, 0, MidpointRounding.AwayFromZero);
+
+    public static decimal FromKobo(int kobo) => kobo / 100m;
+}

--- a/Antital.Application/Features/Investments/Paystack/PaystackChannelMapper.cs
+++ b/Antital.Application/Features/Investments/Paystack/PaystackChannelMapper.cs
@@ -1,0 +1,50 @@
+using Antital.Domain.Enums;
+using BuildingBlocks.Application.Exceptions;
+
+namespace Antital.Application.Features.Investments.Paystack;
+
+public static class PaystackChannelMapper
+{
+    public static bool TryParseChannel(string channel, out PaymentChannel parsed)
+    {
+        parsed = default;
+        switch (channel.Trim().ToLowerInvariant())
+        {
+            case "card":
+                parsed = PaymentChannel.Card;
+                return true;
+            case "transfer":
+                parsed = PaymentChannel.Transfer;
+                return true;
+            case "opay":
+                parsed = PaymentChannel.Opay;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public static PaymentChannel ParseChannel(string channel)
+    {
+        if (TryParseChannel(channel, out var parsed))
+        {
+            return parsed;
+        }
+
+        throw new BadRequestException(
+            "Unsupported payment channel.",
+            new Dictionary<string, string[]>
+            {
+                ["channel"] = ["Channel must be card, transfer, or opay."],
+            });
+    }
+
+    public static IReadOnlyList<string> ToPaystackChannels(PaymentChannel channel) =>
+        channel switch
+        {
+            PaymentChannel.Card => ["card"],
+            PaymentChannel.Transfer => ["bank_transfer"],
+            PaymentChannel.Opay => ["opay"],
+            _ => throw new ArgumentOutOfRangeException(nameof(channel), channel, null)
+        };
+}

--- a/Antital.Application/Features/Investments/Paystack/PaystackReferenceGenerator.cs
+++ b/Antital.Application/Features/Investments/Paystack/PaystackReferenceGenerator.cs
@@ -1,0 +1,7 @@
+namespace Antital.Application.Features.Investments.Paystack;
+
+public static class PaystackReferenceGenerator
+{
+    public static string CreateForOrder(int orderId) =>
+        $"ANT-ORD-{orderId}-{Guid.NewGuid():N}";
+}

--- a/Antital.Application/Features/Investments/ProcessPaystackWebhook/InvestmentPaymentConfirmationService.cs
+++ b/Antital.Application/Features/Investments/ProcessPaystackWebhook/InvestmentPaymentConfirmationService.cs
@@ -1,0 +1,157 @@
+using Antital.Application.Features.Investments.ConfirmInvestmentOrder;
+using Antital.Application.Features.Investments.Paystack;
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using BuildingBlocks.Domain.Interfaces;
+
+namespace Antital.Application.Features.Investments.ProcessPaystackWebhook;
+
+public interface IInvestmentPaymentConfirmationService
+{
+    Task<bool> TryConfirmSuccessfulChargeAsync(
+        string reference,
+        int amountKobo,
+        string? channel,
+        string rawPayload,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> TryMarkFailedChargeAsync(
+        string reference,
+        string rawPayload,
+        CancellationToken cancellationToken = default);
+}
+
+public class InvestmentPaymentConfirmationService(
+    IInvestmentOrderRepository orderRepository,
+    IConfirmInvestmentOrderService confirmInvestmentOrderService,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser
+) : IInvestmentPaymentConfirmationService
+{
+    public async Task<bool> TryConfirmSuccessfulChargeAsync(
+        string reference,
+        int amountKobo,
+        string? channel,
+        string rawPayload,
+        CancellationToken cancellationToken = default)
+    {
+        var order = await orderRepository.GetByPaystackReferenceAsync(reference, cancellationToken);
+        if (order == null)
+        {
+            return false;
+        }
+
+        if (order.Status == InvestmentOrderStatus.Paid)
+        {
+            if (order.InvestorHoldingId.HasValue)
+            {
+                return true;
+            }
+
+            var actor = ResolveActor();
+            await confirmInvestmentOrderService.TryFulfillAsync(order, actor, cancellationToken);
+            await unitOfWork.SaveChangesAsync(cancellationToken);
+            return order.InvestorHoldingId.HasValue;
+        }
+
+        var existingTransaction = await orderRepository.GetPaymentTransactionByReferenceAsync(reference, cancellationToken);
+        if (existingTransaction?.Status == PaymentTransactionStatus.Success)
+        {
+            return true;
+        }
+
+        var expectedKobo = PaystackAmountConverter.ToKobo(order.TotalAmount);
+        if (amountKobo != expectedKobo)
+        {
+            return false;
+        }
+
+        var createdBy = ResolveActor();
+        order.Status = InvestmentOrderStatus.Paid;
+        order.PaidAt = DateTime.UtcNow;
+        order.Updated(createdBy);
+        await orderRepository.UpdateAsync(order, cancellationToken);
+
+        if (existingTransaction == null)
+        {
+            var transaction = new PaymentTransaction
+            {
+                OrderId = order.Id,
+                Reference = reference,
+                Channel = channel,
+                Status = PaymentTransactionStatus.Success,
+                RawPayloadJson = rawPayload,
+                ProcessedAt = DateTime.UtcNow,
+            };
+            transaction.Created(createdBy);
+            await orderRepository.AddPaymentTransactionAsync(transaction, cancellationToken);
+        }
+        else
+        {
+            existingTransaction.Status = PaymentTransactionStatus.Success;
+            existingTransaction.Channel = channel ?? existingTransaction.Channel;
+            existingTransaction.RawPayloadJson = rawPayload;
+            existingTransaction.ProcessedAt = DateTime.UtcNow;
+            existingTransaction.Updated(createdBy);
+            await orderRepository.UpdatePaymentTransactionAsync(existingTransaction, cancellationToken);
+        }
+
+        await confirmInvestmentOrderService.TryFulfillAsync(order, createdBy, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    public async Task<bool> TryMarkFailedChargeAsync(
+        string reference,
+        string rawPayload,
+        CancellationToken cancellationToken = default)
+    {
+        var order = await orderRepository.GetByPaystackReferenceAsync(reference, cancellationToken);
+        if (order == null)
+        {
+            return false;
+        }
+
+        if (order.Status == InvestmentOrderStatus.Paid)
+        {
+            return true;
+        }
+
+        var actor = ResolveActor();
+        order.Status = InvestmentOrderStatus.Failed;
+        order.Updated(actor);
+        await orderRepository.UpdateAsync(order, cancellationToken);
+
+        var existingTransaction = await orderRepository.GetPaymentTransactionByReferenceAsync(reference, cancellationToken);
+        if (existingTransaction == null)
+        {
+            var transaction = new PaymentTransaction
+            {
+                OrderId = order.Id,
+                Reference = reference,
+                Status = PaymentTransactionStatus.Failed,
+                RawPayloadJson = rawPayload,
+                ProcessedAt = DateTime.UtcNow,
+            };
+            transaction.Created(actor);
+            await orderRepository.AddPaymentTransactionAsync(transaction, cancellationToken);
+        }
+        else
+        {
+            existingTransaction.Status = PaymentTransactionStatus.Failed;
+            existingTransaction.RawPayloadJson = rawPayload;
+            existingTransaction.ProcessedAt = DateTime.UtcNow;
+            existingTransaction.Updated(actor);
+            await orderRepository.UpdatePaymentTransactionAsync(existingTransaction, cancellationToken);
+        }
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    private string ResolveActor() =>
+        !string.IsNullOrEmpty(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrEmpty(currentUser.IPAddress) ? currentUser.IPAddress : "PaystackWebhook");
+}

--- a/Antital.Application/Features/Investments/ProcessPaystackWebhook/ProcessPaystackWebhookCommand.cs
+++ b/Antital.Application/Features/Investments/ProcessPaystackWebhook/ProcessPaystackWebhookCommand.cs
@@ -1,0 +1,5 @@
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.ProcessPaystackWebhook;
+
+public record ProcessPaystackWebhookCommand(string RawBody) : ICommandQuery<bool>;

--- a/Antital.Application/Features/Investments/ProcessPaystackWebhook/ProcessPaystackWebhookCommandHandler.cs
+++ b/Antital.Application/Features/Investments/ProcessPaystackWebhook/ProcessPaystackWebhookCommandHandler.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.ProcessPaystackWebhook;
+
+public class ProcessPaystackWebhookCommandHandler(
+    IInvestmentPaymentConfirmationService paymentConfirmationService
+) : ICommandQueryHandler<ProcessPaystackWebhookCommand, bool>
+{
+    public async Task<Result<bool>> Handle(ProcessPaystackWebhookCommand request, CancellationToken cancellationToken)
+    {
+        using var document = JsonDocument.Parse(request.RawBody);
+        var root = document.RootElement;
+
+        if (!root.TryGetProperty("event", out var eventElement))
+        {
+            return Ignored();
+        }
+
+        var eventName = eventElement.GetString();
+
+        if (!root.TryGetProperty("data", out var data))
+        {
+            return Ignored();
+        }
+
+        var reference = data.TryGetProperty("reference", out var referenceElement)
+            ? referenceElement.GetString()
+            : null;
+
+        if (string.IsNullOrWhiteSpace(reference))
+        {
+            return Ignored();
+        }
+
+        var handled = eventName switch
+        {
+            "charge.success" => await HandleSuccessAsync(data, reference, request.RawBody, cancellationToken),
+            "charge.failed" => await paymentConfirmationService.TryMarkFailedChargeAsync(
+                reference,
+                request.RawBody,
+                cancellationToken),
+            _ => false,
+        };
+
+        var result = new Result<bool>();
+        result.AddValue(handled);
+        result.OK();
+        return result;
+    }
+
+    private static Result<bool> Ignored()
+    {
+        var ignored = new Result<bool>();
+        ignored.AddValue(false);
+        ignored.OK();
+        return ignored;
+    }
+
+    private async Task<bool> HandleSuccessAsync(
+        JsonElement data,
+        string reference,
+        string rawPayload,
+        CancellationToken cancellationToken)
+    {
+        var amountKobo = data.TryGetProperty("amount", out var amountElement) && amountElement.TryGetInt32(out var amount)
+            ? amount
+            : 0;
+        var channel = data.TryGetProperty("channel", out var channelElement)
+            ? channelElement.GetString()
+            : null;
+
+        return await paymentConfirmationService.TryConfirmSuccessfulChargeAsync(
+            reference,
+            amountKobo,
+            channel,
+            rawPayload,
+            cancellationToken);
+    }
+}

--- a/Antital.Application/Features/Investments/Swagger/CreateInvestmentOrderRequestExample.cs
+++ b/Antital.Application/Features/Investments/Swagger/CreateInvestmentOrderRequestExample.cs
@@ -1,0 +1,9 @@
+using Antital.Application.DTOs.Investments;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Antital.Application.Features.Investments.Swagger;
+
+public class CreateInvestmentOrderRequestExample : IExamplesProvider<CreateInvestmentOrderRequest>
+{
+    public CreateInvestmentOrderRequest GetExamples() => new(Units: 10);
+}

--- a/Antital.Application/Features/Investments/Swagger/CreateInvestmentOrderResponseExample.cs
+++ b/Antital.Application/Features/Investments/Swagger/CreateInvestmentOrderResponseExample.cs
@@ -1,0 +1,24 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Enums;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Antital.Application.Features.Investments.Swagger;
+
+public class CreateInvestmentOrderResponseExample : IExamplesProvider<CreateInvestmentOrderResponse>
+{
+    public CreateInvestmentOrderResponse GetExamples() =>
+        new(
+            OrderId: 42,
+            OfferingId: 7,
+            Units: 10,
+            SharePrice: 100m,
+            Subtotal: 1000m,
+            PlatformFeePercent: 2.5m,
+            PlatformFee: 25m,
+            TotalAmount: 1025m,
+            Currency: "NGN",
+            Status: nameof(InvestmentOrderStatus.PendingPayment),
+            MinInvestment: 1000m,
+            MaxInvestment: 50_000m,
+            ExpiresAt: DateTime.UtcNow.AddMinutes(30));
+}

--- a/Antital.Application/Features/Investments/Swagger/GetInvestmentOrderResponseExample.cs
+++ b/Antital.Application/Features/Investments/Swagger/GetInvestmentOrderResponseExample.cs
@@ -1,0 +1,25 @@
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Enums;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Antital.Application.Features.Investments.Swagger;
+
+public class GetInvestmentOrderResponseExample : IExamplesProvider<GetInvestmentOrderResponse>
+{
+    public GetInvestmentOrderResponse GetExamples() =>
+        new(
+            OrderId: 42,
+            OfferingId: 7,
+            Units: 10,
+            SharePrice: 100m,
+            Subtotal: 1000m,
+            PlatformFeePercent: 2.5m,
+            PlatformFee: 25m,
+            TotalAmount: 1025m,
+            Currency: "NGN",
+            Status: nameof(InvestmentOrderStatus.Paid),
+            PaystackReference: "ANT-ORD-42-a1b2c3d4e5f6",
+            ExpiresAt: DateTime.UtcNow.AddMinutes(30),
+            PaidAt: DateTime.UtcNow,
+            InvestorHoldingId: 15);
+}

--- a/Antital.Application/Features/Investments/Swagger/InitializeInvestmentPaymentRequestExample.cs
+++ b/Antital.Application/Features/Investments/Swagger/InitializeInvestmentPaymentRequestExample.cs
@@ -1,0 +1,9 @@
+using Antital.Application.DTOs.Investments;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Antital.Application.Features.Investments.Swagger;
+
+public class InitializeInvestmentPaymentRequestExample : IExamplesProvider<InitializeInvestmentPaymentRequest>
+{
+    public InitializeInvestmentPaymentRequest GetExamples() => new(Channel: "card");
+}

--- a/Antital.Application/Features/Investments/Swagger/InitializeInvestmentPaymentResponseExample.cs
+++ b/Antital.Application/Features/Investments/Swagger/InitializeInvestmentPaymentResponseExample.cs
@@ -1,0 +1,14 @@
+using Antital.Application.DTOs.Investments;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Antital.Application.Features.Investments.Swagger;
+
+public class InitializeInvestmentPaymentResponseExample : IExamplesProvider<InitializeInvestmentPaymentResponse>
+{
+    public InitializeInvestmentPaymentResponse GetExamples() =>
+        new(
+            AuthorizationUrl: "https://checkout.paystack.com/abc123",
+            AccessCode: "access_code_xyz",
+            Reference: "ANT-ORD-42-a1b2c3d4e5f6",
+            PublicKey: "pk_test_xxxxxxxx");
+}

--- a/Antital.Application/Features/Investments/Swagger/PaystackWebhookPayloadExample.cs
+++ b/Antital.Application/Features/Investments/Swagger/PaystackWebhookPayloadExample.cs
@@ -1,0 +1,16 @@
+using Antital.Application.DTOs.Investments;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Antital.Application.Features.Investments.Swagger;
+
+public class PaystackWebhookPayloadExample : IExamplesProvider<PaystackWebhookPayloadDto>
+{
+    public PaystackWebhookPayloadDto GetExamples() =>
+        new(
+            Event: "charge.success",
+            Data: new PaystackChargeDataDto(
+                Reference: "ANT-ORD-42-a1b2c3d4e5f6",
+                Amount: 102_500,
+                Channel: "card",
+                Status: "success"));
+}

--- a/Antital.Application/Features/Investments/VerifyInvestmentPayment/VerifyInvestmentPaymentCommand.cs
+++ b/Antital.Application/Features/Investments/VerifyInvestmentPayment/VerifyInvestmentPaymentCommand.cs
@@ -1,0 +1,6 @@
+using Antital.Application.DTOs.Investments;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.VerifyInvestmentPayment;
+
+public record VerifyInvestmentPaymentCommand(int OrderId) : ICommandQuery<GetInvestmentOrderResponse>;

--- a/Antital.Application/Features/Investments/VerifyInvestmentPayment/VerifyInvestmentPaymentCommandHandler.cs
+++ b/Antital.Application/Features/Investments/VerifyInvestmentPayment/VerifyInvestmentPaymentCommandHandler.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using Antital.Application.DTOs.Investments;
+using Antital.Application.Features.Investments.Checkout;
+using Antital.Application.Features.Investments.ProcessPaystackWebhook;
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investments.VerifyInvestmentPayment;
+
+/// <summary>
+/// Confirms payment via Paystack verify API. Use when webhooks cannot reach localhost during local dev.
+/// </summary>
+public class VerifyInvestmentPaymentCommandHandler(
+    IInvestmentCheckoutAccess checkoutAccess,
+    IInvestmentOrderRepository orderRepository,
+    IPaystackClient paystackClient,
+    IInvestmentPaymentConfirmationService paymentConfirmationService
+) : ICommandQueryHandler<VerifyInvestmentPaymentCommand, GetInvestmentOrderResponse>
+{
+    public async Task<Result<GetInvestmentOrderResponse>> Handle(
+        VerifyInvestmentPaymentCommand request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, _) = await checkoutAccess.RequireEligibleInvestorAsync(cancellationToken);
+
+        var order = await orderRepository.GetByIdForUserAsync(request.OrderId, userId, cancellationToken);
+        if (order == null)
+        {
+            throw new NotFoundException("Investment order not found.");
+        }
+
+        if (order.Status == InvestmentOrderStatus.Paid)
+        {
+            return Success(order);
+        }
+
+        if (string.IsNullOrWhiteSpace(order.PaystackReference))
+        {
+            throw new BadRequestException(
+                "Payment has not been initialized for this order.",
+                new Dictionary<string, string[]> { ["order"] = ["Missing Paystack reference."] });
+        }
+
+        if (order.Status != InvestmentOrderStatus.PendingPayment)
+        {
+            throw new BadRequestException(
+                "Order is not awaiting payment.",
+                new Dictionary<string, string[]> { ["order"] = [$"Order status is {order.Status}."] });
+        }
+
+        var verifyResult = await paystackClient.VerifyTransactionAsync(order.PaystackReference, cancellationToken);
+        if (!verifyResult.Success)
+        {
+            throw new BadRequestException(
+                verifyResult.Message ?? "Payment is not complete yet.",
+                new Dictionary<string, string[]> { ["payment"] = ["Paystack verification failed."] });
+        }
+
+        var rawPayload = JsonSerializer.Serialize(new
+        {
+            @event = "charge.success",
+            data = new
+            {
+                reference = order.PaystackReference,
+                amount = verifyResult.AmountKobo,
+                channel = verifyResult.Channel,
+                status = verifyResult.Status,
+            },
+        });
+
+        await paymentConfirmationService.TryConfirmSuccessfulChargeAsync(
+            order.PaystackReference,
+            verifyResult.AmountKobo,
+            verifyResult.Channel,
+            rawPayload,
+            cancellationToken);
+
+        var updated = await orderRepository.GetByIdForUserAsync(request.OrderId, userId, cancellationToken)
+            ?? throw new NotFoundException("Investment order not found.");
+
+        return Success(updated);
+    }
+
+    private static Result<GetInvestmentOrderResponse> Success(Domain.Models.InvestmentOrder order)
+    {
+        var response = new GetInvestmentOrderResponse(
+            order.Id,
+            order.OfferingId,
+            order.Units,
+            order.SharePrice,
+            order.Subtotal,
+            order.PlatformFeePercent,
+            order.PlatformFee,
+            order.TotalAmount,
+            order.Currency,
+            order.Status.ToString(),
+            order.PaystackReference,
+            order.ExpiresAt,
+            order.PaidAt,
+            order.InvestorHoldingId);
+
+        var result = new Result<GetInvestmentOrderResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Domain/Configuration/PaystackSettings.cs
+++ b/Antital.Domain/Configuration/PaystackSettings.cs
@@ -1,0 +1,13 @@
+namespace Antital.Domain.Configuration;
+
+public class PaystackSettings
+{
+    public const string SectionName = "Paystack";
+
+    public string SecretKey { get; set; } = string.Empty;
+    public string PublicKey { get; set; } = string.Empty;
+    public string WebhookSecret { get; set; } = string.Empty;
+    public string CallbackUrl { get; set; } = string.Empty;
+    public decimal PlatformFeePercent { get; set; } = 2.5m;
+    public int OrderExpiryMinutes { get; set; } = 30;
+}

--- a/Antital.Domain/Enums/InvestmentOrderStatus.cs
+++ b/Antital.Domain/Enums/InvestmentOrderStatus.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel;
+
+namespace Antital.Domain.Enums;
+
+public enum InvestmentOrderStatus
+{
+    [Description("Pending Payment")]
+    PendingPayment = 0,
+
+    [Description("Paid")]
+    Paid = 1,
+
+    [Description("Failed")]
+    Failed = 2,
+
+    [Description("Expired")]
+    Expired = 3,
+
+    [Description("Cancelled")]
+    Cancelled = 4
+}

--- a/Antital.Domain/Enums/PaymentChannel.cs
+++ b/Antital.Domain/Enums/PaymentChannel.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel;
+
+namespace Antital.Domain.Enums;
+
+/// <summary>Checkout payment channel selected by the investor (maps to Paystack channels).</summary>
+public enum PaymentChannel
+{
+    [Description("Card")]
+    Card = 0,
+
+    [Description("Bank Transfer")]
+    Transfer = 1,
+
+    [Description("Opay")]
+    Opay = 2
+}

--- a/Antital.Domain/Enums/PaymentTransactionStatus.cs
+++ b/Antital.Domain/Enums/PaymentTransactionStatus.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel;
+
+namespace Antital.Domain.Enums;
+
+public enum PaymentTransactionStatus
+{
+    [Description("Pending")]
+    Pending = 0,
+
+    [Description("Success")]
+    Success = 1,
+
+    [Description("Failed")]
+    Failed = 2
+}

--- a/Antital.Domain/Integrations/Paystack/PaystackModels.cs
+++ b/Antital.Domain/Integrations/Paystack/PaystackModels.cs
@@ -1,0 +1,22 @@
+namespace Antital.Domain.Integrations.Paystack;
+
+public record PaystackInitializeRequest(
+    string Email,
+    int AmountKobo,
+    string Reference,
+    string CallbackUrl,
+    IReadOnlyList<string> Channels);
+
+public record PaystackInitializeResult(
+    bool Success,
+    string? AuthorizationUrl,
+    string? AccessCode,
+    string? Reference,
+    string? Message);
+
+public record PaystackVerifyResult(
+    bool Success,
+    string Status,
+    string? Channel,
+    int AmountKobo,
+    string? Message);

--- a/Antital.Domain/Interfaces/IInvestmentOrderRepository.cs
+++ b/Antital.Domain/Interfaces/IInvestmentOrderRepository.cs
@@ -1,0 +1,45 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+
+namespace Antital.Domain.Interfaces;
+
+public interface IInvestmentOrderRepository
+{
+    Task<InvestmentOrder?> GetByIdAsync(int orderId, CancellationToken cancellationToken = default);
+
+    Task<InvestmentOrder?> GetByIdForUserAsync(int orderId, int userId, CancellationToken cancellationToken = default);
+
+    Task<InvestmentOrder?> GetByPaystackReferenceAsync(string reference, CancellationToken cancellationToken = default);
+
+    Task<InvestmentOrder?> GetPendingByUserAndOfferingAsync(
+        int userId,
+        int offeringId,
+        CancellationToken cancellationToken = default);
+
+    Task AddAsync(InvestmentOrder order, CancellationToken cancellationToken = default);
+
+    Task AddPaymentTransactionAsync(PaymentTransaction transaction, CancellationToken cancellationToken = default);
+
+    Task<PaymentTransaction?> GetPaymentTransactionByReferenceAsync(
+        string reference,
+        CancellationToken cancellationToken = default);
+
+    Task UpdatePaymentTransactionAsync(PaymentTransaction transaction, CancellationToken cancellationToken = default);
+
+    Task<InvestorHolding?> GetHoldingByUserAndOfferingAsync(
+        int userId,
+        int offeringId,
+        CancellationToken cancellationToken = default);
+
+    Task AddInvestorHoldingAsync(InvestorHolding holding, CancellationToken cancellationToken = default);
+
+    Task UpdateInvestorHoldingAsync(InvestorHolding holding, CancellationToken cancellationToken = default);
+
+    Task<OfferingFunding?> GetOfferingFundingForUpdateAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default);
+
+    Task UpdateOfferingFundingAsync(OfferingFunding funding, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(InvestmentOrder order, CancellationToken cancellationToken = default);
+}

--- a/Antital.Domain/Interfaces/IPaystackClient.cs
+++ b/Antital.Domain/Interfaces/IPaystackClient.cs
@@ -1,0 +1,14 @@
+using Antital.Domain.Integrations.Paystack;
+
+namespace Antital.Domain.Interfaces;
+
+public interface IPaystackClient
+{
+    Task<PaystackInitializeResult> InitializeTransactionAsync(
+        PaystackInitializeRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<PaystackVerifyResult> VerifyTransactionAsync(
+        string reference,
+        CancellationToken cancellationToken = default);
+}

--- a/Antital.Domain/Models/InvestmentOrder.cs
+++ b/Antital.Domain/Models/InvestmentOrder.cs
@@ -1,0 +1,28 @@
+using Antital.Domain.Enums;
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class InvestmentOrder : TrackableEntity
+{
+    public int UserId { get; set; }
+    public int OfferingId { get; set; }
+    public int Units { get; set; }
+    public decimal SharePrice { get; set; }
+    public decimal Subtotal { get; set; }
+    public decimal PlatformFeePercent { get; set; }
+    public decimal PlatformFee { get; set; }
+    public decimal TotalAmount { get; set; }
+    public string Currency { get; set; } = "NGN";
+    public InvestmentOrderStatus Status { get; set; }
+    public PaymentChannel? PaymentChannel { get; set; }
+    public string? PaystackReference { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+    public DateTime? PaidAt { get; set; }
+    public int? InvestorHoldingId { get; set; }
+
+    public virtual User User { get; set; } = null!;
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+    public virtual InvestorHolding? InvestorHolding { get; set; }
+    public ICollection<PaymentTransaction> PaymentTransactions { get; set; } = [];
+}

--- a/Antital.Domain/Models/PaymentTransaction.cs
+++ b/Antital.Domain/Models/PaymentTransaction.cs
@@ -1,0 +1,17 @@
+using Antital.Domain.Enums;
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+public class PaymentTransaction : TrackableEntity
+{
+    public int OrderId { get; set; }
+    public string Provider { get; set; } = "Paystack";
+    public string Reference { get; set; } = string.Empty;
+    public string? Channel { get; set; }
+    public PaymentTransactionStatus Status { get; set; }
+    public string? RawPayloadJson { get; set; }
+    public DateTime? ProcessedAt { get; set; }
+
+    public virtual InvestmentOrder Order { get; set; } = null!;
+}

--- a/Antital.Infrastructure/AntitalDBContext.cs
+++ b/Antital.Infrastructure/AntitalDBContext.cs
@@ -32,6 +32,8 @@ public class AntitalDBContext(
     public DbSet<InvestorHolding> InvestorHoldings { get; set; }
     public DbSet<InvestorWatchlistItem> InvestorWatchlistItems { get; set; }
     public DbSet<InvestorPortfolioPerformancePoint> InvestorPortfolioPerformancePoints { get; set; }
+    public DbSet<InvestmentOrder> InvestmentOrders { get; set; }
+    public DbSet<PaymentTransaction> PaymentTransactions { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -151,6 +153,42 @@ public class AntitalDBContext(
 
         ConfigureInvestorDashboard(modelBuilder);
         ConfigureInvestmentOfferings(modelBuilder);
+        ConfigureInvestmentCheckout(modelBuilder);
+    }
+
+    private static void ConfigureInvestmentCheckout(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<InvestmentOrder>(entity =>
+        {
+            entity.HasOne(e => e.User).WithMany().HasForeignKey(e => e.UserId).OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(e => e.Offering).WithMany().HasForeignKey(e => e.OfferingId).OnDelete(DeleteBehavior.Restrict);
+            entity.HasOne(e => e.InvestorHolding).WithMany().HasForeignKey(e => e.InvestorHoldingId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            entity.Property(e => e.Currency).HasMaxLength(10).IsRequired();
+            entity.Property(e => e.PaystackReference).HasMaxLength(100);
+
+            entity.HasIndex(e => e.PaystackReference)
+                .IsUnique()
+                .HasFilter("\"PaystackReference\" IS NOT NULL AND \"IsDeleted\" = false");
+
+            entity.HasIndex(e => new { e.UserId, e.OfferingId, e.Status })
+                .HasFilter("\"Status\" = 0 AND \"IsDeleted\" = false");
+        });
+
+        modelBuilder.Entity<PaymentTransaction>(entity =>
+        {
+            entity.HasOne(e => e.Order).WithMany(o => o.PaymentTransactions).HasForeignKey(e => e.OrderId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.Property(e => e.Provider).HasMaxLength(50).IsRequired();
+            entity.Property(e => e.Reference).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.Channel).HasMaxLength(50);
+
+            entity.HasIndex(e => e.Reference)
+                .IsUnique()
+                .HasFilter("\"IsDeleted\" = false");
+        });
     }
 
     private static void ConfigureInvestorDashboard(ModelBuilder modelBuilder)

--- a/Antital.Infrastructure/Integrations/Paystack/PaystackClient.cs
+++ b/Antital.Infrastructure/Integrations/Paystack/PaystackClient.cs
@@ -1,0 +1,132 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Antital.Domain.Configuration;
+using Antital.Domain.Integrations.Paystack;
+using Antital.Domain.Interfaces;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Antital.Infrastructure.Integrations.Paystack;
+
+public class PaystackClient(
+    HttpClient httpClient,
+    IOptions<PaystackSettings> options,
+    ILogger<PaystackClient> logger) : IPaystackClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public async Task<PaystackInitializeResult> InitializeTransactionAsync(
+        PaystackInitializeRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+
+        var payload = new
+        {
+            email = request.Email,
+            amount = request.AmountKobo,
+            reference = request.Reference,
+            callback_url = request.CallbackUrl,
+            channels = request.Channels,
+            currency = "NGN",
+            metadata = new
+            {
+                orderReference = request.Reference,
+            },
+        };
+
+        using var response = await httpClient.PostAsJsonAsync("transaction/initialize", payload, JsonOptions, cancellationToken);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogWarning("Paystack initialize failed with status {StatusCode}: {Body}", response.StatusCode, body);
+            return new PaystackInitializeResult(false, null, null, null, "Unable to initialize payment.");
+        }
+
+        var parsed = JsonSerializer.Deserialize<PaystackEnvelope<PaystackInitializeData>>(body, JsonOptions);
+        if (parsed is not { Status: true, Data: not null })
+        {
+            return new PaystackInitializeResult(false, null, null, null, parsed?.Message ?? "Unable to initialize payment.");
+        }
+
+        return new PaystackInitializeResult(
+            true,
+            parsed.Data.AuthorizationUrl,
+            parsed.Data.AccessCode,
+            parsed.Data.Reference,
+            parsed.Message);
+    }
+
+    public async Task<PaystackVerifyResult> VerifyTransactionAsync(
+        string reference,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+
+        using var response = await httpClient.GetAsync($"transaction/verify/{Uri.EscapeDataString(reference)}", cancellationToken);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogWarning("Paystack verify failed with status {StatusCode}: {Body}", response.StatusCode, body);
+            return new PaystackVerifyResult(false, "failed", null, 0, "Unable to verify payment.");
+        }
+
+        var parsed = JsonSerializer.Deserialize<PaystackEnvelope<PaystackVerifyData>>(body, JsonOptions);
+        if (parsed?.Data == null)
+        {
+            return new PaystackVerifyResult(false, "failed", null, 0, parsed?.Message ?? "Unable to verify payment.");
+        }
+
+        return new PaystackVerifyResult(
+            parsed.Status && string.Equals(parsed.Data.Status, "success", StringComparison.OrdinalIgnoreCase),
+            parsed.Data.Status,
+            parsed.Data.Channel,
+            parsed.Data.Amount,
+            parsed.Message);
+    }
+
+    private void EnsureConfigured()
+    {
+        var secretKey = options.Value.SecretKey;
+        if (string.IsNullOrWhiteSpace(secretKey))
+        {
+            throw new InvalidOperationException("Paystack secret key is not configured.");
+        }
+
+        if (httpClient.DefaultRequestHeaders.Authorization == null)
+        {
+            httpClient.BaseAddress ??= new Uri("https://api.paystack.co/");
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", secretKey);
+        }
+    }
+
+    private sealed class PaystackEnvelope<T>
+    {
+        public bool Status { get; set; }
+        public string? Message { get; set; }
+        public T? Data { get; set; }
+    }
+
+    private sealed class PaystackInitializeData
+    {
+        public string? AuthorizationUrl { get; set; }
+        public string? AccessCode { get; set; }
+        public string? Reference { get; set; }
+    }
+
+    private sealed class PaystackVerifyData
+    {
+        public string Status { get; set; } = string.Empty;
+        public string? Channel { get; set; }
+        public int Amount { get; set; }
+    }
+}

--- a/Antital.Infrastructure/Integrations/Paystack/PaystackClient.cs
+++ b/Antital.Infrastructure/Integrations/Paystack/PaystackClient.cs
@@ -1,4 +1,3 @@
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -26,7 +25,7 @@ public class PaystackClient(
         PaystackInitializeRequest request,
         CancellationToken cancellationToken = default)
     {
-        EnsureConfigured();
+        EnsureSecretKeyConfigured();
 
         var payload = new
         {
@@ -69,7 +68,7 @@ public class PaystackClient(
         string reference,
         CancellationToken cancellationToken = default)
     {
-        EnsureConfigured();
+        EnsureSecretKeyConfigured();
 
         using var response = await httpClient.GetAsync($"transaction/verify/{Uri.EscapeDataString(reference)}", cancellationToken);
         var body = await response.Content.ReadAsStringAsync(cancellationToken);
@@ -94,18 +93,11 @@ public class PaystackClient(
             parsed.Message);
     }
 
-    private void EnsureConfigured()
+    private void EnsureSecretKeyConfigured()
     {
-        var secretKey = options.Value.SecretKey;
-        if (string.IsNullOrWhiteSpace(secretKey))
+        if (string.IsNullOrWhiteSpace(options.Value.SecretKey))
         {
             throw new InvalidOperationException("Paystack secret key is not configured.");
-        }
-
-        if (httpClient.DefaultRequestHeaders.Authorization == null)
-        {
-            httpClient.BaseAddress ??= new Uri("https://api.paystack.co/");
-            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", secretKey);
         }
     }
 

--- a/Antital.Infrastructure/Integrations/Paystack/PaystackSignatureValidator.cs
+++ b/Antital.Infrastructure/Integrations/Paystack/PaystackSignatureValidator.cs
@@ -1,0 +1,45 @@
+using System.Security.Cryptography;
+using System.Text;
+using Antital.Domain.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Antital.Infrastructure.Integrations.Paystack;
+
+public class PaystackSignatureValidator(IOptions<PaystackSettings> options)
+{
+    public bool IsValid(string payload, string? signatureHeader)
+    {
+        if (string.IsNullOrWhiteSpace(signatureHeader))
+        {
+            return false;
+        }
+
+        var secret = ResolveSigningSecret();
+        if (string.IsNullOrWhiteSpace(secret))
+        {
+            return false;
+        }
+
+        var hash = HMACSHA512.HashData(Encoding.UTF8.GetBytes(secret), Encoding.UTF8.GetBytes(payload));
+        var computed = Convert.ToHexString(hash).ToLowerInvariant();
+        var computedBytes = Encoding.UTF8.GetBytes(computed);
+        var signatureBytes = Encoding.UTF8.GetBytes(signatureHeader.Trim().ToLowerInvariant());
+
+        if (computedBytes.Length != signatureBytes.Length)
+        {
+            return false;
+        }
+
+        return CryptographicOperations.FixedTimeEquals(computedBytes, signatureBytes);
+    }
+
+    private string ResolveSigningSecret()
+    {
+        var settings = options.Value;
+        // Paystack does not expose a separate webhook secret in the dashboard;
+        // HMAC signatures use the secret key when WebhookSecret is empty.
+        return !string.IsNullOrWhiteSpace(settings.WebhookSecret)
+            ? settings.WebhookSecret
+            : settings.SecretKey;
+    }
+}

--- a/Antital.Infrastructure/Migrations/20260629003937_AddInvestmentCheckout.Designer.cs
+++ b/Antital.Infrastructure/Migrations/20260629003937_AddInvestmentCheckout.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Antital.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Antital.Infrastructure.Migrations
 {
     [DbContext(typeof(AntitalDBContext))]
-    partial class AntitalDBContextModelSnapshot : ModelSnapshot
+    [Migration("20260629003937_AddInvestmentCheckout")]
+    partial class AddInvestmentCheckout
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Antital.Infrastructure/Migrations/20260629003937_AddInvestmentCheckout.cs
+++ b/Antital.Infrastructure/Migrations/20260629003937_AddInvestmentCheckout.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Antital.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInvestmentCheckout : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InvestmentOrders",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    Units = table.Column<int>(type: "integer", nullable: false),
+                    SharePrice = table.Column<decimal>(type: "numeric", nullable: false),
+                    Subtotal = table.Column<decimal>(type: "numeric", nullable: false),
+                    PlatformFeePercent = table.Column<decimal>(type: "numeric", nullable: false),
+                    PlatformFee = table.Column<decimal>(type: "numeric", nullable: false),
+                    TotalAmount = table.Column<decimal>(type: "numeric", nullable: false),
+                    Currency = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    PaymentChannel = table.Column<int>(type: "integer", nullable: true),
+                    PaystackReference = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    PaidAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    InvestorHoldingId = table.Column<int>(type: "integer", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InvestmentOrders", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_InvestmentOrders_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_InvestmentOrders_InvestorHoldings_InvestorHoldingId",
+                        column: x => x.InvestorHoldingId,
+                        principalTable: "InvestorHoldings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_InvestmentOrders_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "PaymentTransactions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OrderId = table.Column<int>(type: "integer", nullable: false),
+                    Provider = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Reference = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Channel = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    RawPayloadJson = table.Column<string>(type: "text", nullable: true),
+                    ProcessedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PaymentTransactions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PaymentTransactions_InvestmentOrders_OrderId",
+                        column: x => x.OrderId,
+                        principalTable: "InvestmentOrders",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvestmentOrders_InvestorHoldingId",
+                table: "InvestmentOrders",
+                column: "InvestorHoldingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvestmentOrders_OfferingId",
+                table: "InvestmentOrders",
+                column: "OfferingId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvestmentOrders_PaystackReference",
+                table: "InvestmentOrders",
+                column: "PaystackReference",
+                unique: true,
+                filter: "\"PaystackReference\" IS NOT NULL AND \"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvestmentOrders_UserId_OfferingId_Status",
+                table: "InvestmentOrders",
+                columns: new[] { "UserId", "OfferingId", "Status" },
+                filter: "\"Status\" = 0 AND \"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaymentTransactions_OrderId",
+                table: "PaymentTransactions",
+                column: "OrderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaymentTransactions_Reference",
+                table: "PaymentTransactions",
+                column: "Reference",
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PaymentTransactions");
+
+            migrationBuilder.DropTable(
+                name: "InvestmentOrders");
+        }
+    }
+}

--- a/Antital.Infrastructure/Repositories/InvestmentOrderRepository.cs
+++ b/Antital.Infrastructure/Repositories/InvestmentOrderRepository.cs
@@ -1,0 +1,99 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Antital.Infrastructure.Repositories;
+
+public class InvestmentOrderRepository(AntitalDBContext context) : IInvestmentOrderRepository
+{
+    public Task<InvestmentOrder?> GetByIdAsync(int orderId, CancellationToken cancellationToken = default) =>
+        context.InvestmentOrders
+            .Include(o => o.Offering)
+            .ThenInclude(offering => offering.Funding)
+            .FirstOrDefaultAsync(o => o.Id == orderId && !o.IsDeleted, cancellationToken);
+
+    public Task<InvestmentOrder?> GetByIdForUserAsync(int orderId, int userId, CancellationToken cancellationToken = default) =>
+        context.InvestmentOrders
+            .Include(o => o.Offering)
+            .ThenInclude(offering => offering.Funding)
+            .FirstOrDefaultAsync(o => o.Id == orderId && o.UserId == userId && !o.IsDeleted, cancellationToken);
+
+    public Task<InvestmentOrder?> GetByPaystackReferenceAsync(string reference, CancellationToken cancellationToken = default) =>
+        context.InvestmentOrders
+            .Include(o => o.Offering)
+            .ThenInclude(offering => offering.Funding)
+            .FirstOrDefaultAsync(o => o.PaystackReference == reference && !o.IsDeleted, cancellationToken);
+
+    public Task<InvestmentOrder?> GetPendingByUserAndOfferingAsync(
+        int userId,
+        int offeringId,
+        CancellationToken cancellationToken = default) =>
+        context.InvestmentOrders
+            .FirstOrDefaultAsync(
+                o => o.UserId == userId
+                     && o.OfferingId == offeringId
+                     && o.Status == InvestmentOrderStatus.PendingPayment
+                     && !o.IsDeleted,
+                cancellationToken);
+
+    public async Task AddAsync(InvestmentOrder order, CancellationToken cancellationToken = default)
+    {
+        await context.InvestmentOrders.AddAsync(order, cancellationToken);
+    }
+
+    public async Task AddPaymentTransactionAsync(PaymentTransaction transaction, CancellationToken cancellationToken = default)
+    {
+        await context.PaymentTransactions.AddAsync(transaction, cancellationToken);
+    }
+
+    public Task<PaymentTransaction?> GetPaymentTransactionByReferenceAsync(
+        string reference,
+        CancellationToken cancellationToken = default) =>
+        context.PaymentTransactions
+            .FirstOrDefaultAsync(t => t.Reference == reference && !t.IsDeleted, cancellationToken);
+
+    public Task UpdatePaymentTransactionAsync(PaymentTransaction transaction, CancellationToken cancellationToken = default)
+    {
+        context.PaymentTransactions.Update(transaction);
+        return Task.CompletedTask;
+    }
+
+    public Task<InvestorHolding?> GetHoldingByUserAndOfferingAsync(
+        int userId,
+        int offeringId,
+        CancellationToken cancellationToken = default) =>
+        context.InvestorHoldings
+            .FirstOrDefaultAsync(
+                h => h.UserId == userId && h.OfferingId == offeringId && !h.IsDeleted,
+                cancellationToken);
+
+    public async Task AddInvestorHoldingAsync(InvestorHolding holding, CancellationToken cancellationToken = default)
+    {
+        await context.InvestorHoldings.AddAsync(holding, cancellationToken);
+    }
+
+    public Task UpdateInvestorHoldingAsync(InvestorHolding holding, CancellationToken cancellationToken = default)
+    {
+        context.InvestorHoldings.Update(holding);
+        return Task.CompletedTask;
+    }
+
+    public Task<OfferingFunding?> GetOfferingFundingForUpdateAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default) =>
+        context.OfferingFundings
+            .FirstOrDefaultAsync(f => f.OfferingId == offeringId && !f.IsDeleted, cancellationToken);
+
+    public Task UpdateOfferingFundingAsync(OfferingFunding funding, CancellationToken cancellationToken = default)
+    {
+        context.OfferingFundings.Update(funding);
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateAsync(InvestmentOrder order, CancellationToken cancellationToken = default)
+    {
+        context.InvestmentOrders.Update(order);
+        return Task.CompletedTask;
+    }
+}

--- a/Antital.Test/Application/Features/Investments/ConfirmInvestmentOrderServiceTests.cs
+++ b/Antital.Test/Application/Features/Investments/ConfirmInvestmentOrderServiceTests.cs
@@ -1,0 +1,125 @@
+using Antital.Application.Features.Investments.ConfirmInvestmentOrder;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Infrastructure.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Antital.Test.Application.Features.Investments;
+
+public class ConfirmInvestmentOrderServiceTests : IDisposable
+{
+    private readonly AntitalDBContext _context;
+    private readonly ConfirmInvestmentOrderService _service;
+
+    public ConfirmInvestmentOrderServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<AntitalDBContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new AntitalDBContext(options);
+        _service = new ConfirmInvestmentOrderService(new InvestmentOrderRepository(_context));
+    }
+
+    [Fact]
+    public async Task TryFulfillAsync_CreatesHoldingAndUpdatesFunding()
+    {
+        var order = await SeedPaidOrderAsync();
+
+        var fulfilled = await _service.TryFulfillAsync(order, "Test");
+        await _context.SaveChangesAsync();
+
+        fulfilled.Should().BeTrue();
+        order.InvestorHoldingId.Should().NotBeNull();
+
+        var holding = await _context.InvestorHoldings.SingleAsync();
+        holding.InvestedAmount.Should().Be(1000m);
+        holding.UnitHolding.Should().Be(10);
+        holding.CurrentValue.Should().Be(1000m);
+
+        var funding = await _context.OfferingFundings.SingleAsync();
+        funding.RaisedAmount.Should().Be(101_000m);
+        funding.InvestorCount.Should().Be(26);
+    }
+
+    [Fact]
+    public async Task TryFulfillAsync_IsIdempotentWhenHoldingAlreadyLinked()
+    {
+        var order = await SeedPaidOrderAsync();
+        await _service.TryFulfillAsync(order, "Test");
+        await _context.SaveChangesAsync();
+
+        var fulfilledAgain = await _service.TryFulfillAsync(order, "Test");
+        await _context.SaveChangesAsync();
+
+        fulfilledAgain.Should().BeTrue();
+        (await _context.InvestorHoldings.CountAsync()).Should().Be(1);
+        (await _context.OfferingFundings.SingleAsync()).RaisedAmount.Should().Be(101_000m);
+    }
+
+    private async Task<InvestmentOrder> SeedPaidOrderAsync()
+    {
+        var user = new User
+        {
+            Email = "fulfill@test.com",
+            PasswordHash = "hash",
+            UserType = UserTypeEnum.IndividualInvestor,
+            IsEmailVerified = true,
+            HasAgreedToTerms = true,
+        };
+        user.Created("Test");
+        _context.Users.Add(user);
+
+        var offering = new InvestmentOffering
+        {
+            Slug = "fulfill-co",
+            Name = "Fulfill Co",
+            Category = "Tech",
+            Tagline = "Tagline",
+            CoverImageUrl = "/img.jpg",
+            RiskLevel = OfferingRiskLevel.Low,
+            Status = OfferingStatus.Published,
+            Funding = new OfferingFunding
+            {
+                RaisedAmount = 100_000m,
+                FundingGoal = 500_000m,
+                InvestorCount = 25,
+                SharePrice = 100m,
+                MinInvestment = 1000m,
+                MaxInvestment = 50_000m,
+            },
+        };
+        offering.Created("Test");
+        offering.Funding.Created("Test");
+        _context.InvestmentOfferings.Add(offering);
+        await _context.SaveChangesAsync();
+
+        var order = new InvestmentOrder
+        {
+            UserId = user.Id,
+            OfferingId = offering.Id,
+            Units = 10,
+            SharePrice = 100m,
+            Subtotal = 1000m,
+            PlatformFeePercent = 2.5m,
+            PlatformFee = 25m,
+            TotalAmount = 1025m,
+            Currency = "NGN",
+            Status = InvestmentOrderStatus.Paid,
+            PaystackReference = "ANT-ORD-1-abc",
+            PaidAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(30),
+        };
+        order.Created("Test");
+        _context.InvestmentOrders.Add(order);
+        await _context.SaveChangesAsync();
+        return order;
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+}

--- a/Antital.Test/Application/Features/Investments/InvestmentPaymentConfirmationServiceTests.cs
+++ b/Antital.Test/Application/Features/Investments/InvestmentPaymentConfirmationServiceTests.cs
@@ -1,0 +1,154 @@
+using Antital.Application.Features.Investments.ConfirmInvestmentOrder;
+using Antital.Application.Features.Investments.ProcessPaystackWebhook;
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Infrastructure.Repositories;
+using BuildingBlocks.Domain.Interfaces;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Antital.Test.Application.Features.Investments;
+
+public class InvestmentPaymentConfirmationServiceTests : IDisposable
+{
+    private readonly AntitalDBContext _context;
+    private readonly InvestmentPaymentConfirmationService _service;
+
+    public InvestmentPaymentConfirmationServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<AntitalDBContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new AntitalDBContext(options);
+
+        var unitOfWork = new Mock<IAntitalUnitOfWork>();
+        unitOfWork
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Returns(async (CancellationToken ct) => await _context.SaveChangesAsync(ct) > 0);
+
+        var orderRepository = new InvestmentOrderRepository(_context);
+        _service = new InvestmentPaymentConfirmationService(
+            orderRepository,
+            new ConfirmInvestmentOrderService(orderRepository),
+            unitOfWork.Object,
+            new TestCurrentUser());
+    }
+
+    [Fact]
+    public async Task TryConfirmSuccessfulChargeAsync_MarksOrderPaidAndStoresTransaction()
+    {
+        await SeedPendingOrderAsync(reference: "ANT-ORD-1-abc", totalAmount: 1025m);
+
+        var handled = await _service.TryConfirmSuccessfulChargeAsync(
+            "ANT-ORD-1-abc",
+            102_500,
+            "card",
+            """{"event":"charge.success"}""");
+
+        handled.Should().BeTrue();
+        var updated = await _context.InvestmentOrders.SingleAsync();
+        updated.Status.Should().Be(InvestmentOrderStatus.Paid);
+        updated.PaidAt.Should().NotBeNull();
+        updated.InvestorHoldingId.Should().NotBeNull();
+
+        var transaction = await _context.PaymentTransactions.SingleAsync();
+        transaction.Status.Should().Be(PaymentTransactionStatus.Success);
+        transaction.Reference.Should().Be("ANT-ORD-1-abc");
+
+        var funding = await _context.OfferingFundings.SingleAsync();
+        funding.RaisedAmount.Should().Be(101_000m);
+    }
+
+    [Fact]
+    public async Task TryConfirmSuccessfulChargeAsync_IsIdempotentWhenAlreadyPaid()
+    {
+        await SeedPendingOrderAsync(reference: "ANT-ORD-2-abc", totalAmount: 1025m);
+        await _service.TryConfirmSuccessfulChargeAsync(
+            "ANT-ORD-2-abc",
+            102_500,
+            "card",
+            """{"event":"charge.success"}""");
+
+        var handled = await _service.TryConfirmSuccessfulChargeAsync(
+            "ANT-ORD-2-abc",
+            102_500,
+            "card",
+            """{"event":"charge.success"}""");
+
+        handled.Should().BeTrue();
+        (await _context.PaymentTransactions.CountAsync()).Should().Be(1);
+        (await _context.InvestorHoldings.CountAsync()).Should().Be(1);
+    }
+
+    private async Task SeedPendingOrderAsync(string reference, decimal totalAmount)
+    {
+        var user = new User
+        {
+            Email = "pay@test.com",
+            PasswordHash = "hash",
+            UserType = UserTypeEnum.IndividualInvestor,
+            IsEmailVerified = true,
+            HasAgreedToTerms = true,
+        };
+        user.Created("Test");
+        _context.Users.Add(user);
+
+        var offering = new InvestmentOffering
+        {
+            Slug = "pay-co",
+            Name = "Pay Co",
+            Category = "Tech",
+            Tagline = "Tagline",
+            CoverImageUrl = "/img.jpg",
+            RiskLevel = OfferingRiskLevel.Low,
+            Status = OfferingStatus.Published,
+            Funding = new OfferingFunding
+            {
+                RaisedAmount = 100_000m,
+                FundingGoal = 500_000m,
+                InvestorCount = 25,
+                SharePrice = 100m,
+                MinInvestment = 1000m,
+                MaxInvestment = 50_000m,
+            },
+        };
+        offering.Created("Test");
+        offering.Funding.Created("Test");
+        _context.InvestmentOfferings.Add(offering);
+        await _context.SaveChangesAsync();
+
+        var order = new InvestmentOrder
+        {
+            UserId = user.Id,
+            OfferingId = offering.Id,
+            Units = 10,
+            SharePrice = 100m,
+            Subtotal = 1000m,
+            PlatformFeePercent = 2.5m,
+            PlatformFee = 25m,
+            TotalAmount = totalAmount,
+            Currency = "NGN",
+            Status = InvestmentOrderStatus.PendingPayment,
+            PaystackReference = reference,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(30),
+        };
+        order.Created("Test");
+        _context.InvestmentOrders.Add(order);
+        await _context.SaveChangesAsync();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    private sealed class TestCurrentUser : ICurrentUser
+    {
+        public string UserName => "Test";
+        public string IPAddress => "127.0.0.1";
+    }
+}

--- a/Antital.Test/Application/Features/Investments/ProcessPaystackWebhookCommandHandlerTests.cs
+++ b/Antital.Test/Application/Features/Investments/ProcessPaystackWebhookCommandHandlerTests.cs
@@ -1,0 +1,37 @@
+using Antital.Application.Features.Investments.ProcessPaystackWebhook;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Antital.Test.Application.Features.Investments;
+
+public class ProcessPaystackWebhookCommandHandlerTests
+{
+    private readonly Mock<IInvestmentPaymentConfirmationService> _paymentConfirmationService = new();
+
+    [Fact]
+    public async Task Handle_MissingEvent_ReturnsIgnoredWithoutCallingPaymentService()
+    {
+        var handler = new ProcessPaystackWebhookCommandHandler(_paymentConfirmationService.Object);
+        const string payload = """{"data":{"reference":"ANT-ORD-1-abc","amount":102500}}""";
+
+        var result = await handler.Handle(new ProcessPaystackWebhookCommand(payload), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+        _paymentConfirmationService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Handle_MissingData_ReturnsIgnoredWithoutCallingPaymentService()
+    {
+        var handler = new ProcessPaystackWebhookCommandHandler(_paymentConfirmationService.Object);
+        const string payload = """{"event":"charge.success"}""";
+
+        var result = await handler.Handle(new ProcessPaystackWebhookCommand(payload), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeFalse();
+        _paymentConfirmationService.VerifyNoOtherCalls();
+    }
+}

--- a/Antital.Test/Fakes/FakePaystackClient.cs
+++ b/Antital.Test/Fakes/FakePaystackClient.cs
@@ -1,0 +1,31 @@
+using Antital.Domain.Integrations.Paystack;
+using Antital.Domain.Interfaces;
+
+namespace Antital.Test.Fakes;
+
+public class FakePaystackClient : IPaystackClient
+{
+    public Func<PaystackInitializeRequest, PaystackInitializeResult>? InitializeHandler { get; set; }
+
+    public Task<PaystackInitializeResult> InitializeTransactionAsync(
+        PaystackInitializeRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (InitializeHandler != null)
+        {
+            return Task.FromResult(InitializeHandler(request));
+        }
+
+        return Task.FromResult(new PaystackInitializeResult(
+            true,
+            "https://checkout.paystack.com/test-session",
+            "access-code-test",
+            request.Reference,
+            "Initialized"));
+    }
+
+    public Task<PaystackVerifyResult> VerifyTransactionAsync(
+        string reference,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(new PaystackVerifyResult(true, "success", "card", 0, "Verified"));
+}

--- a/Antital.Test/Helpers/PaystackTestHelper.cs
+++ b/Antital.Test/Helpers/PaystackTestHelper.cs
@@ -1,0 +1,28 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Antital.Test.Helpers;
+
+public static class PaystackTestHelper
+{
+    public const string TestSecretKey = "paystack_test_secret_for_hmac";
+
+    public static string ComputeSignature(string payload, string secret = TestSecretKey)
+    {
+        var hash = HMACSHA512.HashData(Encoding.UTF8.GetBytes(secret), Encoding.UTF8.GetBytes(payload));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    public static string BuildChargeSuccessPayload(string reference, int amountKobo, string channel = "card") =>
+        $$"""
+          {
+            "event": "charge.success",
+            "data": {
+              "reference": "{{reference}}",
+              "amount": {{amountKobo}},
+              "channel": "{{channel}}",
+              "status": "success"
+            }
+          }
+          """;
+}

--- a/Antital.Test/Infrastructure/Integrations/PaystackClientTests.cs
+++ b/Antital.Test/Infrastructure/Integrations/PaystackClientTests.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Text;
+using Antital.Domain.Configuration;
+using Antital.Domain.Integrations.Paystack;
+using Antital.Infrastructure.Integrations.Paystack;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Antital.Test.Infrastructure.Integrations;
+
+public class PaystackClientTests
+{
+    [Fact]
+    public async Task InitializeTransactionAsync_ParsesSnakeCaseResponse()
+    {
+        const string body = """
+            {
+              "status": true,
+              "message": "Authorization URL created",
+              "data": {
+                "authorization_url": "https://checkout.paystack.com/test-session",
+                "access_code": "access-code-test",
+                "reference": "ANT-ORD-1-abc"
+              }
+            }
+            """;
+
+        var handler = new StubHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            });
+
+        var client = new HttpClient(handler) { BaseAddress = new Uri("https://api.paystack.co/") };
+        var paystackClient = new PaystackClient(
+            client,
+            Options.Create(new PaystackSettings { SecretKey = "sk_test_key" }),
+            NullLogger<PaystackClient>.Instance);
+
+        var result = await paystackClient.InitializeTransactionAsync(
+            new PaystackInitializeRequest("user@example.com", 51_250, "ANT-ORD-1-abc", "http://localhost/callback", ["card"]));
+
+        result.Success.Should().BeTrue();
+        result.AuthorizationUrl.Should().Be("https://checkout.paystack.com/test-session");
+        result.AccessCode.Should().Be("access-code-test");
+        result.Reference.Should().Be("ANT-ORD-1-abc");
+        result.Message.Should().Be("Authorization URL created");
+    }
+
+    private sealed class StubHttpMessageHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(response);
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/InvestmentOrdersControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestmentOrdersControllerTests.cs
@@ -1,0 +1,257 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using Antital.Application.DTOs.Investments;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Test.Integration;
+using BuildingBlocks.Application.Features;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Antital.Test.Integration.API.Controllers;
+
+[Collection("IntegrationTests")]
+public class InvestmentOrdersControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>, IDisposable
+{
+    private readonly CustomWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+    private readonly IServiceScope _scope;
+    private readonly AntitalDBContext _context;
+    private readonly IConfiguration _config;
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    public InvestmentOrdersControllerTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+        _scope = _factory.Services.CreateScope();
+        _context = _scope.ServiceProvider.GetRequiredService<AntitalDBContext>();
+        _config = _scope.ServiceProvider.GetRequiredService<IConfiguration>();
+        CleanupDatabase();
+    }
+
+    [Fact]
+    public async Task CreateOrder_WithoutAuth_Returns401()
+    {
+        var response = await _client.PostAsJsonAsync("/api/investments/1/orders", new CreateInvestmentOrderRequest(10));
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task CreateOrder_OnboardingIncomplete_Returns403()
+    {
+        var user = SeedUser("no-onboarding@example.com");
+        await _context.SaveChangesAsync();
+        var offering = await SeedOfferingAsync();
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+
+        var response = await authClient.PostAsJsonAsync(
+            $"/api/investments/{offering.Id}/orders",
+            new CreateInvestmentOrderRequest(10));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task CreateOrder_ValidRequest_ReturnsOrderBreakdown()
+    {
+        var user = SeedUser("investor@example.com");
+        await _context.SaveChangesAsync();
+        SeedSubmittedOnboarding(user.Id);
+        var offering = await SeedOfferingAsync(sharePrice: 100m, minInvestment: 1000m, maxInvestment: 50_000m);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+
+        var response = await authClient.PostAsJsonAsync(
+            $"/api/investments/{offering.Id}/orders",
+            new CreateInvestmentOrderRequest(10));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<CreateInvestmentOrderResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.OfferingId.Should().Be(offering.Id);
+        result.Value.Units.Should().Be(10);
+        result.Value.SharePrice.Should().Be(100m);
+        result.Value.Subtotal.Should().Be(1000m);
+        result.Value.PlatformFeePercent.Should().Be(2.5m);
+        result.Value.PlatformFee.Should().Be(25m);
+        result.Value.TotalAmount.Should().Be(1025m);
+        result.Value.Status.Should().Be(nameof(InvestmentOrderStatus.PendingPayment));
+        result.Value.MinInvestment.Should().Be(1000m);
+        result.Value.ExpiresAt.Should().BeAfter(DateTime.UtcNow);
+    }
+
+    [Fact]
+    public async Task CreateOrder_BelowMinimumInvestment_Returns400()
+    {
+        var user = SeedUser("min-check@example.com");
+        await _context.SaveChangesAsync();
+        SeedSubmittedOnboarding(user.Id);
+        var offering = await SeedOfferingAsync(sharePrice: 100m, minInvestment: 1000m, maxInvestment: 50_000m);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+
+        var response = await authClient.PostAsJsonAsync(
+            $"/api/investments/{offering.Id}/orders",
+            new CreateInvestmentOrderRequest(5));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task CreateOrder_UnknownOffering_Returns404()
+    {
+        var user = SeedUser("unknown-offering@example.com");
+        await _context.SaveChangesAsync();
+        SeedSubmittedOnboarding(user.Id);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+
+        var response = await authClient.PostAsJsonAsync(
+            "/api/investments/99999/orders",
+            new CreateInvestmentOrderRequest(10));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private User SeedUser(string email)
+    {
+        var user = new User
+        {
+            Email = email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
+            UserType = UserTypeEnum.IndividualInvestor,
+            IsEmailVerified = true,
+            FirstName = "Jane",
+            LastName = "Investor",
+            PhoneNumber = "+2348012345678",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            Nationality = "Nigerian",
+            CountryOfResidence = "Nigeria",
+            StateOfResidence = "Lagos",
+            ResidentialAddress = "123 Main Street",
+            HasAgreedToTerms = true,
+        };
+        _context.Users.Add(user);
+        return user;
+    }
+
+    private void SeedSubmittedOnboarding(int userId)
+    {
+        var onboarding = new UserOnboarding
+        {
+            UserId = userId,
+            FlowType = OnboardingFlowType.IndividualInvestor,
+            CurrentStep = OnboardingStep.Kyc,
+            Status = OnboardingStatus.Submitted,
+            SubmittedAt = DateTime.UtcNow,
+        };
+        onboarding.Created("TestUser");
+        _context.UserOnboardings.Add(onboarding);
+    }
+
+    private async Task<InvestmentOffering> SeedOfferingAsync(
+        decimal sharePrice = 100m,
+        decimal minInvestment = 1000m,
+        decimal maxInvestment = 50_000m)
+    {
+        var offering = new InvestmentOffering
+        {
+            Slug = "checkout-co",
+            Name = "Checkout Co",
+            Category = "Tech",
+            Tagline = "Tagline",
+            CoverImageUrl = "/img.jpg",
+            RiskLevel = OfferingRiskLevel.Low,
+            Status = OfferingStatus.Published,
+            PublishedAt = DateTime.UtcNow,
+            Funding = new OfferingFunding
+            {
+                RaisedAmount = 100_000m,
+                FundingGoal = 500_000m,
+                InvestorCount = 25,
+                SharePrice = sharePrice,
+                MinInvestment = minInvestment,
+                MaxInvestment = maxInvestment,
+            },
+            DealTerms = new DealTerms
+            {
+                TotalSharesOffered = 10_000,
+                PricePerShare = sharePrice,
+                MinimumInvestment = minInvestment,
+                MaximumInvestment = maxInvestment,
+                MinimumThreshold = 250_000m,
+                FundingGoal = 500_000m,
+                Deadline = DateTime.UtcNow.AddDays(30),
+            },
+        };
+        offering.Created("TestUser");
+        offering.Funding.Created("TestUser");
+        offering.DealTerms.Created("TestUser");
+        _context.InvestmentOfferings.Add(offering);
+        await _context.SaveChangesAsync();
+        return offering;
+    }
+
+    private HttpClient CreateAuthorizedClient(int userId, string email)
+    {
+        var client = _factory.CreateClient();
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_config["Jwt:Key"]!);
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _config["Jwt:Issuer"],
+            Audience = _config["Jwt:Audience"],
+            Expires = DateTime.UtcNow.AddHours(1),
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim("UserId", userId.ToString()),
+                new Claim(ClaimTypes.Email, email),
+            }),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256),
+        };
+
+        var token = tokenHandler.CreateToken(descriptor);
+        var jwt = tokenHandler.WriteToken(token);
+
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+        return client;
+    }
+
+    private void CleanupDatabase()
+    {
+        _context.PaymentTransactions.RemoveRange(_context.PaymentTransactions);
+        _context.InvestmentOrders.RemoveRange(_context.InvestmentOrders);
+        _context.InvestorHoldings.RemoveRange(_context.InvestorHoldings);
+        _context.UserOnboardings.RemoveRange(_context.UserOnboardings);
+        _context.InvestmentOfferings.RemoveRange(_context.InvestmentOfferings.IgnoreQueryFilters());
+        _context.Users.RemoveRange(_context.Users);
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        CleanupDatabase();
+        _scope.Dispose();
+        _client.Dispose();
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/InvestmentPaymentControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestmentPaymentControllerTests.cs
@@ -1,0 +1,430 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using Antital.Application.DTOs.Investments;
+using Antital.Application.DTOs.Investors;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Test.Helpers;
+using Antital.Test.Integration;
+using BuildingBlocks.Application.Features;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Antital.Test.Integration.API.Controllers;
+
+[Collection("IntegrationTests")]
+public class InvestmentPaymentControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>, IDisposable
+{
+    private readonly CustomWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+    private readonly IServiceScope _scope;
+    private readonly AntitalDBContext _context;
+    private readonly IConfiguration _config;
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+    };
+
+    public InvestmentPaymentControllerTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+        _scope = _factory.Services.CreateScope();
+        _context = _scope.ServiceProvider.GetRequiredService<AntitalDBContext>();
+        _config = _scope.ServiceProvider.GetRequiredService<IConfiguration>();
+        CleanupDatabase();
+    }
+
+    [Fact]
+    public async Task InitializePayment_ValidOrder_ReturnsPaystackSession()
+    {
+        var (user, offering) = await SeedEligibleInvestorWithOfferingAsync();
+        var orderId = await CreateOrderAsync(user, offering.Id);
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PostAsJsonAsync(
+            $"/api/investments/orders/{orderId}/pay",
+            new InitializeInvestmentPaymentRequest("card"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<InitializeInvestmentPaymentResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.AuthorizationUrl.Should().StartWith("https://checkout.paystack.com/");
+        result.Value.AccessCode.Should().NotBeNullOrWhiteSpace();
+        result.Value.Reference.Should().StartWith($"ANT-ORD-{orderId}-");
+        result.Value.PublicKey.Should().Be(_config["Paystack:PublicKey"]);
+
+        var order = await _context.InvestmentOrders.SingleAsync(o => o.Id == orderId);
+        order.PaystackReference.Should().Be(result.Value.Reference);
+        order.PaymentChannel.Should().Be(PaymentChannel.Card);
+    }
+
+    [Fact]
+    public async Task InitializePayment_InvalidChannel_Returns400()
+    {
+        var (user, offering) = await SeedEligibleInvestorWithOfferingAsync();
+        var orderId = await CreateOrderAsync(user, offering.Id);
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PostAsJsonAsync(
+            $"/api/investments/orders/{orderId}/pay",
+            new InitializeInvestmentPaymentRequest("bitcoin"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task PaystackWebhook_ValidSignature_MarksOrderPaid()
+    {
+        var (user, offering) = await SeedEligibleInvestorWithOfferingAsync();
+        var orderId = await CreateOrderAsync(user, offering.Id);
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var payResponse = await authClient.PostAsJsonAsync(
+            $"/api/investments/orders/{orderId}/pay",
+            new InitializeInvestmentPaymentRequest("card"));
+        payResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var payResult = await payResponse.Content.ReadFromJsonAsync<Result<InitializeInvestmentPaymentResponse>>(JsonOptions);
+        var reference = payResult!.Value!.Reference;
+        var payload = PaystackTestHelper.BuildChargeSuccessPayload(reference, 102_500);
+        var signature = PaystackTestHelper.ComputeSignature(payload, PaystackTestHelper.TestSecretKey);
+
+        using var webhookRequest = new HttpRequestMessage(HttpMethod.Post, "/api/payments/paystack/webhook")
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+        };
+        webhookRequest.Headers.Add("x-paystack-signature", signature);
+
+        var webhookResponse = await _client.SendAsync(webhookRequest);
+        webhookResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        _context.ChangeTracker.Clear();
+
+        var order = await _context.InvestmentOrders.AsNoTracking().SingleAsync(o => o.Id == orderId);
+        order.Status.Should().Be(InvestmentOrderStatus.Paid);
+        order.PaidAt.Should().NotBeNull();
+        order.InvestorHoldingId.Should().NotBeNull();
+
+        var transaction = await _context.PaymentTransactions.AsNoTracking().SingleAsync();
+        transaction.Reference.Should().Be(reference);
+        transaction.Status.Should().Be(PaymentTransactionStatus.Success);
+
+        var holding = await _context.InvestorHoldings.AsNoTracking().SingleAsync();
+        holding.UserId.Should().Be(user.Id);
+        holding.OfferingId.Should().Be(offering.Id);
+        holding.InvestedAmount.Should().Be(1000m);
+        holding.UnitHolding.Should().Be(10);
+
+        var funding = await _context.OfferingFundings.AsNoTracking().SingleAsync(f => f.OfferingId == offering.Id);
+        funding.RaisedAmount.Should().Be(101_000m);
+        funding.InvestorCount.Should().Be(26);
+    }
+
+    [Fact]
+    public async Task GetOrder_AfterSuccessfulWebhook_ReturnsPaidOrderWithHolding()
+    {
+        var (user, offering) = await SeedEligibleInvestorWithOfferingAsync();
+        var orderId = await CreateOrderAsync(user, offering.Id);
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var payResponse = await authClient.PostAsJsonAsync(
+            $"/api/investments/orders/{orderId}/pay",
+            new InitializeInvestmentPaymentRequest("card"));
+        var payResult = await payResponse.Content.ReadFromJsonAsync<Result<InitializeInvestmentPaymentResponse>>(JsonOptions);
+        var reference = payResult!.Value!.Reference;
+
+        var payload = PaystackTestHelper.BuildChargeSuccessPayload(reference, 102_500);
+        var signature = PaystackTestHelper.ComputeSignature(payload, PaystackTestHelper.TestSecretKey);
+        using var webhookRequest = new HttpRequestMessage(HttpMethod.Post, "/api/payments/paystack/webhook")
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+        };
+        webhookRequest.Headers.Add("x-paystack-signature", signature);
+        (await _client.SendAsync(webhookRequest)).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var response = await authClient.GetAsync($"/api/investments/orders/{orderId}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<GetInvestmentOrderResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.OrderId.Should().Be(orderId);
+        result.Value.Status.Should().Be(nameof(InvestmentOrderStatus.Paid));
+        result.Value.InvestorHoldingId.Should().NotBeNull();
+        result.Value.TotalAmount.Should().Be(1025m);
+    }
+
+    [Fact]
+    public async Task PaystackWebhook_AfterPayment_AddsHoldingToDashboard()
+    {
+        var (user, offering) = await SeedEligibleInvestorWithOfferingAsync();
+        var orderId = await CreateOrderAsync(user, offering.Id);
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var payResponse = await authClient.PostAsJsonAsync(
+            $"/api/investments/orders/{orderId}/pay",
+            new InitializeInvestmentPaymentRequest("card"));
+        var payResult = await payResponse.Content.ReadFromJsonAsync<Result<InitializeInvestmentPaymentResponse>>(JsonOptions);
+        var reference = payResult!.Value!.Reference;
+
+        var payload = PaystackTestHelper.BuildChargeSuccessPayload(reference, 102_500);
+        var signature = PaystackTestHelper.ComputeSignature(payload, PaystackTestHelper.TestSecretKey);
+        using var webhookRequest = new HttpRequestMessage(HttpMethod.Post, "/api/payments/paystack/webhook")
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+        };
+        webhookRequest.Headers.Add("x-paystack-signature", signature);
+        (await _client.SendAsync(webhookRequest)).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var dashboardResponse = await authClient.GetAsync("/api/investors/me/dashboard?period=this-month");
+        dashboardResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var dashboard = await dashboardResponse.Content.ReadFromJsonAsync<Result<InvestorDashboardResponse>>(JsonOptions);
+        dashboard!.IsSuccess.Should().BeTrue();
+        dashboard.Value!.Holdings.Should().ContainSingle(h =>
+            h.Slug == offering.Slug
+            && h.Invested == 1000m
+            && h.UnitHolding == 10
+            && h.RaisedAmount == 101_000m);
+        dashboard.Value.Summary.TotalInvested.Should().Be(1000m);
+    }
+
+    [Fact]
+    public async Task PaystackWebhook_DuplicateDelivery_IsIdempotent()
+    {
+        var (user, offering) = await SeedEligibleInvestorWithOfferingAsync();
+        var orderId = await CreateOrderAsync(user, offering.Id);
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var payResponse = await authClient.PostAsJsonAsync(
+            $"/api/investments/orders/{orderId}/pay",
+            new InitializeInvestmentPaymentRequest("card"));
+        var payResult = await payResponse.Content.ReadFromJsonAsync<Result<InitializeInvestmentPaymentResponse>>(JsonOptions);
+        var reference = payResult!.Value!.Reference;
+
+        var payload = PaystackTestHelper.BuildChargeSuccessPayload(reference, 102_500);
+        var signature = PaystackTestHelper.ComputeSignature(payload, PaystackTestHelper.TestSecretKey);
+
+        async Task<HttpResponseMessage> SendWebhookAsync()
+        {
+            using var webhookRequest = new HttpRequestMessage(HttpMethod.Post, "/api/payments/paystack/webhook")
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+            };
+            webhookRequest.Headers.Add("x-paystack-signature", signature);
+            return await _client.SendAsync(webhookRequest);
+        }
+
+        (await SendWebhookAsync()).StatusCode.Should().Be(HttpStatusCode.OK);
+        (await SendWebhookAsync()).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        _context.ChangeTracker.Clear();
+
+        (await _context.PaymentTransactions.AsNoTracking().CountAsync()).Should().Be(1);
+        (await _context.InvestorHoldings.AsNoTracking().CountAsync()).Should().Be(1);
+
+        var funding = await _context.OfferingFundings.AsNoTracking().SingleAsync(f => f.OfferingId == offering.Id);
+        funding.RaisedAmount.Should().Be(101_000m);
+        funding.InvestorCount.Should().Be(26);
+    }
+
+    [Fact]
+    public async Task GetOrder_WithoutAuth_Returns401()
+    {
+        var response = await _client.GetAsync("/api/investments/orders/1");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task InitializePayment_WithoutAuth_Returns401()
+    {
+        var response = await _client.PostAsJsonAsync(
+            "/api/investments/orders/1/pay",
+            new InitializeInvestmentPaymentRequest("card"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task PaystackWebhook_InvalidSignature_Returns400()
+    {
+        var payload = PaystackTestHelper.BuildChargeSuccessPayload("ANT-ORD-99-abc", 102_500);
+
+        using var webhookRequest = new HttpRequestMessage(HttpMethod.Post, "/api/payments/paystack/webhook")
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+        };
+        webhookRequest.Headers.Add("x-paystack-signature", "invalid-signature");
+
+        var webhookResponse = await _client.SendAsync(webhookRequest);
+        webhookResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task PaystackWebhook_MissingEvent_Returns200()
+    {
+        const string payload = """{"data":{"reference":"ANT-ORD-99-abc","amount":102500}}""";
+        var signature = PaystackTestHelper.ComputeSignature(payload, PaystackTestHelper.TestSecretKey);
+
+        using var webhookRequest = new HttpRequestMessage(HttpMethod.Post, "/api/payments/paystack/webhook")
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+        };
+        webhookRequest.Headers.Add("x-paystack-signature", signature);
+
+        var webhookResponse = await _client.SendAsync(webhookRequest);
+        webhookResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private async Task<int> CreateOrderAsync(User user, int offeringId)
+    {
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PostAsJsonAsync(
+            $"/api/investments/{offeringId}/orders",
+            new CreateInvestmentOrderRequest(10));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<CreateInvestmentOrderResponse>>(JsonOptions);
+        return result!.Value!.OrderId;
+    }
+
+    private async Task<(User User, InvestmentOffering Offering)> SeedEligibleInvestorWithOfferingAsync()
+    {
+        var user = SeedUser("payment-investor@example.com");
+        await _context.SaveChangesAsync();
+        SeedSubmittedOnboarding(user.Id);
+        var offering = await SeedOfferingAsync();
+        await _context.SaveChangesAsync();
+        return (user, offering);
+    }
+
+    private User SeedUser(string email)
+    {
+        var user = new User
+        {
+            Email = email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
+            UserType = UserTypeEnum.IndividualInvestor,
+            IsEmailVerified = true,
+            FirstName = "Jane",
+            LastName = "Investor",
+            PhoneNumber = "+2348012345678",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            Nationality = "Nigerian",
+            CountryOfResidence = "Nigeria",
+            StateOfResidence = "Lagos",
+            ResidentialAddress = "123 Main Street",
+            HasAgreedToTerms = true,
+        };
+        _context.Users.Add(user);
+        return user;
+    }
+
+    private void SeedSubmittedOnboarding(int userId)
+    {
+        var onboarding = new UserOnboarding
+        {
+            UserId = userId,
+            FlowType = OnboardingFlowType.IndividualInvestor,
+            CurrentStep = OnboardingStep.Kyc,
+            Status = OnboardingStatus.Submitted,
+            SubmittedAt = DateTime.UtcNow,
+        };
+        onboarding.Created("TestUser");
+        _context.UserOnboardings.Add(onboarding);
+    }
+
+    private async Task<InvestmentOffering> SeedOfferingAsync()
+    {
+        var offering = new InvestmentOffering
+        {
+            Slug = "payment-co",
+            Name = "Payment Co",
+            Category = "Tech",
+            Tagline = "Tagline",
+            CoverImageUrl = "/img.jpg",
+            RiskLevel = OfferingRiskLevel.Low,
+            Status = OfferingStatus.Published,
+            PublishedAt = DateTime.UtcNow,
+            Funding = new OfferingFunding
+            {
+                RaisedAmount = 100_000m,
+                FundingGoal = 500_000m,
+                InvestorCount = 25,
+                SharePrice = 100m,
+                MinInvestment = 1000m,
+                MaxInvestment = 50_000m,
+            },
+            DealTerms = new DealTerms
+            {
+                TotalSharesOffered = 10_000,
+                PricePerShare = 100m,
+                MinimumInvestment = 1000m,
+                MaximumInvestment = 50_000m,
+                MinimumThreshold = 250_000m,
+                FundingGoal = 500_000m,
+                Deadline = DateTime.UtcNow.AddDays(30),
+            },
+        };
+        offering.Created("TestUser");
+        offering.Funding.Created("TestUser");
+        offering.DealTerms.Created("TestUser");
+        _context.InvestmentOfferings.Add(offering);
+        await _context.SaveChangesAsync();
+        return offering;
+    }
+
+    private HttpClient CreateAuthorizedClient(int userId, string email)
+    {
+        var client = _factory.CreateClient();
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_config["Jwt:Key"]!);
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _config["Jwt:Issuer"],
+            Audience = _config["Jwt:Audience"],
+            Expires = DateTime.UtcNow.AddHours(1),
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim("UserId", userId.ToString()),
+                new Claim(ClaimTypes.Email, email),
+            }),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256),
+        };
+
+        var token = tokenHandler.CreateToken(descriptor);
+        var jwt = tokenHandler.WriteToken(token);
+
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+        return client;
+    }
+
+    private void CleanupDatabase()
+    {
+        _context.PaymentTransactions.RemoveRange(_context.PaymentTransactions);
+        _context.InvestmentOrders.RemoveRange(_context.InvestmentOrders);
+        _context.InvestorHoldings.RemoveRange(_context.InvestorHoldings);
+        _context.UserOnboardings.RemoveRange(_context.UserOnboardings);
+        _context.InvestmentOfferings.RemoveRange(_context.InvestmentOfferings.IgnoreQueryFilters());
+        _context.Users.RemoveRange(_context.Users);
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        CleanupDatabase();
+        _scope.Dispose();
+        _client.Dispose();
+    }
+}

--- a/Antital.Test/Integration/WebApplicationFactory.cs
+++ b/Antital.Test/Integration/WebApplicationFactory.cs
@@ -4,9 +4,14 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Antital.API;
+using Antital.Domain.Interfaces;
 using Antital.Infrastructure;
+using Antital.Infrastructure.Integrations.Paystack;
+using Antital.Test.Fakes;
+using Antital.Test.Helpers;
 using BuildingBlocks.Infrastructure.Implementations;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
 
@@ -14,6 +19,8 @@ namespace Antital.Test.Integration;
 
 public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<Program> where TProgram : class
 {
+    public FakePaystackClient FakePaystackClient { get; } = new();
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         // Set environment FIRST before configuration is loaded
@@ -39,7 +46,11 @@ public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<Progr
                 { "ElasticSearch:Uri", null! }, // Null to skip Elasticsearch sink
                 { "Jwt:Key", "BehzadDaraSecurityKey@#@BehzadDaraSecurityKey" }, // JWT key for testing
                 { "Jwt:Issuer", "http://localhost:28747/" },
-                { "Jwt:Audience", "http://localhost:28747/" }
+                { "Jwt:Audience", "http://localhost:28747/" },
+                { "Paystack:SecretKey", PaystackTestHelper.TestSecretKey },
+                { "Paystack:PublicKey", "pk_test_public_key" },
+                { "Paystack:WebhookSecret", PaystackTestHelper.TestSecretKey },
+                { "Paystack:CallbackUrl", "http://localhost:3000/marketplace/invest/callback" },
             });
         });
 
@@ -79,6 +90,10 @@ public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<Progr
             });
 
             services.AddScoped<DBContext>(provider => provider.GetService<AntitalDBContext>()!);
+
+            services.RemoveAll(typeof(IPaystackClient));
+            services.RemoveAll(typeof(PaystackClient));
+            services.AddSingleton<IPaystackClient>(FakePaystackClient);
         });
         
         // Workaround: Configure Kestrel to use a real server instead of TestServer

--- a/AntitalAPI.AppHost/AppHost.cs
+++ b/AntitalAPI.AppHost/AppHost.cs
@@ -18,4 +18,9 @@ var ui = builder.AddJavaScriptApp("ui", "../../../React/antital-ui")
     .WithReference(api)
     .WaitFor(api);
 
+// Paystack redirect after payment must match the Aspire UI port (e.g. http://localhost:62388/...).
+api.WithEnvironment(
+    "Paystack__CallbackUrl",
+    ReferenceExpression.Create($"{ui.GetEndpoint("http")}/marketplace/invest/callback"));
+
 builder.Build().Run();

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ dotnet restore
 dotnet run --project AntitalAPI.AppHost
 ```
 
+The AppHost wires `NEXT_PUBLIC_API_URL` for the UI and sets `Paystack:CallbackUrl` to the Aspire UI port automatically (e.g. `http://localhost:62388/marketplace/invest/callback`).
+
+**Paystack local dev:** Paystack does not provide a separate webhook secret in the dashboard. Leave `Paystack:WebhookSecret` empty — the API validates webhook signatures using `Paystack:SecretKey`. For localhost, webhooks cannot reach your machine; after Paystack redirect the UI calls `POST /api/investments/orders/{orderId}/verify` to confirm payment via Paystack's verify API.
+
 If you want Aspire workload/templates available locally:
 ```bash
 dotnet workload install aspire


### PR DESCRIPTION
## Summary
- Adds investment order lifecycle: create order, initialize Paystack payment, poll order status, and verify payment for local/dev when webhooks cannot reach localhost.
- Implements Paystack webhook handling with signature validation, payment confirmation, and fulfillment into investor holdings and offering funding totals.
- Includes EF migration, Aspire callback URL wiring, integration/unit tests, and README notes for local Paystack setup.

## Test plan
- [x] Run `dotnet test` in `Antital.Test`
- [x] Apply migration `20260629003937_AddInvestmentCheckout` on target environment
- [x] Configure `Paystack` settings (secret/public keys, callback URL, platform fee)
- [x] Create order → initialize payment → complete Paystack test payment → verify order is Paid and holding is created
- [x] POST Paystack webhook with valid `x-paystack-signature` confirms order
- [x] Confirm onboarding-gated access returns 403 for incomplete investors


Made with [Cursor](https://cursor.com)