### PR TITLE
Expose signup profile fields on GET user for onboarding resume

### DIFF
--- a/Antital.Application/DTOs/UserDto.cs
+++ b/Antital.Application/DTOs/UserDto.cs
@@ -12,4 +12,38 @@ public class UserDto
     public string? PreferredName { get; set; }
     public UserTypeEnum UserType { get; set; }
     public bool IsEmailVerified { get; set; }
+
+    /// <summary>Personal details captured at signup (individual / representative-linked user row).</summary>
+    public DateTime? DateOfBirth { get; set; }
+    public string? Nationality { get; set; }
+    public string? CountryOfResidence { get; set; }
+    public string? StateOfResidence { get; set; }
+    public string? ResidentialAddress { get; set; }
+    public bool HasAgreedToTerms { get; set; }
+
+    /// <summary>Corporate / fundraiser company details from investment profile when present.</summary>
+    public UserCompanyDto? Company { get; set; }
+}
+
+public class UserCompanyDto
+{
+    public string? CompanyLegalName { get; set; }
+    public string? TradingBrandName { get; set; }
+    public string? RegistrationType { get; set; }
+    public string? RegistrationNumber { get; set; }
+    public string? CompanyLoginEmail { get; set; }
+    public DateTime? DateOfRegistration { get; set; }
+    public string? CompanyWebsite { get; set; }
+    public string? BusinessAddress { get; set; }
+    public string? RegisteredAddress { get; set; }
+    public string? CompanyEmail { get; set; }
+    public string? CompanyPhone { get; set; }
+    public string? RepresentativeFullName { get; set; }
+    public string? RepresentativeJobTitle { get; set; }
+    public string? RepresentativePhoneNumber { get; set; }
+    public DateTime? RepresentativeDateOfBirth { get; set; }
+    public string? RepresentativeEmail { get; set; }
+    public string? RepresentativeNationality { get; set; }
+    public string? RepresentativeCountryOfResidence { get; set; }
+    public string? RepresentativeAddress { get; set; }
 }

--- a/Antital.Application/Features/Users/GetUserById/GetUserByIdQueryHandler.cs
+++ b/Antital.Application/Features/Users/GetUserById/GetUserByIdQueryHandler.cs
@@ -6,13 +6,18 @@ using BuildingBlocks.Resources;
 
 namespace Antital.Application.Features.Users.GetUserById;
 
-public class GetUserByIdQueryHandler(IUserRepository userRepository) : ICommandQueryHandler<GetUserByIdQuery, UserDto>
+public class GetUserByIdQueryHandler(
+    IUserRepository userRepository,
+    IUserInvestmentProfileRepository userInvestmentProfileRepository
+) : ICommandQueryHandler<GetUserByIdQuery, UserDto>
 {
     public async Task<Result<UserDto>> Handle(GetUserByIdQuery request, CancellationToken cancellationToken)
     {
         var user = await userRepository.GetByIdAsync(request.Id, cancellationToken);
         if (user == null)
             throw new NotFoundException(Messages.NotFound);
+
+        var profile = await userInvestmentProfileRepository.GetByUserIdAsync(user.Id, cancellationToken);
 
         var dto = new UserDto
         {
@@ -23,7 +28,37 @@ public class GetUserByIdQueryHandler(IUserRepository userRepository) : ICommandQ
             PhoneNumber = user.PhoneNumber,
             PreferredName = user.PreferredName,
             UserType = user.UserType,
-            IsEmailVerified = user.IsEmailVerified
+            IsEmailVerified = user.IsEmailVerified,
+            DateOfBirth = user.DateOfBirth == DateTime.MinValue ? null : user.DateOfBirth,
+            Nationality = NullIfEmpty(user.Nationality),
+            CountryOfResidence = NullIfEmpty(user.CountryOfResidence),
+            StateOfResidence = NullIfEmpty(user.StateOfResidence),
+            ResidentialAddress = NullIfEmpty(user.ResidentialAddress),
+            HasAgreedToTerms = user.HasAgreedToTerms,
+            Company = profile is null
+                ? null
+                : new UserCompanyDto
+                {
+                    CompanyLegalName = profile.CompanyLegalName,
+                    TradingBrandName = profile.TradingBrandName,
+                    RegistrationType = profile.RegistrationType,
+                    RegistrationNumber = profile.RegistrationNumber,
+                    CompanyLoginEmail = profile.CompanyLoginEmail,
+                    DateOfRegistration = profile.DateOfRegistration,
+                    CompanyWebsite = profile.CompanyWebsite,
+                    BusinessAddress = profile.BusinessAddress,
+                    RegisteredAddress = profile.RegisteredAddress,
+                    CompanyEmail = profile.CompanyEmail,
+                    CompanyPhone = profile.CompanyPhone,
+                    RepresentativeFullName = profile.RepresentativeFullName,
+                    RepresentativeJobTitle = profile.RepresentativeJobTitle,
+                    RepresentativePhoneNumber = profile.RepresentativePhoneNumber,
+                    RepresentativeDateOfBirth = profile.RepresentativeDateOfBirth,
+                    RepresentativeEmail = profile.RepresentativeEmail,
+                    RepresentativeNationality = profile.RepresentativeNationality,
+                    RepresentativeCountryOfResidence = profile.RepresentativeCountryOfResidence,
+                    RepresentativeAddress = profile.RepresentativeAddress
+                }
         };
 
         var result = new Result<UserDto>();
@@ -31,4 +66,7 @@ public class GetUserByIdQueryHandler(IUserRepository userRepository) : ICommandQ
         result.OK();
         return result;
     }
+
+    private static string? NullIfEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
 }

--- a/Antital.Test/Application/Features/Users/GetUserByIdQueryHandlerTests.cs
+++ b/Antital.Test/Application/Features/Users/GetUserByIdQueryHandlerTests.cs
@@ -11,24 +11,44 @@ namespace Antital.Test.Application.Features.Users;
 public class GetUserByIdQueryHandlerTests
 {
     private readonly Mock<IUserRepository> _userRepo = new();
+    private readonly Mock<IUserInvestmentProfileRepository> _profileRepo = new();
     private readonly GetUserByIdQueryHandler _handler;
 
     public GetUserByIdQueryHandlerTests()
     {
-        _handler = new GetUserByIdQueryHandler(_userRepo.Object);
+        _handler = new GetUserByIdQueryHandler(_userRepo.Object, _profileRepo.Object);
     }
 
     [Fact]
     public async Task Handle_UserFound_ReturnsDto()
     {
-        var user = new User { Id = 5, Email = "x@y.com", FirstName = "X", LastName = "Y", IsEmailVerified = true };
+        var user = new User
+        {
+            Id = 5,
+            Email = "x@y.com",
+            FirstName = "X",
+            LastName = "Y",
+            IsEmailVerified = true,
+            PhoneNumber = "08012345678",
+            Nationality = "Nigerian",
+            CountryOfResidence = "Nigeria",
+            StateOfResidence = "Lagos",
+            ResidentialAddress = "12 Test St",
+            DateOfBirth = new DateTime(1990, 1, 15, 0, 0, 0, DateTimeKind.Utc),
+            HasAgreedToTerms = true
+        };
         _userRepo.Setup(x => x.GetByIdAsync(5, It.IsAny<CancellationToken>())).ReturnsAsync(user);
+        _profileRepo.Setup(x => x.GetByUserIdAsync(5, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserInvestmentProfile?)null);
 
         var result = await _handler.Handle(new GetUserByIdQuery(5), CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
         result.Value!.Id.Should().Be(5);
         result.Value.Email.Should().Be("x@y.com");
+        result.Value.Nationality.Should().Be("Nigerian");
+        result.Value.DateOfBirth.Should().Be(user.DateOfBirth);
+        result.Value.Company.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Expand `UserDto` / `GET /api/users/{id}` with signup personal fields and optional corporate/fundraiser company details from the investment profile.
- Supports UI onboarding resume after logout/login while email is still unverified (onboarding APIs require verification).

## Test plan
- [x] `GET /api/users/{id}` for an individual returns DOB, nationality, residence, address, etc.
- [x] Corporate/fundraiser user returns `company` block when an investment profile exists
- [x] Existing GetUserById unit tests pass
- [x] Pair with UI PR: logout → login mid-verify → personal/company form fields are populated


Made with [Cursor](https://cursor.com)