### PR TITLE
Add fundraiser dashboard API

### DIFF
--- a/Antital.API/Configs/AppUseExtensions.cs
+++ b/Antital.API/Configs/AppUseExtensions.cs
@@ -117,6 +117,7 @@ public static class AppUseExtensions
                 if (!env.IsEnvironment("Testing"))
                 {
                     InvestmentOfferingSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
+                    FundraiserOfferingOwnershipSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
                     InvestorDashboardSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
                     WalletTransactionSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
                 }

--- a/Antital.API/Configs/DependencyInjection.cs
+++ b/Antital.API/Configs/DependencyInjection.cs
@@ -6,6 +6,7 @@ using Antital.Application.Features.Investments.ConfirmInvestmentOrder;
 using Antital.Application.Features.Investments.ProcessPaystackWebhook;
 using Antital.Infrastructure.Integrations.Paystack;
 using Antital.Application.Features.Investors;
+using Antital.Application.Features.Fundraisers;
 using Antital.Application.Features.Onboarding;
 using Antital.Application.Services;
 using Antital.Domain.Interfaces;
@@ -67,6 +68,7 @@ public static class DependencyInjection
         services.AddScoped(typeof(IUserKycRepository), typeof(UserKycRepository));
         services.AddScoped(typeof(IInvestmentOfferingRepository), typeof(InvestmentOfferingRepository));
         services.AddScoped(typeof(IInvestorDashboardRepository), typeof(InvestorDashboardRepository));
+        services.AddScoped(typeof(IFundraiserDashboardRepository), typeof(FundraiserDashboardRepository));
         services.AddScoped(typeof(IInvestmentOrderRepository), typeof(InvestmentOrderRepository));
         services.AddScoped(typeof(IInvestorPaymentMethodRepository), typeof(InvestorPaymentMethodRepository));
         services.AddScoped(typeof(IInvestorWatchlistRepository), typeof(InvestorWatchlistRepository));
@@ -117,6 +119,7 @@ public static class DependencyInjection
         services.AddScoped<IKycVerificationService, PassThroughKycVerificationService>();
         services.AddScoped<IOnboardingUserAccess, OnboardingUserAccess>();
         services.AddScoped<IInvestorUserAccess, InvestorUserAccess>();
+        services.AddScoped<IFundraiserUserAccess, FundraiserUserAccess>();
         services.AddScoped<IInvestmentCheckoutAccess, InvestmentCheckoutAccess>();
         services.AddScoped<IInvestmentPaymentConfirmationService, InvestmentPaymentConfirmationService>();
         services.AddScoped<IConfirmInvestmentOrderService, ConfirmInvestmentOrderService>();

--- a/Antital.API/Controllers/FundraisersController.cs
+++ b/Antital.API/Controllers/FundraisersController.cs
@@ -1,0 +1,33 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Application.Features.Fundraisers.GetFundraiserDashboard;
+using BuildingBlocks.API.Controllers;
+using BuildingBlocks.Application.Features;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Antital.API.Controllers;
+
+[SwaggerTag("Fundraisers")]
+[Route("api/fundraisers")]
+[Authorize]
+[ApiController]
+public class FundraisersController(IMediator mediator) : BaseController
+{
+    [HttpGet("me/dashboard")]
+    [SwaggerOperation(
+        "Get Fundraiser Dashboard",
+        "Returns campaign summary, funding progress, investor breakdown, and milestones for the authenticated fundraiser.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserDashboardResponse>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid period", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    public async Task<IActionResult> GetDashboard(
+        [FromQuery] string period = "this-month",
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(new GetFundraiserDashboardQuery(period), cancellationToken);
+        return ApiResult(result);
+    }
+}

--- a/Antital.Application/DTOs/Fundraisers/FundraiserDashboardDtos.cs
+++ b/Antital.Application/DTOs/Fundraisers/FundraiserDashboardDtos.cs
@@ -1,0 +1,38 @@
+namespace Antital.Application.DTOs.Fundraisers;
+
+public record FundraiserDashboardSummaryDto(
+    decimal TotalAmountRaised,
+    int TotalInvestors,
+    int DaysRemaining,
+    decimal AverageInvestmentSize);
+
+public record FundraiserFundingProgressDto(
+    decimal RaisedAmount,
+    decimal TargetAmount,
+    decimal MinimumThreshold,
+    decimal CurrentVelocity,
+    string VelocityPeriod,
+    int ConfidenceRate);
+
+public record FundraiserBreakdownBucketDto(string Label, int Percentage);
+
+public record FundraiserInvestorBreakdownDto(
+    string Dimension,
+    IReadOnlyList<FundraiserBreakdownBucketDto> Buckets);
+
+public record FundraiserMilestoneDto(
+    string Key,
+    string Title,
+    string Description,
+    string DateLabel,
+    string Status);
+
+public record FundraiserDashboardResponse(
+    int? OfferingId,
+    string? OfferingSlug,
+    string? OfferingName,
+    string Currency,
+    FundraiserDashboardSummaryDto Summary,
+    FundraiserFundingProgressDto FundingProgress,
+    FundraiserInvestorBreakdownDto InvestorBreakdown,
+    IReadOnlyList<FundraiserMilestoneDto> Milestones);

--- a/Antital.Application/Features/Fundraisers/FundraiserUserAccess.cs
+++ b/Antital.Application/Features/Fundraisers/FundraiserUserAccess.cs
@@ -1,0 +1,39 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using BuildingBlocks.Application.Exceptions;
+
+namespace Antital.Application.Features.Fundraisers;
+
+public interface IFundraiserUserAccess
+{
+    Task<(int UserId, User User)> RequireFundraiserAsync(CancellationToken cancellationToken = default);
+}
+
+public class FundraiserUserAccess(
+    IAntitalCurrentUser currentUser,
+    IUserRepository userRepository
+) : IFundraiserUserAccess
+{
+    public async Task<(int UserId, User User)> RequireFundraiserAsync(CancellationToken cancellationToken = default)
+    {
+        var userId = currentUser.UserId;
+        if (!userId.HasValue)
+        {
+            throw new UnauthorizedException("User is not authenticated.");
+        }
+
+        var user = await userRepository.GetByIdAsync(userId.Value, cancellationToken);
+        if (user == null)
+        {
+            throw new NotFoundException("User not found.");
+        }
+
+        if (user.UserType != UserTypeEnum.FundRaiser)
+        {
+            throw new ForbiddenException("Only fundraisers can access this resource.");
+        }
+
+        return (userId.Value, user);
+    }
+}

--- a/Antital.Application/Features/Fundraisers/GetFundraiserDashboard/GetFundraiserDashboardQuery.cs
+++ b/Antital.Application/Features/Fundraisers/GetFundraiserDashboard/GetFundraiserDashboardQuery.cs
@@ -1,0 +1,6 @@
+using Antital.Application.DTOs.Fundraisers;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Fundraisers.GetFundraiserDashboard;
+
+public record GetFundraiserDashboardQuery(string Period = "this-month") : ICommandQuery<FundraiserDashboardResponse>;

--- a/Antital.Application/Features/Fundraisers/GetFundraiserDashboard/GetFundraiserDashboardQueryHandler.cs
+++ b/Antital.Application/Features/Fundraisers/GetFundraiserDashboard/GetFundraiserDashboardQueryHandler.cs
@@ -1,0 +1,262 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Application.Features.Investments;
+using Antital.Application.Features.Investors;
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Fundraisers.GetFundraiserDashboard;
+
+public class GetFundraiserDashboardQueryHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserDashboardRepository dashboardRepository
+) : ICommandQueryHandler<GetFundraiserDashboardQuery, FundraiserDashboardResponse>
+{
+    private static readonly (string Label, decimal MinInclusive, decimal? MaxExclusive)[] SizeBuckets =
+    [
+        ("0 - 5M", 0m, 6_000_000m),
+        ("6M - 20M", 6_000_000m, 21_000_000m),
+        ("21M - 100M", 21_000_000m, 101_000_000m),
+        ("101M - 500M", 101_000_000m, null),
+    ];
+
+    public async Task<Result<FundraiserDashboardResponse>> Handle(
+        GetFundraiserDashboardQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (!DashboardPeriodResolver.TryResolve(request.Period, out _, out var periodError))
+        {
+            var invalidResult = new Result<FundraiserDashboardResponse>();
+            invalidResult.BadRequest(
+                "Invalid period.",
+                new Dictionary<string, string[]>
+                {
+                    ["period"] =
+                    [
+                        periodError
+                        ?? "Period must be this-month, last-month, last-3-months, last-6-months, or last-12-months.",
+                    ],
+                });
+            return invalidResult;
+        }
+
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var offering = await dashboardRepository.GetPrimaryOfferingAsync(userId, cancellationToken);
+
+        if (offering?.Funding == null || offering.DealTerms == null)
+        {
+            var empty = FundraiserDashboardMappers.Empty();
+            var emptyResult = new Result<FundraiserDashboardResponse>();
+            emptyResult.AddValue(empty);
+            emptyResult.OK();
+            return emptyResult;
+        }
+
+        var holdings = await dashboardRepository.GetHoldingsForOfferingAsync(offering.Id, cancellationToken);
+        var response = FundraiserDashboardMappers.ToResponse(offering, holdings, SizeBuckets);
+
+        var result = new Result<FundraiserDashboardResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}
+
+internal static class FundraiserDashboardMappers
+{
+    public static FundraiserDashboardResponse Empty() =>
+        new(
+            null,
+            null,
+            null,
+            "NGN",
+            new FundraiserDashboardSummaryDto(0m, 0, 0, 0m),
+            new FundraiserFundingProgressDto(0m, 0m, 0m, 0m, "week", 0),
+            new FundraiserInvestorBreakdownDto(
+                "size",
+                SizeBucketLabels().Select(label => new FundraiserBreakdownBucketDto(label, 0)).ToList()),
+            []);
+
+    public static FundraiserDashboardResponse ToResponse(
+        InvestmentOffering offering,
+        IReadOnlyList<InvestorHolding> holdings,
+        (string Label, decimal MinInclusive, decimal? MaxExclusive)[] sizeBuckets)
+    {
+        var funding = offering.Funding!;
+        var dealTerms = offering.DealTerms!;
+        var raised = funding.RaisedAmount;
+        var investors = funding.InvestorCount;
+        var goal = dealTerms.FundingGoal;
+        var threshold = dealTerms.MinimumThreshold;
+        var daysRemaining = InvestmentMappers.ComputeDaysLeft(dealTerms.Deadline) ?? 0;
+        var average = investors > 0 ? decimal.Round(raised / investors, 2, MidpointRounding.AwayFromZero) : 0m;
+        var velocity = ComputeWeeklyVelocity(holdings);
+        var confidence = ComputeConfidenceRate(
+            raised,
+            goal,
+            threshold,
+            offering.PublishedAt,
+            dealTerms.Deadline);
+
+        return new FundraiserDashboardResponse(
+            offering.Id,
+            offering.Slug,
+            offering.Name,
+            "NGN",
+            new FundraiserDashboardSummaryDto(raised, investors, daysRemaining, average),
+            new FundraiserFundingProgressDto(raised, goal, threshold, velocity, "week", confidence),
+            new FundraiserInvestorBreakdownDto("size", BuildSizeBuckets(holdings, sizeBuckets)),
+            BuildMilestones(offering, raised, goal, dealTerms.Deadline));
+    }
+
+    private static IReadOnlyList<string> SizeBucketLabels() =>
+    [
+        "0 - 5M",
+        "6M - 20M",
+        "21M - 100M",
+        "101M - 500M",
+    ];
+
+    private static decimal ComputeWeeklyVelocity(IReadOnlyList<InvestorHolding> holdings)
+    {
+        var weekStart = DateTime.UtcNow.AddDays(-7);
+        return holdings
+            .Where(h => h.InvestedAt >= weekStart)
+            .Sum(h => h.InvestedAmount);
+    }
+
+    private static int ComputeConfidenceRate(
+        decimal raised,
+        decimal goal,
+        decimal threshold,
+        DateTime? publishedAt,
+        DateTime deadline)
+    {
+        if (goal <= 0)
+        {
+            return 0;
+        }
+
+        var goalProgress = (double)(raised / goal);
+        var start = publishedAt ?? deadline.AddDays(-90);
+        var totalDays = Math.Max((deadline - start).TotalDays, 1);
+        var elapsedDays = Math.Clamp((DateTime.UtcNow - start).TotalDays, 0, totalDays);
+        var timeProgress = elapsedDays / totalDays;
+        var paceScore = timeProgress <= 0.01
+            ? Math.Min(1, goalProgress)
+            : Math.Min(1, goalProgress / timeProgress);
+
+        var confidence = (int)Math.Round(Math.Clamp(paceScore * 100, 0, 100), MidpointRounding.AwayFromZero);
+        if (raised >= threshold && threshold > 0)
+        {
+            confidence = Math.Min(100, confidence + 5);
+        }
+
+        return confidence;
+    }
+
+    private static IReadOnlyList<FundraiserBreakdownBucketDto> BuildSizeBuckets(
+        IReadOnlyList<InvestorHolding> holdings,
+        (string Label, decimal MinInclusive, decimal? MaxExclusive)[] sizeBuckets)
+    {
+        if (holdings.Count == 0)
+        {
+            return sizeBuckets
+                .Select(b => new FundraiserBreakdownBucketDto(b.Label, 0))
+                .ToList();
+        }
+
+        var total = holdings.Count;
+        return sizeBuckets
+            .Select(bucket =>
+            {
+                var count = holdings.Count(h =>
+                    h.InvestedAmount >= bucket.MinInclusive
+                    && (!bucket.MaxExclusive.HasValue || h.InvestedAmount < bucket.MaxExclusive.Value));
+                var percentage = (int)Math.Round(count * 100m / total, MidpointRounding.AwayFromZero);
+                return new FundraiserBreakdownBucketDto(bucket.Label, percentage);
+            })
+            .ToList();
+    }
+
+    private static IReadOnlyList<FundraiserMilestoneDto> BuildMilestones(
+        InvestmentOffering offering,
+        decimal raised,
+        decimal goal,
+        DateTime deadline)
+    {
+        var launchCompleted = offering.PublishedAt.HasValue;
+        var launchDate = offering.PublishedAt ?? offering.CreatedAt;
+
+        var pct25 = goal * 0.25m;
+        var pct50 = goal * 0.50m;
+        var pct75 = goal * 0.75m;
+        var closed = offering.Status == OfferingStatus.Closed || DateTime.UtcNow >= deadline;
+
+        var funded25 = ResolvePercentStatus(raised, pct25, launchCompleted);
+        var funded50 = ResolvePercentStatus(raised, pct50, funded25 == "completed");
+        var funded75 = ResolvePercentStatus(raised, pct75, funded50 == "completed");
+        var closedStatus = closed ? "completed" : funded75 == "completed" ? "active" : "pending";
+
+        return
+        [
+            new FundraiserMilestoneDto(
+                "launch",
+                "Launch",
+                "Campaign published",
+                FormatDateLabel(launchDate, completed: launchCompleted),
+                launchCompleted ? "completed" : "pending"),
+            new FundraiserMilestoneDto(
+                "funded_25",
+                "25% Funded",
+                "Quarter of funding goal reached",
+                TargetDateLabel(launchDate, deadline, 0.25),
+                funded25),
+            new FundraiserMilestoneDto(
+                "funded_50",
+                "50% Funded",
+                "Halfway to funding goal",
+                TargetDateLabel(launchDate, deadline, 0.50),
+                funded50),
+            new FundraiserMilestoneDto(
+                "funded_75",
+                "75% Funded",
+                "Three-quarters of funding goal reached",
+                TargetDateLabel(launchDate, deadline, 0.75),
+                funded75),
+            new FundraiserMilestoneDto(
+                "campaign_closed",
+                "Campaign closed",
+                "Fundraising campaign ended",
+                $"Target: {deadline:MMM d}",
+                closedStatus),
+        ];
+    }
+
+    private static string ResolvePercentStatus(decimal raised, decimal thresholdAmount, bool previousCompleted)
+    {
+        if (raised >= thresholdAmount)
+        {
+            return "completed";
+        }
+
+        return previousCompleted ? "active" : "pending";
+    }
+
+    private static string FormatDateLabel(DateTime date, bool completed) =>
+        completed ? date.ToString("MMM d, yyyy") : $"Target: {date:MMM d}";
+
+    private static string TargetDateLabel(DateTime campaignStart, DateTime deadline, double fractionAlongCampaign)
+    {
+        var totalDays = (deadline - campaignStart).TotalDays;
+        if (totalDays <= 0)
+        {
+            return $"Target: {deadline:MMM d}";
+        }
+
+        var clampedFraction = Math.Clamp(fractionAlongCampaign, 0, 1);
+        var target = campaignStart.AddDays(totalDays * clampedFraction);
+        return $"Target: {target:MMM d}";
+    }
+}

--- a/Antital.Domain/Interfaces/IFundraiserDashboardRepository.cs
+++ b/Antital.Domain/Interfaces/IFundraiserDashboardRepository.cs
@@ -1,0 +1,12 @@
+using Antital.Domain.Models;
+
+namespace Antital.Domain.Interfaces;
+
+public interface IFundraiserDashboardRepository
+{
+    Task<InvestmentOffering?> GetPrimaryOfferingAsync(int ownerUserId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<InvestorHolding>> GetHoldingsForOfferingAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default);
+}

--- a/Antital.Domain/Models/InvestmentOffering.cs
+++ b/Antital.Domain/Models/InvestmentOffering.cs
@@ -14,6 +14,8 @@ public class InvestmentOffering : TrackableEntity
     public OfferingStatus Status { get; set; }
     public DateTime? PublishedAt { get; set; }
 
+    public int? OwnerUserId { get; set; }
+    public User? Owner { get; set; }
     public OfferingFunding? Funding { get; set; }
     public DealTerms? DealTerms { get; set; }
     public OfferingCorporateProfile? CorporateProfile { get; set; }

--- a/Antital.Infrastructure/AntitalDBContext.cs
+++ b/Antital.Infrastructure/AntitalDBContext.cs
@@ -242,6 +242,14 @@ public class AntitalDBContext(
             entity.Property(e => e.Category).HasMaxLength(100).IsRequired();
             entity.Property(e => e.Tagline).HasMaxLength(500).IsRequired();
             entity.Property(e => e.CoverImageUrl).HasMaxLength(500).IsRequired();
+
+            entity.HasOne(e => e.Owner)
+                .WithMany()
+                .HasForeignKey(e => e.OwnerUserId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasIndex(e => e.OwnerUserId)
+                .HasFilter("\"OwnerUserId\" IS NOT NULL AND \"IsDeleted\" = false");
         });
 
         modelBuilder.Entity<OfferingFunding>(entity =>

--- a/Antital.Infrastructure/Migrations/20260721050705_AddOfferingOwnerUserId.Designer.cs
+++ b/Antital.Infrastructure/Migrations/20260721050705_AddOfferingOwnerUserId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Antital.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Antital.Infrastructure.Migrations
 {
     [DbContext(typeof(AntitalDBContext))]
-    partial class AntitalDBContextModelSnapshot : ModelSnapshot
+    [Migration("20260721050705_AddOfferingOwnerUserId")]
+    partial class AddOfferingOwnerUserId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Antital.Infrastructure/Migrations/20260721050705_AddOfferingOwnerUserId.cs
+++ b/Antital.Infrastructure/Migrations/20260721050705_AddOfferingOwnerUserId.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Antital.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOfferingOwnerUserId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "OwnerUserId",
+                table: "InvestmentOfferings",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvestmentOfferings_OwnerUserId",
+                table: "InvestmentOfferings",
+                column: "OwnerUserId",
+                filter: "\"OwnerUserId\" IS NOT NULL AND \"IsDeleted\" = false");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_InvestmentOfferings_Users_OwnerUserId",
+                table: "InvestmentOfferings",
+                column: "OwnerUserId",
+                principalTable: "Users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_InvestmentOfferings_Users_OwnerUserId",
+                table: "InvestmentOfferings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InvestmentOfferings_OwnerUserId",
+                table: "InvestmentOfferings");
+
+            migrationBuilder.DropColumn(
+                name: "OwnerUserId",
+                table: "InvestmentOfferings");
+        }
+    }
+}

--- a/Antital.Infrastructure/Repositories/FundraiserDashboardRepository.cs
+++ b/Antital.Infrastructure/Repositories/FundraiserDashboardRepository.cs
@@ -1,0 +1,36 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Antital.Infrastructure.Repositories;
+
+public class FundraiserDashboardRepository(AntitalDBContext context) : IFundraiserDashboardRepository
+{
+    public async Task<InvestmentOffering?> GetPrimaryOfferingAsync(
+        int ownerUserId,
+        CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+
+        return await context.InvestmentOfferings
+            .AsNoTracking()
+            .Include(o => o.Funding)
+            .Include(o => o.DealTerms)
+            .Where(o => o.OwnerUserId == ownerUserId && !o.IsDeleted)
+            .OrderByDescending(o => o.Status == OfferingStatus.Published)
+            .ThenBy(o => o.DealTerms != null && o.DealTerms.Deadline >= now ? 0 : 1)
+            .ThenBy(o => o.DealTerms != null ? o.DealTerms.Deadline : DateTime.MaxValue)
+            .ThenByDescending(o => o.PublishedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<InvestorHolding>> GetHoldingsForOfferingAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default) =>
+        await context.InvestorHoldings
+            .AsNoTracking()
+            .Where(h => h.OfferingId == offeringId && !h.IsDeleted)
+            .OrderByDescending(h => h.InvestedAt)
+            .ToListAsync(cancellationToken);
+}

--- a/Antital.Infrastructure/Seed/FundraiserOfferingOwnershipSeed.cs
+++ b/Antital.Infrastructure/Seed/FundraiserOfferingOwnershipSeed.cs
@@ -1,0 +1,66 @@
+using Antital.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Antital.Infrastructure.Seed;
+
+/// <summary>
+/// Assigns seeded / unowned published offerings to fundraiser users for local dashboard testing.
+/// Idempotent: only updates offerings where <c>OwnerUserId</c> is null.
+/// </summary>
+public static class FundraiserOfferingOwnershipSeed
+{
+    private const string PreferredFundraiserEmail = "johneseyin@gmail.com";
+    private const string PreferredOfferingSlug = "greentech-solutions";
+
+    public static async Task SeedAsync(
+        AntitalDBContext context,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        var unownedOfferings = await context.InvestmentOfferings
+            .Where(o => !o.IsDeleted && o.OwnerUserId == null)
+            .OrderBy(o => o.Id)
+            .ToListAsync(cancellationToken);
+
+        if (unownedOfferings.Count == 0)
+        {
+            return;
+        }
+
+        var fundraisers = await context.Users
+            .Where(u => u.UserType == UserTypeEnum.FundRaiser && !u.IsDeleted)
+            .OrderBy(u => u.Id)
+            .ToListAsync(cancellationToken);
+
+        if (fundraisers.Count == 0)
+        {
+            logger.LogInformation(
+                "Fundraiser offering ownership seed skipped: no fundraiser users found.");
+            return;
+        }
+
+        var preferredOwner = fundraisers.FirstOrDefault(u =>
+            string.Equals(u.Email, PreferredFundraiserEmail, StringComparison.OrdinalIgnoreCase))
+            ?? fundraisers[0];
+
+        var preferredOffering = unownedOfferings.FirstOrDefault(o => o.Slug == PreferredOfferingSlug)
+            ?? unownedOfferings[0];
+
+        preferredOffering.OwnerUserId = preferredOwner.Id;
+
+        // Round-robin remaining unowned offerings across fundraisers (dev convenience).
+        var otherOfferings = unownedOfferings.Where(o => o.Id != preferredOffering.Id).ToList();
+        for (var i = 0; i < otherOfferings.Count; i++)
+        {
+            otherOfferings[i].OwnerUserId = fundraisers[i % fundraisers.Count].Id;
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+        logger.LogInformation(
+            "Assigned OwnerUserId on {Count} investment offerings (primary: {Slug} → {Email}).",
+            unownedOfferings.Count,
+            preferredOffering.Slug,
+            preferredOwner.Email);
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/FundraisersControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/FundraisersControllerTests.cs
@@ -1,0 +1,265 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Test.Integration;
+using BuildingBlocks.Application.Features;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Antital.Test.Integration.API.Controllers;
+
+[Collection("IntegrationTests")]
+public class FundraisersControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>, IDisposable
+{
+    private readonly CustomWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+    private readonly IServiceScope _scope;
+    private readonly AntitalDBContext _context;
+    private readonly IConfiguration _config;
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+
+    public FundraisersControllerTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+        _scope = _factory.Services.CreateScope();
+        _context = _scope.ServiceProvider.GetRequiredService<AntitalDBContext>();
+        _config = _scope.ServiceProvider.GetRequiredService<IConfiguration>();
+        CleanupDatabase();
+    }
+
+    [Fact]
+    public async Task GetDashboard_WithoutAuth_Returns401()
+    {
+        var response = await _client.GetAsync("/api/fundraisers/me/dashboard");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetDashboard_InvestorUser_Returns403()
+    {
+        var user = SeedUser("investor-fundraiser-dash@example.com", UserTypeEnum.IndividualInvestor);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/dashboard");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetDashboard_InvalidPeriod_ReturnsValidationError()
+    {
+        var user = SeedUser("fundraiser-period@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/dashboard?period=active");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserDashboardResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeFalse();
+        result.ValidationErrors.Should().ContainKey("period");
+    }
+
+    [Fact]
+    public async Task GetDashboard_NoOwnedOffering_ReturnsEmptyZeros()
+    {
+        var user = SeedUser("fundraiser-empty@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/dashboard?period=this-month");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserDashboardResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.OfferingId.Should().BeNull();
+        result.Value.Summary.TotalAmountRaised.Should().Be(0m);
+        result.Value.Summary.TotalInvestors.Should().Be(0);
+        result.Value.FundingProgress.RaisedAmount.Should().Be(0m);
+        result.Value.InvestorBreakdown.Buckets.Should().HaveCount(4);
+        result.Value.Milestones.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetDashboard_OwnedOfferingWithHoldings_ReturnsAggregates()
+    {
+        var fundraiser = SeedUser("fundraiser-owned@example.com", UserTypeEnum.FundRaiser);
+        var investor = SeedUser("holding-investor@example.com", UserTypeEnum.IndividualInvestor);
+        await _context.SaveChangesAsync();
+
+        var offering = await SeedOwnedOfferingAsync(fundraiser.Id, "fundraiser-campaign");
+        await SeedHoldingsAsync(offering.Id, investor.Id);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/dashboard?period=this-month");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserDashboardResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.OfferingId.Should().Be(offering.Id);
+        result.Value.OfferingSlug.Should().Be("fundraiser-campaign");
+        result.Value.Summary.TotalAmountRaised.Should().Be(142_500_000m);
+        result.Value.Summary.TotalInvestors.Should().Be(2);
+        result.Value.Summary.AverageInvestmentSize.Should().Be(71_250_000m);
+        result.Value.Summary.DaysRemaining.Should().BeGreaterThan(0);
+        result.Value.FundingProgress.TargetAmount.Should().Be(200_000_000m);
+        result.Value.FundingProgress.MinimumThreshold.Should().Be(100_000_000m);
+        result.Value.FundingProgress.CurrentVelocity.Should().Be(12_500_000m);
+        result.Value.FundingProgress.VelocityPeriod.Should().Be("week");
+        result.Value.InvestorBreakdown.Dimension.Should().Be("size");
+        result.Value.InvestorBreakdown.Buckets.Sum(b => b.Percentage).Should().Be(100);
+        result.Value.Milestones.Should().HaveCount(5);
+        result.Value.Milestones.First(m => m.Key == "launch").Status.Should().Be("completed");
+        result.Value.Milestones.First(m => m.Key == "funded_50").Status.Should().Be("completed");
+    }
+
+    private User SeedUser(string email, UserTypeEnum userType)
+    {
+        var user = new User
+        {
+            Email = email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
+            UserType = userType,
+            IsEmailVerified = true,
+            FirstName = "Jane",
+            LastName = "Okonkwo",
+            PhoneNumber = "+2348012345678",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            Nationality = "Nigerian",
+            CountryOfResidence = "Nigeria",
+            StateOfResidence = "Lagos",
+            ResidentialAddress = "123 Main Street",
+            HasAgreedToTerms = true,
+        };
+        _context.Users.Add(user);
+        return user;
+    }
+
+    private async Task<InvestmentOffering> SeedOwnedOfferingAsync(int ownerUserId, string slug)
+    {
+        var offering = new InvestmentOffering
+        {
+            OwnerUserId = ownerUserId,
+            Slug = slug,
+            Name = "Fundraiser Campaign",
+            Category = "Energy",
+            Tagline = "Solar innovation",
+            CoverImageUrl = "/investments/ayka_solar.jpg",
+            RiskLevel = OfferingRiskLevel.Low,
+            Status = OfferingStatus.Published,
+            PublishedAt = DateTime.UtcNow.AddDays(-45),
+            Funding = new OfferingFunding
+            {
+                RaisedAmount = 142_500_000m,
+                FundingGoal = 200_000_000m,
+                InvestorCount = 2,
+                SharePrice = 100m,
+                MinInvestment = 1_000_000m,
+                MaxInvestment = 100_000_000m,
+            },
+            DealTerms = new DealTerms
+            {
+                TotalSharesOffered = 10_000,
+                PricePerShare = 100m,
+                MinimumInvestment = 1_000_000m,
+                MaximumInvestment = 100_000_000m,
+                MinimumThreshold = 100_000_000m,
+                FundingGoal = 200_000_000m,
+                Deadline = DateTime.UtcNow.AddDays(18),
+            },
+        };
+        offering.Created("TestUser");
+        offering.Funding.Created("TestUser");
+        offering.DealTerms.Created("TestUser");
+        _context.InvestmentOfferings.Add(offering);
+        await _context.SaveChangesAsync();
+        return offering;
+    }
+
+    private async Task SeedHoldingsAsync(int offeringId, int investorUserId)
+    {
+        var recent = new InvestorHolding
+        {
+            UserId = investorUserId,
+            OfferingId = offeringId,
+            InvestedAmount = 12_500_000m,
+            CurrentValue = 12_500_000m,
+            Returns = 0m,
+            UnitHolding = 100,
+            InvestedAt = DateTime.UtcNow.AddDays(-2),
+        };
+        recent.Created("TestUser");
+
+        var older = new InvestorHolding
+        {
+            UserId = investorUserId,
+            OfferingId = offeringId,
+            InvestedAmount = 130_000_000m,
+            CurrentValue = 130_000_000m,
+            Returns = 0m,
+            UnitHolding = 1000,
+            InvestedAt = DateTime.UtcNow.AddDays(-20),
+        };
+        older.Created("TestUser");
+
+        _context.InvestorHoldings.AddRange(recent, older);
+        await _context.SaveChangesAsync();
+    }
+
+    private HttpClient CreateAuthorizedClient(int userId, string email)
+    {
+        var client = _factory.CreateClient();
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_config["Jwt:Key"]!);
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _config["Jwt:Issuer"],
+            Audience = _config["Jwt:Audience"],
+            Expires = DateTime.UtcNow.AddHours(1),
+            Subject = new ClaimsIdentity(
+            [
+                new Claim("UserId", userId.ToString()),
+                new Claim(ClaimTypes.Email, email),
+            ]),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256),
+        };
+
+        var token = tokenHandler.CreateToken(descriptor);
+        var jwt = tokenHandler.WriteToken(token);
+
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+        return client;
+    }
+
+    private void CleanupDatabase()
+    {
+        _context.InvestorHoldings.RemoveRange(_context.InvestorHoldings);
+        _context.InvestmentOfferings.RemoveRange(_context.InvestmentOfferings.IgnoreQueryFilters());
+        _context.Users.RemoveRange(_context.Users);
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        CleanupDatabase();
+        _scope.Dispose();
+        _client.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `OwnerUserId` on investment offerings (migration + ownership seed) so campaigns can be scoped to a fundraiser.
- Expose `GET /api/fundraisers/me/dashboard` with summary, funding progress, investor size breakdown, and derived milestones.
- Cover auth/empty/populated paths with integration tests.

## Test plan
- [ ] `dotnet test --filter FullyQualifiedName~FundraisersControllerTests` passes
- [ ] Swagger shows Fundraisers → `GET /api/fundraisers/me/dashboard`
- [ ] Login as fundraiser → call dashboard endpoint returns owned campaign metrics (or zeros if none)
- [ ] Investor token receives 403; unauthenticated receives 401
- [ ] Confirm `appsettings.Development.json` / local secrets are not included in this PR


Made with [Cursor](https://cursor.com)