### PR TITLE
Add investor settings endpoints for profile, account, and password change

### DIFF
--- a/Antital.API/Controllers/AuthenticationController.cs
+++ b/Antital.API/Controllers/AuthenticationController.cs
@@ -12,6 +12,7 @@ using Antital.Application.Features.Authentication.Logout;
 using Antital.Application.Features.Authentication.ForgotPassword;
 using Antital.Application.Features.Authentication.ResetPassword;
 using Antital.Application.Features.Authentication.ResendVerificationEmail;
+using Antital.Application.Features.Authentication.ChangePassword;
 using Antital.Application.Features.Authentication.DeleteUnverifiedUser;
 using Antital.Application.Features.Authentication.RequestUnverifiedUserOtp;
 using Antital.Application.Features.Users.GetUsers;
@@ -116,6 +117,18 @@ public class AuthenticationController(IMediator mediator) : BaseController
     [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid or expired token", typeof(void))]
     [SwaggerResponse(StatusCodes.Status404NotFound, "User not found", typeof(void))]
     public async Task<IActionResult> ResetPassword(ResetPasswordCommand request, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(request, cancellationToken);
+        return ApiResult(result);
+    }
+
+    [Authorize]
+    [HttpPost("change-password")]
+    [SwaggerOperation("Change Password", "Change password for the authenticated user.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Password changed successfully", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error or incorrect current password", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    public async Task<IActionResult> ChangePassword(ChangePasswordCommand request, CancellationToken cancellationToken)
     {
         var result = await mediator.Send(request, cancellationToken);
         return ApiResult(result);

--- a/Antital.API/Controllers/InvestorsController.cs
+++ b/Antital.API/Controllers/InvestorsController.cs
@@ -1,6 +1,8 @@
 using Antital.Application.DTOs.Investors;
 using Antital.Application.Features.Investors.AddToWatchlist;
+using Antital.Application.Features.Investors.GetInvestorAccount;
 using Antital.Application.Features.Investors.GetInvestorDashboard;
+using Antital.Application.Features.Investors.GetInvestorProfile;
 using Antital.Application.Features.Investors.GetWatchlist;
 using Antital.Application.Features.Investors.GetWatchlistStatus;
 using Antital.Application.Features.Investors.GetWalletTransaction;
@@ -10,6 +12,7 @@ using Antital.Application.Features.Investors.PaymentMethods.DeletePaymentMethod;
 using Antital.Application.Features.Investors.PaymentMethods.GetPaymentMethods;
 using Antital.Application.Features.Investors.PaymentMethods.SetDefaultPaymentMethod;
 using Antital.Application.Features.Investors.RemoveFromWatchlist;
+using Antital.Application.Features.Investors.UpdateInvestorProfile;
 using BuildingBlocks.API.Controllers;
 using BuildingBlocks.Application.Features;
 using MediatR;
@@ -122,6 +125,48 @@ public class InvestorsController(IMediator mediator) : BaseController
     public async Task<IActionResult> DeletePaymentMethod(int paymentMethodId, CancellationToken cancellationToken)
     {
         var result = await mediator.Send(new DeletePaymentMethodCommand(paymentMethodId), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpGet("me/account")]
+    [SwaggerOperation("Get Investor Account", "Returns account summary for the authenticated investor settings page.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<InvestorAccountResponse>))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    public async Task<IActionResult> GetAccount(CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetInvestorAccountQuery(), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpGet("me/profile")]
+    [SwaggerOperation("Get Investor Profile", "Returns profile and location fields for the authenticated investor.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<InvestorProfileResponse>))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    public async Task<IActionResult> GetProfile(CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetInvestorProfileQuery(), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpPut("me/profile")]
+    [SwaggerOperation("Update Investor Profile", "Updates editable profile fields for the authenticated investor.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<InvestorProfileResponse>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    public async Task<IActionResult> UpdateProfile(
+        [FromBody] UpdateInvestorProfileRequest request,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(
+            new UpdateInvestorProfileCommand(
+                request.FirstName,
+                request.LastName,
+                request.PreferredName,
+                request.PhoneNumber,
+                request.ResidentialAddress,
+                request.StateOfResidence,
+                request.CountryOfResidence),
+            cancellationToken);
         return ApiResult(result);
     }
 

--- a/Antital.Application/DTOs/Investors/InvestorAccountDtos.cs
+++ b/Antital.Application/DTOs/Investors/InvestorAccountDtos.cs
@@ -1,0 +1,24 @@
+namespace Antital.Application.DTOs.Investors;
+
+public record InvestorAccountResponse(
+    string AccountType,
+    string AccountStatus,
+    string KycStatus,
+    DateTime? KycCompletedDate,
+    string InvestorClassification,
+    string VerificationStatus,
+    DateTime MemberSince,
+    string RiskRating,
+    InvestorInvestmentLimitsDto? InvestmentLimits,
+    IReadOnlyList<InvestorComplianceCheckDto> ComplianceChecks);
+
+public record InvestorInvestmentLimitsDto(
+    decimal AnnualLimit,
+    decimal UsedPercentage,
+    decimal PerProjectLimit,
+    decimal LifetimeLimit);
+
+public record InvestorComplianceCheckDto(
+    string Id,
+    string Label,
+    string Status);

--- a/Antital.Application/DTOs/Investors/InvestorProfileDtos.cs
+++ b/Antital.Application/DTOs/Investors/InvestorProfileDtos.cs
@@ -1,0 +1,27 @@
+using Antital.Domain.Enums;
+
+namespace Antital.Application.DTOs.Investors;
+
+public record InvestorProfileResponse(
+    int Id,
+    string Email,
+    string FirstName,
+    string LastName,
+    string? PreferredName,
+    string PhoneNumber,
+    string ResidentialAddress,
+    string StateOfResidence,
+    string CountryOfResidence,
+    DateTime DateOfBirth,
+    string Nationality,
+    UserTypeEnum UserType,
+    bool IsEmailVerified);
+
+public record UpdateInvestorProfileRequest(
+    string FirstName,
+    string LastName,
+    string? PreferredName,
+    string PhoneNumber,
+    string ResidentialAddress,
+    string StateOfResidence,
+    string CountryOfResidence);

--- a/Antital.Application/Features/Authentication/ChangePassword/ChangePasswordCommand.cs
+++ b/Antital.Application/Features/Authentication/ChangePassword/ChangePasswordCommand.cs
@@ -1,0 +1,9 @@
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Authentication.ChangePassword;
+
+public record ChangePasswordCommand(
+    string CurrentPassword,
+    string NewPassword,
+    string ConfirmPassword
+) : ICommandQuery;

--- a/Antital.Application/Features/Authentication/ChangePassword/ChangePasswordCommandHandler.cs
+++ b/Antital.Application/Features/Authentication/ChangePassword/ChangePasswordCommandHandler.cs
@@ -1,0 +1,45 @@
+using Antital.Application.Features.Investors;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using BuildingBlocks.Domain.Interfaces;
+
+namespace Antital.Application.Features.Authentication.ChangePassword;
+
+public class ChangePasswordCommandHandler(
+    IInvestorUserAccess investorUserAccess,
+    IUserRepository userRepository,
+    IPasswordHasher passwordHasher,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser
+) : ICommandQueryHandler<ChangePasswordCommand>
+{
+    public async Task<Result> Handle(ChangePasswordCommand request, CancellationToken cancellationToken)
+    {
+        var (_, user) = await investorUserAccess.RequireAuthenticatedUserAsync(cancellationToken);
+
+        if (!passwordHasher.VerifyPassword(request.CurrentPassword, user.PasswordHash))
+        {
+            throw new BadRequestException("Current password is incorrect.", new Dictionary<string, string[]>
+            {
+                { "CurrentPassword", new[] { "Current password is incorrect." } },
+            });
+        }
+
+        user.PasswordHash = passwordHasher.HashPassword(request.NewPassword);
+        user.RefreshTokenHash = null;
+        user.RefreshTokenExpiresAt = null;
+
+        var updatedBy = !string.IsNullOrEmpty(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrEmpty(currentUser.IPAddress) ? currentUser.IPAddress : "System");
+        user.Updated(updatedBy);
+
+        await userRepository.UpdateAsync(user, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        var result = new Result();
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Authentication/ChangePassword/ChangePasswordCommandValidator.cs
+++ b/Antital.Application/Features/Authentication/ChangePassword/ChangePasswordCommandValidator.cs
@@ -1,0 +1,43 @@
+using FluentValidation;
+
+namespace Antital.Application.Features.Authentication.ChangePassword;
+
+public class ChangePasswordCommandValidator : AbstractValidator<ChangePasswordCommand>
+{
+    public ChangePasswordCommandValidator()
+    {
+        RuleFor(x => x.CurrentPassword)
+            .NotEmpty()
+            .WithMessage("Current password is required.");
+
+        RuleFor(x => x.NewPassword)
+            .NotEmpty()
+            .MinimumLength(8)
+            .WithMessage("Password must be at least 8 characters long.")
+            .Must(BeValidPassword)
+            .WithMessage("Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character.");
+
+        RuleFor(x => x.ConfirmPassword)
+            .Equal(x => x.NewPassword)
+            .WithMessage("Passwords must match");
+
+        RuleFor(x => x)
+            .Must(x => !string.Equals(x.CurrentPassword, x.NewPassword, StringComparison.Ordinal))
+            .WithMessage("New password must be different from current password.");
+    }
+
+    private static bool BeValidPassword(string? password)
+    {
+        if (string.IsNullOrEmpty(password))
+        {
+            return false;
+        }
+
+        var hasUpper = password.Any(char.IsUpper);
+        var hasLower = password.Any(char.IsLower);
+        var hasDigit = password.Any(char.IsDigit);
+        var hasSpecial = password.Any(ch => !char.IsLetterOrDigit(ch));
+
+        return hasUpper && hasLower && hasDigit && hasSpecial;
+    }
+}

--- a/Antital.Application/Features/Investors/Account/InvestorAccountMapper.cs
+++ b/Antital.Application/Features/Investors/Account/InvestorAccountMapper.cs
@@ -1,0 +1,112 @@
+using System.ComponentModel;
+using System.Reflection;
+using Antital.Application.DTOs.Investors;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+
+namespace Antital.Application.Features.Investors.Account;
+
+internal static class InvestorAccountMapper
+{
+    private static readonly IReadOnlyList<InvestorComplianceCheckDto> DefaultComplianceChecks =
+    [
+        new("aml", "Anti-Money Laundering Check", "Passed"),
+        new("sanctions", "Sanctions Screening", "Clear"),
+        new("pep", "Politically Exposed Person", "Not Applicable"),
+    ];
+
+    public static InvestorAccountResponse ToResponse(
+        User user,
+        UserOnboarding? onboarding,
+        UserInvestmentProfile? profile,
+        UserKyc? kyc)
+    {
+        var kycCompletedDate = kyc != null && IsKycCompleted(kyc) ? DeriveKycCompletedDate(kyc) : null;
+        var kycStatus = kycCompletedDate.HasValue ? "Completed" : "Pending";
+
+        return new InvestorAccountResponse(
+            AccountType: DeriveAccountType(user, profile),
+            AccountStatus: DeriveAccountStatus(user, onboarding),
+            KycStatus: kycStatus,
+            KycCompletedDate: kycCompletedDate,
+            InvestorClassification: DeriveInvestorClassification(profile),
+            VerificationStatus: user.IsEmailVerified ? "Verified" : "Unverified",
+            MemberSince: user.CreatedAt,
+            RiskRating: "Low",
+            InvestmentLimits: null,
+            ComplianceChecks: DefaultComplianceChecks);
+    }
+
+    private static string DeriveAccountType(User user, UserInvestmentProfile? profile)
+    {
+        if (profile != null)
+        {
+            return profile.InvestorCategory == InvestorCategory.Retail
+                ? "Ordinary Investor"
+                : GetEnumDescription(profile.InvestorCategory);
+        }
+
+        return user.UserType switch
+        {
+            UserTypeEnum.CorporateInvestor => "Corporate Investor",
+            UserTypeEnum.FundRaiser => "Fundraiser",
+            _ => "Ordinary Investor",
+        };
+    }
+
+    private static string DeriveAccountStatus(User user, UserOnboarding? onboarding)
+    {
+        if (user.IsDeleted)
+        {
+            return "Suspended";
+        }
+
+        var status = onboarding?.Status ?? OnboardingStatus.Draft;
+        return status is OnboardingStatus.Draft or OnboardingStatus.UnderReview
+            ? "Pending"
+            : "Active";
+    }
+
+    private static string DeriveInvestorClassification(UserInvestmentProfile? profile)
+    {
+        if (profile == null)
+        {
+            return "Ordinary";
+        }
+
+        return profile.InvestorCategory switch
+        {
+            InvestorCategory.Retail => "Ordinary",
+            InvestorCategory.Sophisticated => "Sophisticated",
+            InvestorCategory.HighNetWorth => "HNI",
+            InvestorCategory.QualifiedInstitutionalInvestor => "QII",
+            InvestorCategory.OtherCorporateInvestor => "OCI",
+            _ => "Ordinary",
+        };
+    }
+
+    private static bool IsKycCompleted(UserKyc kyc) =>
+        kyc.GovernmentIdVerifiedAt.HasValue
+        && kyc.ProofOfAddressVerifiedAt.HasValue
+        && kyc.SelfieVerifiedAt.HasValue;
+
+    private static DateTime? DeriveKycCompletedDate(UserKyc kyc)
+    {
+        var dates = new[]
+        {
+            kyc.GovernmentIdVerifiedAt,
+            kyc.ProofOfAddressVerifiedAt,
+            kyc.SelfieVerifiedAt,
+            kyc.IncomeVerifiedAt,
+        }.Where(d => d.HasValue).Select(d => d!.Value).ToList();
+
+        return dates.Count == 0 ? null : dates.Max();
+    }
+
+    private static string GetEnumDescription(InvestorCategory category)
+    {
+        var field = category.GetType().GetField(category.ToString());
+        var attribute = field?.GetCustomAttribute<DescriptionAttribute>();
+        return attribute?.Description ?? category.ToString();
+    }
+}

--- a/Antital.Application/Features/Investors/GetInvestorAccount/GetInvestorAccountQuery.cs
+++ b/Antital.Application/Features/Investors/GetInvestorAccount/GetInvestorAccountQuery.cs
@@ -1,0 +1,33 @@
+using Antital.Application.DTOs.Investors;
+using Antital.Application.Features.Investors.Account;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investors.GetInvestorAccount;
+
+public record GetInvestorAccountQuery : ICommandQuery<InvestorAccountResponse>;
+
+public class GetInvestorAccountQueryHandler(
+    IInvestorUserAccess investorUserAccess,
+    IUserOnboardingRepository userOnboardingRepository,
+    IUserInvestmentProfileRepository userInvestmentProfileRepository,
+    IUserKycRepository userKycRepository
+) : ICommandQueryHandler<GetInvestorAccountQuery, InvestorAccountResponse>
+{
+    public async Task<Result<InvestorAccountResponse>> Handle(
+        GetInvestorAccountQuery request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, user) = await investorUserAccess.RequireAuthenticatedUserAsync(cancellationToken);
+
+        var onboarding = await userOnboardingRepository.GetByUserIdAsync(userId, cancellationToken);
+        var profile = await userInvestmentProfileRepository.GetByUserIdAsync(userId, cancellationToken);
+        var kyc = await userKycRepository.GetByUserIdAsync(userId, cancellationToken);
+
+        var response = InvestorAccountMapper.ToResponse(user, onboarding, profile, kyc);
+        var result = new Result<InvestorAccountResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investors/GetInvestorProfile/GetInvestorProfileQuery.cs
+++ b/Antital.Application/Features/Investors/GetInvestorProfile/GetInvestorProfileQuery.cs
@@ -1,0 +1,25 @@
+using Antital.Application.DTOs.Investors;
+using Antital.Application.Features.Investors.Profile;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Investors.GetInvestorProfile;
+
+public record GetInvestorProfileQuery : ICommandQuery<InvestorProfileResponse>;
+
+public class GetInvestorProfileQueryHandler(
+    IInvestorUserAccess investorUserAccess
+) : ICommandQueryHandler<GetInvestorProfileQuery, InvestorProfileResponse>
+{
+    public async Task<Result<InvestorProfileResponse>> Handle(
+        GetInvestorProfileQuery request,
+        CancellationToken cancellationToken)
+    {
+        var (_, user) = await investorUserAccess.RequireAuthenticatedUserAsync(cancellationToken);
+
+        var response = InvestorProfileMapper.ToResponse(user);
+        var result = new Result<InvestorProfileResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investors/Profile/InvestorProfileMapper.cs
+++ b/Antital.Application/Features/Investors/Profile/InvestorProfileMapper.cs
@@ -1,0 +1,34 @@
+using Antital.Application.DTOs.Investors;
+using Antital.Domain.Models;
+
+namespace Antital.Application.Features.Investors.Profile;
+
+internal static class InvestorProfileMapper
+{
+    public static InvestorProfileResponse ToResponse(User user) =>
+        new(
+            user.Id,
+            user.Email,
+            user.FirstName,
+            user.LastName,
+            user.PreferredName,
+            user.PhoneNumber,
+            user.ResidentialAddress,
+            user.StateOfResidence,
+            user.CountryOfResidence,
+            user.DateOfBirth,
+            user.Nationality,
+            user.UserType,
+            user.IsEmailVerified);
+
+    public static void ApplyUpdate(User user, UpdateInvestorProfileRequest request)
+    {
+        user.FirstName = request.FirstName;
+        user.LastName = request.LastName;
+        user.PreferredName = request.PreferredName;
+        user.PhoneNumber = request.PhoneNumber;
+        user.ResidentialAddress = request.ResidentialAddress;
+        user.StateOfResidence = request.StateOfResidence;
+        user.CountryOfResidence = request.CountryOfResidence;
+    }
+}

--- a/Antital.Application/Features/Investors/UpdateInvestorProfile/UpdateInvestorProfileCommand.cs
+++ b/Antital.Application/Features/Investors/UpdateInvestorProfile/UpdateInvestorProfileCommand.cs
@@ -1,0 +1,59 @@
+using Antital.Application.DTOs.Investors;
+using Antital.Application.Features.Investors.Profile;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+using BuildingBlocks.Domain.Interfaces;
+
+namespace Antital.Application.Features.Investors.UpdateInvestorProfile;
+
+public record UpdateInvestorProfileCommand(
+    string FirstName,
+    string LastName,
+    string? PreferredName,
+    string PhoneNumber,
+    string ResidentialAddress,
+    string StateOfResidence,
+    string CountryOfResidence
+) : ICommandQuery<InvestorProfileResponse>;
+
+public class UpdateInvestorProfileCommandHandler(
+    IInvestorUserAccess investorUserAccess,
+    IUserRepository userRepository,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser
+) : ICommandQueryHandler<UpdateInvestorProfileCommand, InvestorProfileResponse>
+{
+    public async Task<Result<InvestorProfileResponse>> Handle(
+        UpdateInvestorProfileCommand request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, user) = await investorUserAccess.RequireAuthenticatedUserAsync(cancellationToken);
+
+        var updateRequest = new UpdateInvestorProfileRequest(
+            request.FirstName,
+            request.LastName,
+            request.PreferredName,
+            request.PhoneNumber,
+            request.ResidentialAddress,
+            request.StateOfResidence,
+            request.CountryOfResidence);
+
+        InvestorProfileMapper.ApplyUpdate(user, updateRequest);
+
+        var actor = !string.IsNullOrEmpty(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrEmpty(currentUser.IPAddress) ? currentUser.IPAddress : "System");
+        user.Updated(actor);
+
+        await userRepository.UpdateAsync(user, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        var refreshed = await userRepository.GetByIdAsync(userId, cancellationToken);
+        var response = InvestorProfileMapper.ToResponse(refreshed!);
+
+        var result = new Result<InvestorProfileResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investors/UpdateInvestorProfile/UpdateInvestorProfileCommandValidator.cs
+++ b/Antital.Application/Features/Investors/UpdateInvestorProfile/UpdateInvestorProfileCommandValidator.cs
@@ -1,0 +1,43 @@
+using BuildingBlocks.Application.Methods;
+using FluentValidation;
+
+namespace Antital.Application.Features.Investors.UpdateInvestorProfile;
+
+public class UpdateInvestorProfileCommandValidator : AbstractValidator<UpdateInvestorProfileCommand>
+{
+    public UpdateInvestorProfileCommandValidator()
+    {
+        RuleFor(x => x.FirstName)
+            .NotEmpty().WithMessage("First name is required.")
+            .Must(ValidationHelper.IsValidString).WithMessage("First name is required.")
+            .MinimumLength(2).WithMessage("First name must be at least 2 characters long.")
+            .MaximumLength(50).WithMessage("First name must not exceed 50 characters.");
+
+        RuleFor(x => x.LastName)
+            .NotEmpty().WithMessage("Last name is required.")
+            .Must(ValidationHelper.IsValidString).WithMessage("Last name is required.")
+            .MinimumLength(2).WithMessage("Last name must be at least 2 characters long.")
+            .MaximumLength(50).WithMessage("Last name must not exceed 50 characters.");
+
+        RuleFor(x => x.PreferredName)
+            .MaximumLength(50).WithMessage("Preferred name must not exceed 50 characters.")
+            .When(x => !string.IsNullOrWhiteSpace(x.PreferredName));
+
+        RuleFor(x => x.PhoneNumber)
+            .NotEmpty().WithMessage("Phone number is required.")
+            .Must(ValidationHelper.IsValidString).WithMessage("Phone number is required.");
+
+        RuleFor(x => x.ResidentialAddress)
+            .NotEmpty().WithMessage("Residential address is required.")
+            .MinimumLength(10).WithMessage("Residential address must be at least 10 characters long.")
+            .MaximumLength(500).WithMessage("Residential address must not exceed 500 characters.");
+
+        RuleFor(x => x.StateOfResidence)
+            .NotEmpty().WithMessage("State of residence is required.")
+            .MaximumLength(100).WithMessage("State of residence must not exceed 100 characters.");
+
+        RuleFor(x => x.CountryOfResidence)
+            .NotEmpty().WithMessage("Country of residence is required.")
+            .MaximumLength(100).WithMessage("Country of residence must not exceed 100 characters.");
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/ChangePasswordControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/ChangePasswordControllerTests.cs
@@ -1,0 +1,191 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using Antital.Application.Features.Authentication.ChangePassword;
+using Antital.Application.Features.Authentication.Login;
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Test.Integration;
+using BuildingBlocks.Application.Features;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Antital.Test.Integration.API.Controllers;
+
+[Collection("IntegrationTests")]
+public class ChangePasswordControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>, IDisposable
+{
+    private readonly CustomWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+    private readonly IServiceScope _scope;
+    private readonly AntitalDBContext _context;
+    private readonly IConfiguration _config;
+    private readonly IPasswordHasher _passwordHasher;
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+    };
+
+    public ChangePasswordControllerTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+        _scope = _factory.Services.CreateScope();
+        _context = _scope.ServiceProvider.GetRequiredService<AntitalDBContext>();
+        _config = _scope.ServiceProvider.GetRequiredService<IConfiguration>();
+        _passwordHasher = _scope.ServiceProvider.GetRequiredService<IPasswordHasher>();
+        CleanupDatabase();
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithoutAuth_Returns401()
+    {
+        var response = await _client.PostAsJsonAsync(
+            "/api/auth/change-password",
+            new ChangePasswordCommand("OldPass1!", "NewPass2@", "NewPass2@"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithCorrectCurrentPassword_UpdatesPassword()
+    {
+        const string currentPassword = "CurrentP@ss1";
+        const string newPassword = "NewStrongP@ss2";
+        var user = SeedUser("change-password@example.com", currentPassword);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PostAsJsonAsync(
+            "/api/auth/change-password",
+            new ChangePasswordCommand(currentPassword, newPassword, newPassword));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var freshContext = scope.ServiceProvider.GetRequiredService<AntitalDBContext>();
+        var updated = await freshContext.Users.AsNoTracking().FirstAsync(u => u.Id == user.Id);
+        _passwordHasher.VerifyPassword(newPassword, updated.PasswordHash).Should().BeTrue();
+        _passwordHasher.VerifyPassword(currentPassword, updated.PasswordHash).Should().BeFalse();
+        updated.RefreshTokenHash.Should().BeNull();
+        updated.RefreshTokenExpiresAt.Should().BeNull();
+
+        var loginResponse = await _client.PostAsJsonAsync(
+            "/api/auth/login",
+            new LoginCommand(user.Email, newPassword));
+        loginResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithWrongCurrentPassword_Returns400()
+    {
+        var user = SeedUser("change-password-wrong@example.com", "CurrentP@ss1");
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PostAsJsonAsync(
+            "/api/auth/change-password",
+            new ChangePasswordCommand("WrongPass1!", "NewStrongP@ss2", "NewStrongP@ss2"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithWeakNewPassword_Returns400()
+    {
+        var user = SeedUser("change-password-weak@example.com", "CurrentP@ss1");
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PostAsJsonAsync(
+            "/api/auth/change-password",
+            new ChangePasswordCommand("CurrentP@ss1", "weakpass", "weakpass"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WithMismatchedConfirmPassword_Returns400()
+    {
+        var user = SeedUser("change-password-mismatch@example.com", "CurrentP@ss1");
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PostAsJsonAsync(
+            "/api/auth/change-password",
+            new ChangePasswordCommand("CurrentP@ss1", "NewStrongP@ss2", "DifferentP@ss3"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    private User SeedUser(string email, string password)
+    {
+        var user = new User
+        {
+            Email = email,
+            PasswordHash = _passwordHasher.HashPassword(password),
+            UserType = UserTypeEnum.IndividualInvestor,
+            IsEmailVerified = true,
+            FirstName = "Jane",
+            LastName = "Okonkwo",
+            PhoneNumber = "+2348012345678",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            Nationality = "Nigerian",
+            CountryOfResidence = "Nigeria",
+            StateOfResidence = "Lagos",
+            ResidentialAddress = "123 Main Street",
+            HasAgreedToTerms = true,
+        };
+        user.Created("TestUser");
+        _context.Users.Add(user);
+        return user;
+    }
+
+    private HttpClient CreateAuthorizedClient(int userId, string email)
+    {
+        var client = _factory.CreateClient();
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_config["Jwt:Key"]!);
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _config["Jwt:Issuer"],
+            Audience = _config["Jwt:Audience"],
+            Expires = DateTime.UtcNow.AddHours(1),
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim("UserId", userId.ToString()),
+                new Claim(ClaimTypes.Email, email),
+            }),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256),
+        };
+
+        var token = tokenHandler.CreateToken(descriptor);
+        var jwt = tokenHandler.WriteToken(token);
+
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+        return client;
+    }
+
+    private void CleanupDatabase()
+    {
+        _context.Users.RemoveRange(_context.Users);
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        CleanupDatabase();
+        _scope.Dispose();
+        _client.Dispose();
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/InvestorAccountControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestorAccountControllerTests.cs
@@ -1,0 +1,261 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using Antital.Application.DTOs.Investors;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Test.Integration;
+using BuildingBlocks.Application.Features;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Antital.Test.Integration.API.Controllers;
+
+[Collection("IntegrationTests")]
+public class InvestorAccountControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>, IDisposable
+{
+    private readonly CustomWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+    private readonly IServiceScope _scope;
+    private readonly AntitalDBContext _context;
+    private readonly IConfiguration _config;
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+    };
+
+    public InvestorAccountControllerTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+        _scope = _factory.Services.CreateScope();
+        _context = _scope.ServiceProvider.GetRequiredService<AntitalDBContext>();
+        _config = _scope.ServiceProvider.GetRequiredService<IConfiguration>();
+        CleanupDatabase();
+    }
+
+    [Fact]
+    public async Task GetAccount_WithoutAuth_Returns401()
+    {
+        var response = await _client.GetAsync("/api/investors/me/account");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetAccount_NewInvestor_ReturnsPendingDefaults()
+    {
+        var user = SeedUser("account-new@example.com");
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/investors/me/account");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorAccountResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.AccountType.Should().Be("Ordinary Investor");
+        result.Value.AccountStatus.Should().Be("Pending");
+        result.Value.KycStatus.Should().Be("Pending");
+        result.Value.KycCompletedDate.Should().BeNull();
+        result.Value.InvestorClassification.Should().Be("Ordinary");
+        result.Value.VerificationStatus.Should().Be("Verified");
+        result.Value.RiskRating.Should().Be("Low");
+        result.Value.InvestmentLimits.Should().BeNull();
+        result.Value.ComplianceChecks.Should().HaveCount(3);
+        result.Value.MemberSince.Should().BeCloseTo(user.CreatedAt, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public async Task GetAccount_WithRetailProfileAndCompletedKyc_ReturnsActiveAccount()
+    {
+        var user = SeedUser("account-complete@example.com");
+        await _context.SaveChangesAsync();
+
+        var completedAt = new DateTime(2024, 10, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        _context.UserOnboardings.Add(new UserOnboarding
+        {
+            UserId = user.Id,
+            FlowType = OnboardingFlowType.IndividualInvestor,
+            CurrentStep = OnboardingStep.Review,
+            Status = OnboardingStatus.Activated,
+            SubmittedAt = completedAt.AddDays(-5),
+        });
+
+        _context.UserInvestmentProfiles.Add(new UserInvestmentProfile
+        {
+            UserId = user.Id,
+            InvestorCategory = InvestorCategory.Retail,
+        });
+
+        _context.UserKycs.Add(new UserKyc
+        {
+            UserId = user.Id,
+            IdType = KycIdType.NationalIdCard,
+            GovernmentIdDocumentPathOrKey = "gov-id.png",
+            ProofOfAddressDocumentPathOrKey = "proof.png",
+            SelfieVerificationPathOrKey = "selfie.png",
+            GovernmentIdVerifiedAt = completedAt.AddDays(-2),
+            ProofOfAddressVerifiedAt = completedAt.AddDays(-1),
+            SelfieVerifiedAt = completedAt,
+        });
+
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/investors/me/account");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorAccountResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.AccountType.Should().Be("Ordinary Investor");
+        result.Value.AccountStatus.Should().Be("Active");
+        result.Value.KycStatus.Should().Be("Completed");
+        result.Value.KycCompletedDate.Should().BeCloseTo(completedAt, TimeSpan.FromSeconds(1));
+        result.Value.InvestorClassification.Should().Be("Ordinary");
+        result.Value.VerificationStatus.Should().Be("Verified");
+        result.Value.ComplianceChecks.Should().Contain(c => c.Id == "aml" && c.Status == "Passed");
+    }
+
+    [Fact]
+    public async Task GetAccount_WithActivatedOnboardingAndDocumentsOnly_ReturnsPendingKyc()
+    {
+        var user = SeedUser("account-docs-only@example.com");
+        await _context.SaveChangesAsync();
+
+        _context.UserOnboardings.Add(new UserOnboarding
+        {
+            UserId = user.Id,
+            FlowType = OnboardingFlowType.IndividualInvestor,
+            CurrentStep = OnboardingStep.Review,
+            Status = OnboardingStatus.Activated,
+        });
+
+        _context.UserKycs.Add(new UserKyc
+        {
+            UserId = user.Id,
+            IdType = KycIdType.NationalIdCard,
+            GovernmentIdDocumentPathOrKey = "gov-id.png",
+            ProofOfAddressDocumentPathOrKey = "proof.png",
+            SelfieVerificationPathOrKey = "selfie.png",
+        });
+
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/investors/me/account");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorAccountResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.AccountStatus.Should().Be("Active");
+        result.Value.KycStatus.Should().Be("Pending");
+        result.Value.KycCompletedDate.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetAccount_WithSophisticatedProfile_ReturnsClassification()
+    {
+        var user = SeedUser("account-sophisticated@example.com");
+        await _context.SaveChangesAsync();
+
+        _context.UserOnboardings.Add(new UserOnboarding
+        {
+            UserId = user.Id,
+            FlowType = OnboardingFlowType.IndividualInvestor,
+            CurrentStep = OnboardingStep.Review,
+            Status = OnboardingStatus.Submitted,
+        });
+
+        _context.UserInvestmentProfiles.Add(new UserInvestmentProfile
+        {
+            UserId = user.Id,
+            InvestorCategory = InvestorCategory.Sophisticated,
+        });
+
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/investors/me/account");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorAccountResponse>>(JsonOptions);
+        result!.Value!.AccountType.Should().Be("Sophisticated Investor");
+        result.Value.InvestorClassification.Should().Be("Sophisticated");
+        result.Value.AccountStatus.Should().Be("Active");
+        result.Value.KycStatus.Should().Be("Pending");
+    }
+
+    private User SeedUser(string email)
+    {
+        var user = new User
+        {
+            Email = email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
+            UserType = UserTypeEnum.IndividualInvestor,
+            IsEmailVerified = true,
+            FirstName = "Jane",
+            LastName = "Okonkwo",
+            PhoneNumber = "+2348012345678",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            Nationality = "Nigerian",
+            CountryOfResidence = "Nigeria",
+            StateOfResidence = "Lagos",
+            ResidentialAddress = "123 Main Street",
+            HasAgreedToTerms = true,
+        };
+        user.Created("TestUser");
+        _context.Users.Add(user);
+        return user;
+    }
+
+    private HttpClient CreateAuthorizedClient(int userId, string email)
+    {
+        var client = _factory.CreateClient();
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_config["Jwt:Key"]!);
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _config["Jwt:Issuer"],
+            Audience = _config["Jwt:Audience"],
+            Expires = DateTime.UtcNow.AddHours(1),
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim("UserId", userId.ToString()),
+                new Claim(ClaimTypes.Email, email),
+            }),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256),
+        };
+
+        var token = tokenHandler.CreateToken(descriptor);
+        var jwt = tokenHandler.WriteToken(token);
+
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+        return client;
+    }
+
+    private void CleanupDatabase()
+    {
+        _context.UserKycs.RemoveRange(_context.UserKycs);
+        _context.UserInvestmentProfiles.RemoveRange(_context.UserInvestmentProfiles);
+        _context.UserOnboardings.RemoveRange(_context.UserOnboardings);
+        _context.Users.RemoveRange(_context.Users);
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        CleanupDatabase();
+        _scope.Dispose();
+        _client.Dispose();
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/InvestorProfileControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestorProfileControllerTests.cs
@@ -1,0 +1,213 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using Antital.Application.DTOs.Investors;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Test.Integration;
+using BuildingBlocks.Application.Features;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Antital.Test.Integration.API.Controllers;
+
+[Collection("IntegrationTests")]
+public class InvestorProfileControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>, IDisposable
+{
+    private readonly CustomWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+    private readonly IServiceScope _scope;
+    private readonly AntitalDBContext _context;
+    private readonly IConfiguration _config;
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+    };
+
+    public InvestorProfileControllerTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+        _scope = _factory.Services.CreateScope();
+        _context = _scope.ServiceProvider.GetRequiredService<AntitalDBContext>();
+        _config = _scope.ServiceProvider.GetRequiredService<IConfiguration>();
+        CleanupDatabase();
+    }
+
+    [Fact]
+    public async Task GetProfile_WithoutAuth_Returns401()
+    {
+        var response = await _client.GetAsync("/api/investors/me/profile");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetProfile_ReturnsAuthenticatedUserProfile()
+    {
+        var user = SeedUser("profile-get@example.com");
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/investors/me/profile");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorProfileResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Id.Should().Be(user.Id);
+        result.Value.Email.Should().Be("profile-get@example.com");
+        result.Value.FirstName.Should().Be("Jane");
+        result.Value.LastName.Should().Be("Okonkwo");
+        result.Value.PhoneNumber.Should().Be("+2348012345678");
+        result.Value.ResidentialAddress.Should().Be("123 Main Street");
+        result.Value.StateOfResidence.Should().Be("Lagos");
+        result.Value.CountryOfResidence.Should().Be("Nigeria");
+        result.Value.Nationality.Should().Be("Nigerian");
+        result.Value.IsEmailVerified.Should().BeTrue();
+        result.Value.UserType.Should().Be(UserTypeEnum.IndividualInvestor);
+    }
+
+    [Fact]
+    public async Task UpdateProfile_WithoutAuth_Returns401()
+    {
+        var response = await _client.PutAsJsonAsync(
+            "/api/investors/me/profile",
+            ValidUpdateRequest());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task UpdateProfile_UpdatesEditableFields()
+    {
+        var user = SeedUser("profile-update@example.com");
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PutAsJsonAsync(
+            "/api/investors/me/profile",
+            new UpdateInvestorProfileRequest(
+                FirstName: "Ada",
+                LastName: "Okafor",
+                PreferredName: "Ada",
+                PhoneNumber: "+2348098765432",
+                ResidentialAddress: "42 Admiralty Way, Lekki Phase 1",
+                StateOfResidence: "Lagos State",
+                CountryOfResidence: "Nigeria"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorProfileResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.FirstName.Should().Be("Ada");
+        result.Value.LastName.Should().Be("Okafor");
+        result.Value.PreferredName.Should().Be("Ada");
+        result.Value.PhoneNumber.Should().Be("+2348098765432");
+        result.Value.ResidentialAddress.Should().Be("42 Admiralty Way, Lekki Phase 1");
+        result.Value.StateOfResidence.Should().Be("Lagos State");
+        result.Value.Email.Should().Be("profile-update@example.com");
+        result.Value.Nationality.Should().Be("Nigerian");
+
+        var getResponse = await authClient.GetAsync("/api/investors/me/profile");
+        var getResult = await getResponse.Content.ReadFromJsonAsync<Result<InvestorProfileResponse>>(JsonOptions);
+        getResult!.Value!.FirstName.Should().Be("Ada");
+    }
+
+    [Fact]
+    public async Task UpdateProfile_WithInvalidPayload_Returns400()
+    {
+        var user = SeedUser("profile-invalid@example.com");
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PutAsJsonAsync(
+            "/api/investors/me/profile",
+            new UpdateInvestorProfileRequest(
+                FirstName: "",
+                LastName: "Okafor",
+                PreferredName: null,
+                PhoneNumber: "+2348098765432",
+                ResidentialAddress: "Short",
+                StateOfResidence: "Lagos State",
+                CountryOfResidence: "Nigeria"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    private static UpdateInvestorProfileRequest ValidUpdateRequest() =>
+        new(
+            FirstName: "Ada",
+            LastName: "Okafor",
+            PreferredName: null,
+            PhoneNumber: "+2348098765432",
+            ResidentialAddress: "42 Admiralty Way, Lekki Phase 1",
+            StateOfResidence: "Lagos State",
+            CountryOfResidence: "Nigeria");
+
+    private User SeedUser(string email)
+    {
+        var user = new User
+        {
+            Email = email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
+            UserType = UserTypeEnum.IndividualInvestor,
+            IsEmailVerified = true,
+            FirstName = "Jane",
+            LastName = "Okonkwo",
+            PhoneNumber = "+2348012345678",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            Nationality = "Nigerian",
+            CountryOfResidence = "Nigeria",
+            StateOfResidence = "Lagos",
+            ResidentialAddress = "123 Main Street",
+            HasAgreedToTerms = true,
+        };
+        _context.Users.Add(user);
+        return user;
+    }
+
+    private HttpClient CreateAuthorizedClient(int userId, string email)
+    {
+        var client = _factory.CreateClient();
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_config["Jwt:Key"]!);
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _config["Jwt:Issuer"],
+            Audience = _config["Jwt:Audience"],
+            Expires = DateTime.UtcNow.AddHours(1),
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim("UserId", userId.ToString()),
+                new Claim(ClaimTypes.Email, email),
+            }),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256),
+        };
+
+        var token = tokenHandler.CreateToken(descriptor);
+        var jwt = tokenHandler.WriteToken(token);
+
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+        return client;
+    }
+
+    private void CleanupDatabase()
+    {
+        _context.Users.RemoveRange(_context.Users);
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        CleanupDatabase();
+        _scope.Dispose();
+        _client.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `GET/PUT /api/investors/me/profile` for self-service profile read and update
- Add `GET /api/investors/me/account` for settings account summary (KYC, classification, compliance placeholders)
- Add `POST /api/auth/change-password` for authenticated password change with refresh token revocation
- Include integration tests and align KYC status with completion date semantics

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~InvestorProfileControllerTests`
- [x] `dotnet test --filter FullyQualifiedName~InvestorAccountControllerTests`
- [x] `dotnet test --filter FullyQualifiedName~ChangePasswordControllerTests`
- [x] Smoke test settings flows on staging after deploy


Made with [Cursor](https://cursor.com)