### PR TITLE
Add fundraiser campaign and update APIs

### DIFF
--- a/Antital.API/Configs/DependencyInjection.cs
+++ b/Antital.API/Configs/DependencyInjection.cs
@@ -69,6 +69,7 @@ public static class DependencyInjection
         services.AddScoped(typeof(IInvestmentOfferingRepository), typeof(InvestmentOfferingRepository));
         services.AddScoped(typeof(IInvestorDashboardRepository), typeof(InvestorDashboardRepository));
         services.AddScoped(typeof(IFundraiserDashboardRepository), typeof(FundraiserDashboardRepository));
+        services.AddScoped(typeof(IFundraiserCampaignUpdatesRepository), typeof(FundraiserCampaignUpdatesRepository));
         services.AddScoped(typeof(IInvestmentOrderRepository), typeof(InvestmentOrderRepository));
         services.AddScoped(typeof(IInvestorPaymentMethodRepository), typeof(InvestorPaymentMethodRepository));
         services.AddScoped(typeof(IInvestorWatchlistRepository), typeof(InvestorWatchlistRepository));

--- a/Antital.API/Controllers/FundraisersController.cs
+++ b/Antital.API/Controllers/FundraisersController.cs
@@ -1,4 +1,8 @@
 using Antital.Application.DTOs.Fundraisers;
+using Antital.Application.Features.Fundraisers.CampaignUpdates.CreateFundraiserCampaignUpdate;
+using Antital.Application.Features.Fundraisers.CampaignUpdates.ListFundraiserCampaignUpdates;
+using Antital.Application.Features.Fundraisers.CampaignUpdates.UpdateFundraiserCampaignUpdate;
+using Antital.Application.Features.Fundraisers.GetFundraiserCampaign;
 using Antital.Application.Features.Fundraisers.GetFundraiserDashboard;
 using BuildingBlocks.API.Controllers;
 using BuildingBlocks.Application.Features;
@@ -28,6 +32,78 @@ public class FundraisersController(IMediator mediator) : BaseController
         CancellationToken cancellationToken = default)
     {
         var result = await mediator.Send(new GetFundraiserDashboardQuery(period), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpGet("me/campaign")]
+    [SwaggerOperation(
+        "Get Fundraiser Campaign",
+        "Returns the authenticated fundraiser's primary owned offering context for the campaigns page.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserCampaignResponse>))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    public async Task<IActionResult> GetCampaign(CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(new GetFundraiserCampaignQuery(), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpGet("me/campaign/updates")]
+    [SwaggerOperation(
+        "List Campaign Updates",
+        "Returns draft and/or published updates for the authenticated fundraiser's primary owned campaign.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserCampaignUpdatesResponse>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid status", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    public async Task<IActionResult> ListCampaignUpdates(
+        [FromQuery] string status = "all",
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new ListFundraiserCampaignUpdatesQuery(status, page, pageSize),
+            cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpPost("me/campaign/updates")]
+    [SwaggerOperation(
+        "Create Campaign Update",
+        "Creates a draft or published update for the authenticated fundraiser's primary owned campaign.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserCampaignUpdateDto>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "No owned campaign", typeof(void))]
+    public async Task<IActionResult> CreateCampaignUpdate(
+        [FromBody] CreateFundraiserCampaignUpdateRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new CreateFundraiserCampaignUpdateCommand(request.Title, request.Body, request.Publish),
+            cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpPatch("me/campaign/updates/{updateId:int}")]
+    [SwaggerOperation(
+        "Update Campaign Update",
+        "Edits title/body and/or publishes a draft owned by the authenticated fundraiser.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserCampaignUpdateDto>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Update or campaign not found", typeof(void))]
+    public async Task<IActionResult> UpdateCampaignUpdate(
+        int updateId,
+        [FromBody] UpdateFundraiserCampaignUpdateRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new UpdateFundraiserCampaignUpdateCommand(updateId, request.Title, request.Body, request.Publish),
+            cancellationToken);
         return ApiResult(result);
     }
 }

--- a/Antital.Application/DTOs/Fundraisers/FundraiserCampaignDtos.cs
+++ b/Antital.Application/DTOs/Fundraisers/FundraiserCampaignDtos.cs
@@ -1,0 +1,8 @@
+namespace Antital.Application.DTOs.Fundraisers;
+
+public record FundraiserCampaignResponse(
+    int? OfferingId,
+    string? OfferingSlug,
+    string? OfferingName,
+    string? Status,
+    string? PublicPath);

--- a/Antital.Application/DTOs/Fundraisers/FundraiserCampaignUpdateDtos.cs
+++ b/Antital.Application/DTOs/Fundraisers/FundraiserCampaignUpdateDtos.cs
@@ -1,0 +1,25 @@
+namespace Antital.Application.DTOs.Fundraisers;
+
+public record FundraiserCampaignUpdateDto(
+    int Id,
+    string Title,
+    string Body,
+    string Status,
+    DateTime? PublishedAt,
+    int LikeCount);
+
+public record FundraiserCampaignUpdatesResponse(
+    IReadOnlyList<FundraiserCampaignUpdateDto> Items,
+    int Page,
+    int PageSize,
+    int TotalCount);
+
+public record CreateFundraiserCampaignUpdateRequest(
+    string Title,
+    string Body,
+    bool Publish);
+
+public record UpdateFundraiserCampaignUpdateRequest(
+    string? Title,
+    string? Body,
+    bool? Publish);

--- a/Antital.Application/Features/Fundraisers/CampaignUpdates/CreateFundraiserCampaignUpdate/CreateFundraiserCampaignUpdateCommand.cs
+++ b/Antital.Application/Features/Fundraisers/CampaignUpdates/CreateFundraiserCampaignUpdate/CreateFundraiserCampaignUpdateCommand.cs
@@ -1,0 +1,76 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using BuildingBlocks.Domain.Interfaces;
+
+namespace Antital.Application.Features.Fundraisers.CampaignUpdates.CreateFundraiserCampaignUpdate;
+
+public record CreateFundraiserCampaignUpdateCommand(
+    string Title,
+    string Body,
+    bool Publish
+) : ICommandQuery<FundraiserCampaignUpdateDto>;
+
+public class CreateFundraiserCampaignUpdateCommandHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserDashboardRepository dashboardRepository,
+    IFundraiserCampaignUpdatesRepository updatesRepository,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser
+) : ICommandQueryHandler<CreateFundraiserCampaignUpdateCommand, FundraiserCampaignUpdateDto>
+{
+    public async Task<Result<FundraiserCampaignUpdateDto>> Handle(
+        CreateFundraiserCampaignUpdateCommand request,
+        CancellationToken cancellationToken)
+    {
+        var title = request.Title?.Trim() ?? string.Empty;
+        var body = request.Body?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(title) || string.IsNullOrWhiteSpace(body))
+        {
+            var invalid = new Result<FundraiserCampaignUpdateDto>();
+            invalid.BadRequest(
+                "Title and body are required.",
+                new Dictionary<string, string[]>
+                {
+                    ["title"] = string.IsNullOrWhiteSpace(title) ? ["Title is required."] : [],
+                    ["body"] = string.IsNullOrWhiteSpace(body) ? ["Body is required."] : [],
+                }.Where(kv => kv.Value.Length > 0).ToDictionary(kv => kv.Key, kv => kv.Value));
+            return invalid;
+        }
+
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var offering = await dashboardRepository.GetPrimaryOfferingAsync(userId, cancellationToken);
+        if (offering == null)
+        {
+            throw new NotFoundException("No owned fundraising campaign found.");
+        }
+
+        var now = DateTime.UtcNow;
+        var update = new OfferingUpdate
+        {
+            OfferingId = offering.Id,
+            Title = title,
+            Body = body,
+            Status = request.Publish ? OfferingUpdateStatus.Published : OfferingUpdateStatus.Draft,
+            PublishedAt = request.Publish ? now : null,
+            LikeCount = 0,
+        };
+        update.Created(ResolveActor());
+
+        await updatesRepository.AddAsync(update, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        var result = new Result<FundraiserCampaignUpdateDto>();
+        result.AddValue(FundraiserCampaignUpdateMappers.ToDto(update));
+        result.OK();
+        return result;
+    }
+
+    private string ResolveActor() =>
+        !string.IsNullOrEmpty(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrEmpty(currentUser.IPAddress) ? currentUser.IPAddress : "System");
+}

--- a/Antital.Application/Features/Fundraisers/CampaignUpdates/FundraiserCampaignUpdateMappers.cs
+++ b/Antital.Application/Features/Fundraisers/CampaignUpdates/FundraiserCampaignUpdateMappers.cs
@@ -1,0 +1,51 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+
+namespace Antital.Application.Features.Fundraisers.CampaignUpdates;
+
+internal static class FundraiserCampaignUpdateMappers
+{
+    public static FundraiserCampaignUpdateDto ToDto(OfferingUpdate update) =>
+        new(
+            update.Id,
+            update.Title,
+            update.Body,
+            ToStatusString(update.Status),
+            update.PublishedAt,
+            update.LikeCount);
+
+    public static string ToStatusString(OfferingUpdateStatus status) =>
+        status switch
+        {
+            OfferingUpdateStatus.Draft => "draft",
+            OfferingUpdateStatus.Published => "published",
+            _ => status.ToString().ToLowerInvariant(),
+        };
+
+    public static bool TryParseStatusFilter(string? status, out OfferingUpdateStatus? parsed, out string? error)
+    {
+        parsed = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(status) || status.Equals("all", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (status.Equals("draft", StringComparison.OrdinalIgnoreCase))
+        {
+            parsed = OfferingUpdateStatus.Draft;
+            return true;
+        }
+
+        if (status.Equals("published", StringComparison.OrdinalIgnoreCase))
+        {
+            parsed = OfferingUpdateStatus.Published;
+            return true;
+        }
+
+        error = "Status must be all, draft, or published.";
+        return false;
+    }
+}

--- a/Antital.Application/Features/Fundraisers/CampaignUpdates/ListFundraiserCampaignUpdates/ListFundraiserCampaignUpdatesQuery.cs
+++ b/Antital.Application/Features/Fundraisers/CampaignUpdates/ListFundraiserCampaignUpdates/ListFundraiserCampaignUpdatesQuery.cs
@@ -1,0 +1,64 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Fundraisers.CampaignUpdates.ListFundraiserCampaignUpdates;
+
+public record ListFundraiserCampaignUpdatesQuery(
+    string? Status = "all",
+    int Page = 1,
+    int PageSize = 20
+) : ICommandQuery<FundraiserCampaignUpdatesResponse>;
+
+public class ListFundraiserCampaignUpdatesQueryHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserDashboardRepository dashboardRepository,
+    IFundraiserCampaignUpdatesRepository updatesRepository
+) : ICommandQueryHandler<ListFundraiserCampaignUpdatesQuery, FundraiserCampaignUpdatesResponse>
+{
+    private const int MaxPageSize = 50;
+
+    public async Task<Result<FundraiserCampaignUpdatesResponse>> Handle(
+        ListFundraiserCampaignUpdatesQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (!FundraiserCampaignUpdateMappers.TryParseStatusFilter(request.Status, out var statusFilter, out var statusError))
+        {
+            var invalid = new Result<FundraiserCampaignUpdatesResponse>();
+            invalid.BadRequest(
+                "Invalid status.",
+                new Dictionary<string, string[]> { ["status"] = [statusError!] });
+            return invalid;
+        }
+
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var offering = await dashboardRepository.GetPrimaryOfferingAsync(userId, cancellationToken);
+
+        var page = request.Page < 1 ? 1 : request.Page;
+        var pageSize = request.PageSize < 1 ? 20 : Math.Min(request.PageSize, MaxPageSize);
+
+        if (offering == null)
+        {
+            var empty = new Result<FundraiserCampaignUpdatesResponse>();
+            empty.AddValue(new FundraiserCampaignUpdatesResponse([], page, pageSize, 0));
+            empty.OK();
+            return empty;
+        }
+
+        var (items, totalCount) = await updatesRepository.ListUpdatesAsync(
+            offering.Id,
+            statusFilter,
+            page,
+            pageSize,
+            cancellationToken);
+
+        var result = new Result<FundraiserCampaignUpdatesResponse>();
+        result.AddValue(new FundraiserCampaignUpdatesResponse(
+            items.Select(FundraiserCampaignUpdateMappers.ToDto).ToList(),
+            page,
+            pageSize,
+            totalCount));
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Fundraisers/CampaignUpdates/UpdateFundraiserCampaignUpdate/UpdateFundraiserCampaignUpdateCommand.cs
+++ b/Antital.Application/Features/Fundraisers/CampaignUpdates/UpdateFundraiserCampaignUpdate/UpdateFundraiserCampaignUpdateCommand.cs
@@ -1,0 +1,92 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using BuildingBlocks.Domain.Interfaces;
+
+namespace Antital.Application.Features.Fundraisers.CampaignUpdates.UpdateFundraiserCampaignUpdate;
+
+public record UpdateFundraiserCampaignUpdateCommand(
+    int UpdateId,
+    string? Title,
+    string? Body,
+    bool? Publish
+) : ICommandQuery<FundraiserCampaignUpdateDto>;
+
+public class UpdateFundraiserCampaignUpdateCommandHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserDashboardRepository dashboardRepository,
+    IFundraiserCampaignUpdatesRepository updatesRepository,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser
+) : ICommandQueryHandler<UpdateFundraiserCampaignUpdateCommand, FundraiserCampaignUpdateDto>
+{
+    public async Task<Result<FundraiserCampaignUpdateDto>> Handle(
+        UpdateFundraiserCampaignUpdateCommand request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var offering = await dashboardRepository.GetPrimaryOfferingAsync(userId, cancellationToken);
+        if (offering == null)
+        {
+            throw new NotFoundException("No owned fundraising campaign found.");
+        }
+
+        var update = await updatesRepository.GetByIdAsync(request.UpdateId, cancellationToken);
+        if (update == null || update.OfferingId != offering.Id)
+        {
+            throw new NotFoundException("Campaign update not found.");
+        }
+
+        if (request.Title != null)
+        {
+            var title = request.Title.Trim();
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                var invalid = new Result<FundraiserCampaignUpdateDto>();
+                invalid.BadRequest(
+                    "Title is required.",
+                    new Dictionary<string, string[]> { ["title"] = ["Title is required."] });
+                return invalid;
+            }
+
+            update.Title = title;
+        }
+
+        if (request.Body != null)
+        {
+            var body = request.Body.Trim();
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                var invalid = new Result<FundraiserCampaignUpdateDto>();
+                invalid.BadRequest(
+                    "Body is required.",
+                    new Dictionary<string, string[]> { ["body"] = ["Body is required."] });
+                return invalid;
+            }
+
+            update.Body = body;
+        }
+
+        if (request.Publish == true && update.Status != OfferingUpdateStatus.Published)
+        {
+            update.Status = OfferingUpdateStatus.Published;
+            update.PublishedAt = DateTime.UtcNow;
+        }
+
+        update.Updated(ResolveActor());
+        await updatesRepository.UpdateAsync(update, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        var result = new Result<FundraiserCampaignUpdateDto>();
+        result.AddValue(FundraiserCampaignUpdateMappers.ToDto(update));
+        result.OK();
+        return result;
+    }
+
+    private string ResolveActor() =>
+        !string.IsNullOrEmpty(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrEmpty(currentUser.IPAddress) ? currentUser.IPAddress : "System");
+}

--- a/Antital.Application/Features/Fundraisers/GetFundraiserCampaign/GetFundraiserCampaignQuery.cs
+++ b/Antital.Application/Features/Fundraisers/GetFundraiserCampaign/GetFundraiserCampaignQuery.cs
@@ -1,0 +1,41 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Fundraisers.GetFundraiserCampaign;
+
+public record GetFundraiserCampaignQuery : ICommandQuery<FundraiserCampaignResponse>;
+
+public class GetFundraiserCampaignQueryHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserDashboardRepository dashboardRepository
+) : ICommandQueryHandler<GetFundraiserCampaignQuery, FundraiserCampaignResponse>
+{
+    public async Task<Result<FundraiserCampaignResponse>> Handle(
+        GetFundraiserCampaignQuery request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var offering = await dashboardRepository.GetPrimaryOfferingAsync(userId, cancellationToken);
+
+        FundraiserCampaignResponse response;
+        if (offering == null)
+        {
+            response = new FundraiserCampaignResponse(null, null, null, null, null);
+        }
+        else
+        {
+            response = new FundraiserCampaignResponse(
+                offering.Id,
+                offering.Slug,
+                offering.Name,
+                offering.Status.ToString().ToLowerInvariant(),
+                $"/explore/{offering.Slug}");
+        }
+
+        var result = new Result<FundraiserCampaignResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Investments/InvestmentMappers.cs
+++ b/Antital.Application/Features/Investments/InvestmentMappers.cs
@@ -121,7 +121,7 @@ internal static class InvestmentMappers
         new(asset.Id, asset.AssetType.ToString(), asset.Url, asset.SortOrder);
 
     public static OfferingUpdateDto ToUpdateDto(OfferingUpdate update) =>
-        new(update.Id, update.PublishedAt, update.Title, update.Body, update.LikeCount);
+        new(update.Id, update.PublishedAt ?? DateTime.UtcNow, update.Title, update.Body, update.LikeCount);
 
     public static TestimonialDto ToTestimonialDto(Testimonial testimonial) =>
         new(

--- a/Antital.Domain/Enums/OfferingUpdateStatus.cs
+++ b/Antital.Domain/Enums/OfferingUpdateStatus.cs
@@ -1,0 +1,7 @@
+namespace Antital.Domain.Enums;
+
+public enum OfferingUpdateStatus
+{
+    Draft = 0,
+    Published = 1,
+}

--- a/Antital.Domain/Interfaces/IFundraiserCampaignUpdatesRepository.cs
+++ b/Antital.Domain/Interfaces/IFundraiserCampaignUpdatesRepository.cs
@@ -1,0 +1,20 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+
+namespace Antital.Domain.Interfaces;
+
+public interface IFundraiserCampaignUpdatesRepository
+{
+    Task<(IReadOnlyList<OfferingUpdate> Items, int TotalCount)> ListUpdatesAsync(
+        int offeringId,
+        OfferingUpdateStatus? status,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken = default);
+
+    Task<OfferingUpdate?> GetByIdAsync(int updateId, CancellationToken cancellationToken = default);
+
+    Task AddAsync(OfferingUpdate update, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(OfferingUpdate update, CancellationToken cancellationToken = default);
+}

--- a/Antital.Domain/Models/OfferingUpdate.cs
+++ b/Antital.Domain/Models/OfferingUpdate.cs
@@ -1,3 +1,4 @@
+using Antital.Domain.Enums;
 using BuildingBlocks.Domain.Models;
 
 namespace Antital.Domain.Models;
@@ -5,7 +6,8 @@ namespace Antital.Domain.Models;
 public class OfferingUpdate : TrackableEntity
 {
     public int OfferingId { get; set; }
-    public DateTime PublishedAt { get; set; }
+    public OfferingUpdateStatus Status { get; set; } = OfferingUpdateStatus.Draft;
+    public DateTime? PublishedAt { get; set; }
     public string Title { get; set; } = string.Empty;
     public string Body { get; set; } = string.Empty;
     public int LikeCount { get; set; }

--- a/Antital.Infrastructure/AntitalDBContext.cs
+++ b/Antital.Infrastructure/AntitalDBContext.cs
@@ -358,6 +358,8 @@ public class AntitalDBContext(
                 .OnDelete(DeleteBehavior.Cascade);
             entity.Property(e => e.Title).HasMaxLength(300).IsRequired();
             entity.Property(e => e.Body).HasMaxLength(8000).IsRequired();
+            entity.HasIndex(e => new { e.OfferingId, e.Status, e.PublishedAt })
+                .HasFilter("\"IsDeleted\" = false");
         });
 
         modelBuilder.Entity<Testimonial>(entity =>

--- a/Antital.Infrastructure/Migrations/20260723041729_AddOfferingUpdateStatus.Designer.cs
+++ b/Antital.Infrastructure/Migrations/20260723041729_AddOfferingUpdateStatus.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Antital.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Antital.Infrastructure.Migrations
 {
     [DbContext(typeof(AntitalDBContext))]
-    partial class AntitalDBContextModelSnapshot : ModelSnapshot
+    [Migration("20260723041729_AddOfferingUpdateStatus")]
+    partial class AddOfferingUpdateStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Antital.Infrastructure/Migrations/20260723041729_AddOfferingUpdateStatus.cs
+++ b/Antital.Infrastructure/Migrations/20260723041729_AddOfferingUpdateStatus.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Antital.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOfferingUpdateStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OfferingUpdates_OfferingId",
+                table: "OfferingUpdates");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "PublishedAt",
+                table: "OfferingUpdates",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Status",
+                table: "OfferingUpdates",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE "OfferingUpdates"
+                SET "Status" = 1
+                WHERE "PublishedAt" IS NOT NULL;
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingUpdates_OfferingId_Status_PublishedAt",
+                table: "OfferingUpdates",
+                columns: new[] { "OfferingId", "Status", "PublishedAt" },
+                filter: "\"IsDeleted\" = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OfferingUpdates_OfferingId_Status_PublishedAt",
+                table: "OfferingUpdates");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "OfferingUpdates");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "PublishedAt",
+                table: "OfferingUpdates",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingUpdates_OfferingId",
+                table: "OfferingUpdates",
+                column: "OfferingId");
+        }
+    }
+}

--- a/Antital.Infrastructure/Repositories/FundraiserCampaignUpdatesRepository.cs
+++ b/Antital.Infrastructure/Repositories/FundraiserCampaignUpdatesRepository.cs
@@ -1,0 +1,50 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Antital.Infrastructure.Repositories;
+
+public class FundraiserCampaignUpdatesRepository(AntitalDBContext context) : IFundraiserCampaignUpdatesRepository
+{
+    public async Task<(IReadOnlyList<OfferingUpdate> Items, int TotalCount)> ListUpdatesAsync(
+        int offeringId,
+        OfferingUpdateStatus? status,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        var query = context.OfferingUpdates
+            .AsNoTracking()
+            .Where(u => u.OfferingId == offeringId && !u.IsDeleted);
+
+        if (status.HasValue)
+        {
+            query = query.Where(u => u.Status == status.Value);
+        }
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
+            .OrderByDescending(u => u.Status == OfferingUpdateStatus.Draft)
+            .ThenByDescending(u => u.PublishedAt ?? u.CreatedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return (items, totalCount);
+    }
+
+    public Task<OfferingUpdate?> GetByIdAsync(int updateId, CancellationToken cancellationToken = default) =>
+        context.OfferingUpdates
+            .FirstOrDefaultAsync(u => u.Id == updateId && !u.IsDeleted, cancellationToken);
+
+    public async Task AddAsync(OfferingUpdate update, CancellationToken cancellationToken = default) =>
+        await context.OfferingUpdates.AddAsync(update, cancellationToken);
+
+    public Task UpdateAsync(OfferingUpdate update, CancellationToken cancellationToken = default)
+    {
+        context.OfferingUpdates.Update(update);
+        return Task.CompletedTask;
+    }
+}

--- a/Antital.Infrastructure/Repositories/InvestmentOfferingRepository.cs
+++ b/Antital.Infrastructure/Repositories/InvestmentOfferingRepository.cs
@@ -162,7 +162,10 @@ public class InvestmentOfferingRepository(
     {
         var query = _dbContext.Set<OfferingUpdate>()
             .AsNoTracking()
-            .Where(u => u.OfferingId == offeringId && !u.IsDeleted);
+            .Where(u =>
+                u.OfferingId == offeringId
+                && !u.IsDeleted
+                && u.Status == OfferingUpdateStatus.Published);
 
         var totalCount = await query.CountAsync(cancellationToken);
 

--- a/Antital.Infrastructure/Repositories/InvestorWatchlistRepository.cs
+++ b/Antital.Infrastructure/Repositories/InvestorWatchlistRepository.cs
@@ -1,3 +1,4 @@
+using Antital.Domain.Enums;
 using Antital.Domain.Interfaces;
 using Antital.Domain.Models;
 using Microsoft.EntityFrameworkCore;
@@ -53,7 +54,10 @@ public class InvestorWatchlistRepository(AntitalDBContext context) : IInvestorWa
 
         var updates = await context.OfferingUpdates
             .AsNoTracking()
-            .Where(u => offeringIds.Contains(u.OfferingId) && !u.IsDeleted)
+            .Where(u =>
+                offeringIds.Contains(u.OfferingId)
+                && !u.IsDeleted
+                && u.Status == OfferingUpdateStatus.Published)
             .OrderByDescending(u => u.PublishedAt)
             .ToListAsync(cancellationToken);
 

--- a/Antital.Infrastructure/Seed/InvestmentOfferingSeed.cs
+++ b/Antital.Infrastructure/Seed/InvestmentOfferingSeed.cs
@@ -388,6 +388,7 @@ public static class InvestmentOfferingSeed
             var entity = new OfferingUpdate
             {
                 OfferingId = offeringId,
+                Status = OfferingUpdateStatus.Published,
                 PublishedAt = u.At,
                 Title = u.Title,
                 Body = u.Body,

--- a/Antital.Test/Integration/API/Controllers/FundraisersControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/FundraisersControllerTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Security.Claims;
 using System.Text;
 using Antital.Application.DTOs.Fundraisers;
+using Antital.Application.DTOs.Investments;
 using Antital.Domain.Enums;
 using Antital.Domain.Models;
 using Antital.Infrastructure;
@@ -129,6 +130,108 @@ public class FundraisersControllerTests : IClassFixture<CustomWebApplicationFact
         result.Value.Milestones.First(m => m.Key == "funded_50").Status.Should().Be("completed");
     }
 
+    [Fact]
+    public async Task ListCampaignUpdates_WithoutAuth_Returns401()
+    {
+        var response = await _client.GetAsync("/api/fundraisers/me/campaign/updates");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task CreateAndListCampaignUpdates_DraftThenPublish_Works()
+    {
+        var fundraiser = SeedUser("fundraiser-updates@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+        await SeedOwnedOfferingAsync(fundraiser.Id, "updates-campaign");
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+
+        var createResponse = await authClient.PostAsJsonAsync(
+            "/api/fundraisers/me/campaign/updates",
+            new CreateFundraiserCampaignUpdateRequest("Draft title", "Draft body", Publish: false));
+        createResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var created = await createResponse.Content.ReadFromJsonAsync<Result<FundraiserCampaignUpdateDto>>(JsonOptions);
+        created!.IsSuccess.Should().BeTrue();
+        created.Value!.Status.Should().Be("draft");
+        created.Value.PublishedAt.Should().BeNull();
+
+        var listDrafts = await authClient.GetAsync("/api/fundraisers/me/campaign/updates?status=draft");
+        var drafts = await listDrafts.Content.ReadFromJsonAsync<Result<FundraiserCampaignUpdatesResponse>>(JsonOptions);
+        drafts!.Value!.Items.Should().ContainSingle(i => i.Id == created.Value.Id);
+
+        var publishResponse = await authClient.PatchAsJsonAsync(
+            $"/api/fundraisers/me/campaign/updates/{created.Value.Id}",
+            new UpdateFundraiserCampaignUpdateRequest(null, null, Publish: true));
+        publishResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var published = await publishResponse.Content.ReadFromJsonAsync<Result<FundraiserCampaignUpdateDto>>(JsonOptions);
+        published!.Value!.Status.Should().Be("published");
+        published.Value.PublishedAt.Should().NotBeNull();
+
+        var publicUpdates = await _client.GetAsync("/api/investments/updates-campaign/updates");
+        publicUpdates.StatusCode.Should().Be(HttpStatusCode.OK);
+        var publicResult = await publicUpdates.Content.ReadFromJsonAsync<Result<OfferingUpdatesResponse>>(JsonOptions);
+        publicResult!.Value!.Items.Should().ContainSingle(i => i.Title == "Draft title");
+    }
+
+    [Fact]
+    public async Task CreateCampaignUpdate_NoOwnedOffering_Returns404()
+    {
+        var fundraiser = SeedUser("fundraiser-no-offer@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+        var response = await authClient.PostAsJsonAsync(
+            "/api/fundraisers/me/campaign/updates",
+            new CreateFundraiserCampaignUpdateRequest("Title", "Body", Publish: true));
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetCampaign_WithoutAuth_Returns401()
+    {
+        var response = await _client.GetAsync("/api/fundraisers/me/campaign");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetCampaign_NoOwnedOffering_ReturnsNullFields()
+    {
+        var fundraiser = SeedUser("fundraiser-campaign-empty@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/campaign");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserCampaignResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.OfferingId.Should().BeNull();
+        result.Value.OfferingSlug.Should().BeNull();
+        result.Value.PublicPath.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetCampaign_OwnedOffering_ReturnsContext()
+    {
+        var fundraiser = SeedUser("fundraiser-campaign-ctx@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+        var offering = await SeedOwnedOfferingAsync(fundraiser.Id, "campaign-context");
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/campaign");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserCampaignResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.OfferingId.Should().Be(offering.Id);
+        result.Value.OfferingSlug.Should().Be("campaign-context");
+        result.Value.OfferingName.Should().Be("Fundraiser Campaign");
+        result.Value.Status.Should().Be("published");
+        result.Value.PublicPath.Should().Be("/explore/campaign-context");
+    }
+
     private User SeedUser(string email, UserTypeEnum userType)
     {
         var user = new User
@@ -250,6 +353,7 @@ public class FundraisersControllerTests : IClassFixture<CustomWebApplicationFact
 
     private void CleanupDatabase()
     {
+        _context.OfferingUpdates.RemoveRange(_context.OfferingUpdates);
         _context.InvestorHoldings.RemoveRange(_context.InvestorHoldings);
         _context.InvestmentOfferings.RemoveRange(_context.InvestmentOfferings.IgnoreQueryFilters());
         _context.Users.RemoveRange(_context.Users);

--- a/Antital.Test/Integration/API/Controllers/WatchlistControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/WatchlistControllerTests.cs
@@ -283,6 +283,7 @@ public class WatchlistControllerTests : IClassFixture<CustomWebApplicationFactor
         var update = new OfferingUpdate
         {
             OfferingId = offeringId,
+            Status = OfferingUpdateStatus.Published,
             PublishedAt = DateTime.UtcNow.AddHours(-4),
             Title = title,
             Body = "Details",


### PR DESCRIPTION
## Summary
- Add `OfferingUpdate` draft/published status and migration so public update reads stay published-only.
- Expose fundraiser campaign context (`GET /api/fundraisers/me/campaign`) plus list/create/patch campaign update endpoints.
- Cover ownership, draft→publish, and public visibility with integration tests.

## Test plan
- [ ] Run `FundraisersControllerTests` (campaign + updates)
- [ ] As fundraiser: `GET /api/fundraisers/me/campaign` returns owned slug/`publicPath`
- [ ] Create draft via `POST .../campaign/updates` with `publish: false`; confirm public `/updates` excludes it
- [ ] Publish via create or patch; confirm public `/updates` includes it
- [ ] Non-fundraiser / unauthenticated callers get 403 / 401


Made with [Cursor](https://cursor.com)