### PR TITLE
Add fundraiser investors inbox, analytics, and QII APIs

### DIFF
--- a/Antital.API/Configs/AppUseExtensions.cs
+++ b/Antital.API/Configs/AppUseExtensions.cs
@@ -120,6 +120,8 @@ public static class AppUseExtensions
                     FundraiserOfferingOwnershipSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
                     InvestorDashboardSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
                     WalletTransactionSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
+                    FundraiserInvestorMessagesSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
+                    FundraiserQiiParticipationSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
                 }
             }
             catch (Exception ex)

--- a/Antital.API/Configs/DependencyInjection.cs
+++ b/Antital.API/Configs/DependencyInjection.cs
@@ -70,6 +70,8 @@ public static class DependencyInjection
         services.AddScoped(typeof(IInvestorDashboardRepository), typeof(InvestorDashboardRepository));
         services.AddScoped(typeof(IFundraiserDashboardRepository), typeof(FundraiserDashboardRepository));
         services.AddScoped(typeof(IFundraiserCampaignUpdatesRepository), typeof(FundraiserCampaignUpdatesRepository));
+        services.AddScoped(typeof(IFundraiserInvestorMessagesRepository), typeof(FundraiserInvestorMessagesRepository));
+        services.AddScoped(typeof(IFundraiserQiiParticipationRepository), typeof(FundraiserQiiParticipationRepository));
         services.AddScoped(typeof(IInvestmentOrderRepository), typeof(InvestmentOrderRepository));
         services.AddScoped(typeof(IInvestorPaymentMethodRepository), typeof(InvestorPaymentMethodRepository));
         services.AddScoped(typeof(IInvestorWatchlistRepository), typeof(InvestorWatchlistRepository));

--- a/Antital.API/Controllers/FundraisersController.cs
+++ b/Antital.API/Controllers/FundraisersController.cs
@@ -4,6 +4,11 @@ using Antital.Application.Features.Fundraisers.CampaignUpdates.ListFundraiserCam
 using Antital.Application.Features.Fundraisers.CampaignUpdates.UpdateFundraiserCampaignUpdate;
 using Antital.Application.Features.Fundraisers.GetFundraiserCampaign;
 using Antital.Application.Features.Fundraisers.GetFundraiserDashboard;
+using Antital.Application.Features.Fundraisers.Investors.GetFundraiserInvestorAnalytics;
+using Antital.Application.Features.Fundraisers.Investors.GetFundraiserQiiParticipation;
+using Antital.Application.Features.Fundraisers.Investors.ListFundraiserInvestorMessages;
+using Antital.Application.Features.Fundraisers.Investors.ReplyFundraiserInvestorMessage;
+using Antital.Application.Features.Fundraisers.Investors.UpdateFundraiserInvestorMessage;
 using BuildingBlocks.API.Controllers;
 using BuildingBlocks.Application.Features;
 using MediatR;
@@ -104,6 +109,92 @@ public class FundraisersController(IMediator mediator) : BaseController
         var result = await mediator.Send(
             new UpdateFundraiserCampaignUpdateCommand(updateId, request.Title, request.Body, request.Publish),
             cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpGet("me/investors/qii")]
+    [SwaggerOperation(
+        "List QII Participation",
+        "Returns Qualified Institutional Investor commitments for the fundraiser's primary owned offering.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserQiiParticipationResponse>))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    public async Task<IActionResult> GetQiiParticipation(CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(new GetFundraiserQiiParticipationQuery(), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpGet("me/investors/messages")]
+    [SwaggerOperation(
+        "List Investor Messages",
+        "Returns investor questions for the authenticated fundraiser's primary owned offering.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserInvestorMessagesResponse>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid status", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    public async Task<IActionResult> ListInvestorMessages(
+        [FromQuery] string status = "all",
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new ListFundraiserInvestorMessagesQuery(status, page, pageSize),
+            cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpPost("me/investors/messages/{messageId:int}/reply")]
+    [SwaggerOperation(
+        "Reply To Investor Message",
+        "Posts a reply to an investor question on the fundraiser's owned offering.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserInvestorMessageDto>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Message or campaign not found", typeof(void))]
+    public async Task<IActionResult> ReplyInvestorMessage(
+        int messageId,
+        [FromBody] ReplyFundraiserInvestorMessageRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new ReplyFundraiserInvestorMessageCommand(messageId, request.Reply),
+            cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpPatch("me/investors/messages/{messageId:int}")]
+    [SwaggerOperation(
+        "Update Investor Message",
+        "Updates visibility and/or reply text for an investor message on the owned offering.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserInvestorMessageDto>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "Message or campaign not found", typeof(void))]
+    public async Task<IActionResult> UpdateInvestorMessage(
+        int messageId,
+        [FromBody] UpdateFundraiserInvestorMessageRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new UpdateFundraiserInvestorMessageCommand(messageId, request.Visibility, request.Reply),
+            cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpGet("me/investors/analytics")]
+    [SwaggerOperation(
+        "Get Investor Inbox Analytics",
+        "Returns response rate and average response time for the fundraiser's primary owned offering inbox.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserInvestorAnalyticsResponse>))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    public async Task<IActionResult> GetInvestorAnalytics(CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(new GetFundraiserInvestorAnalyticsQuery(), cancellationToken);
         return ApiResult(result);
     }
 }

--- a/Antital.Application/DTOs/Fundraisers/FundraiserInvestorMessageDtos.cs
+++ b/Antital.Application/DTOs/Fundraisers/FundraiserInvestorMessageDtos.cs
@@ -1,0 +1,36 @@
+namespace Antital.Application.DTOs.Fundraisers;
+
+public record FundraiserInvestorMessageAuthorDto(
+    int UserId,
+    string DisplayName,
+    string? AvatarUrl);
+
+public record FundraiserInvestorMessageDto(
+    int Id,
+    FundraiserInvestorMessageAuthorDto Author,
+    string Question,
+    DateTime AskedAt,
+    string Visibility,
+    string? Reply,
+    DateTime? RepliedAt,
+    string Status);
+
+public record FundraiserInvestorMessagesResponse(
+    IReadOnlyList<FundraiserInvestorMessageDto> Items,
+    int Page,
+    int PageSize,
+    int TotalCount,
+    int NewCount);
+
+public record ReplyFundraiserInvestorMessageRequest(string Reply);
+
+public record UpdateFundraiserInvestorMessageRequest(
+    string? Visibility,
+    string? Reply);
+
+public record FundraiserInvestorAnalyticsResponse(
+    decimal ResponseRate,
+    double? AverageResponseTimeHours,
+    int TotalMessages,
+    int AnsweredCount,
+    int UnansweredCount);

--- a/Antital.Application/DTOs/Fundraisers/FundraiserQiiParticipationDtos.cs
+++ b/Antital.Application/DTOs/Fundraisers/FundraiserQiiParticipationDtos.cs
@@ -1,0 +1,14 @@
+namespace Antital.Application.DTOs.Fundraisers;
+
+public record FundraiserQiiParticipationItemDto(
+    int Id,
+    string Institution,
+    string Type,
+    decimal CommitmentAmount,
+    string Currency,
+    DateTime CommittedAt,
+    string Status);
+
+public record FundraiserQiiParticipationResponse(
+    int? OfferingId,
+    IReadOnlyList<FundraiserQiiParticipationItemDto> Items);

--- a/Antital.Application/Features/Fundraisers/Investors/FundraiserInvestorMessageMappers.cs
+++ b/Antital.Application/Features/Fundraisers/Investors/FundraiserInvestorMessageMappers.cs
@@ -1,0 +1,99 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+
+namespace Antital.Application.Features.Fundraisers.Investors;
+
+internal static class FundraiserInvestorMessageMappers
+{
+    public static FundraiserInvestorMessageDto ToDto(OfferingInvestorMessage message) =>
+        new(
+            message.Id,
+            new FundraiserInvestorMessageAuthorDto(
+                message.AskerUserId,
+                ResolveDisplayName(message.AskerUser),
+                AvatarUrl: null),
+            message.Question,
+            message.AskedAt,
+            ToVisibilityString(message.Visibility),
+            message.Reply,
+            message.RepliedAt,
+            message.RepliedAt == null ? "unanswered" : "answered");
+
+    public static string ToVisibilityString(OfferingInvestorMessageVisibility visibility) =>
+        visibility switch
+        {
+            OfferingInvestorMessageVisibility.Public => "public",
+            OfferingInvestorMessageVisibility.Private => "private",
+            _ => visibility.ToString().ToLowerInvariant(),
+        };
+
+    public static bool TryParseMessageStatusFilter(string? status, out bool? answered, out string? error)
+    {
+        answered = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(status) || status.Equals("all", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (status.Equals("answered", StringComparison.OrdinalIgnoreCase))
+        {
+            answered = true;
+            return true;
+        }
+
+        if (status.Equals("unanswered", StringComparison.OrdinalIgnoreCase))
+        {
+            answered = false;
+            return true;
+        }
+
+        error = "Status must be all, answered, or unanswered.";
+        return false;
+    }
+
+    public static bool TryParseVisibility(string? visibility, out OfferingInvestorMessageVisibility parsed, out string? error)
+    {
+        parsed = OfferingInvestorMessageVisibility.Private;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(visibility))
+        {
+            error = "Visibility is required.";
+            return false;
+        }
+
+        if (visibility.Equals("public", StringComparison.OrdinalIgnoreCase))
+        {
+            parsed = OfferingInvestorMessageVisibility.Public;
+            return true;
+        }
+
+        if (visibility.Equals("private", StringComparison.OrdinalIgnoreCase))
+        {
+            parsed = OfferingInvestorMessageVisibility.Private;
+            return true;
+        }
+
+        error = "Visibility must be public or private.";
+        return false;
+    }
+
+    private static string ResolveDisplayName(User? user)
+    {
+        if (user == null)
+        {
+            return "Investor";
+        }
+
+        if (!string.IsNullOrWhiteSpace(user.PreferredName))
+        {
+            return user.PreferredName.Trim();
+        }
+
+        var fullName = $"{user.FirstName} {user.LastName}".Trim();
+        return string.IsNullOrWhiteSpace(fullName) ? user.Email : fullName;
+    }
+}

--- a/Antital.Application/Features/Fundraisers/Investors/FundraiserQiiParticipationMappers.cs
+++ b/Antital.Application/Features/Fundraisers/Investors/FundraiserQiiParticipationMappers.cs
@@ -1,0 +1,140 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+
+namespace Antital.Application.Features.Fundraisers.Investors;
+
+internal static class FundraiserQiiParticipationMappers
+{
+    public static IReadOnlyList<FundraiserQiiParticipationItemDto> BuildItems(
+        IReadOnlyList<InvestorHolding> holdings,
+        IReadOnlyList<InvestmentOrder> pendingOrders,
+        IReadOnlyDictionary<int, UserInvestmentProfile> profiles)
+    {
+        var confirmedByUser = holdings
+            .GroupBy(h => h.UserId)
+            .ToDictionary(
+                g => g.Key,
+                g => new
+                {
+                    Amount = g.Sum(h => h.InvestedAmount),
+                    CommittedAt = g.Max(h => h.InvestedAt),
+                    User = g.First().User,
+                });
+
+        var pendingByUser = pendingOrders
+            .GroupBy(o => o.UserId)
+            .Where(g => !confirmedByUser.ContainsKey(g.Key))
+            .ToDictionary(
+                g => g.Key,
+                g =>
+                {
+                    var latest = g.OrderByDescending(o => o.CreatedAt).First();
+                    return new
+                    {
+                        Amount = latest.TotalAmount,
+                        CommittedAt = latest.CreatedAt,
+                        Currency = latest.Currency,
+                        User = latest.User,
+                    };
+                });
+
+        var items = new List<FundraiserQiiParticipationItemDto>();
+
+        foreach (var (userId, row) in confirmedByUser.OrderByDescending(kv => kv.Value.CommittedAt))
+        {
+            profiles.TryGetValue(userId, out var profile);
+            items.Add(new FundraiserQiiParticipationItemDto(
+                userId,
+                ResolveInstitution(profile, row.User),
+                ResolveType(profile),
+                row.Amount,
+                "NGN",
+                row.CommittedAt,
+                "confirmed"));
+        }
+
+        foreach (var (userId, row) in pendingByUser.OrderByDescending(kv => kv.Value.CommittedAt))
+        {
+            profiles.TryGetValue(userId, out var profile);
+            items.Add(new FundraiserQiiParticipationItemDto(
+                userId,
+                ResolveInstitution(profile, row.User),
+                ResolveType(profile),
+                row.Amount,
+                string.IsNullOrWhiteSpace(row.Currency) ? "NGN" : row.Currency,
+                row.CommittedAt,
+                "pending"));
+        }
+
+        return items;
+    }
+
+    private static string ResolveInstitution(UserInvestmentProfile? profile, User? user)
+    {
+        if (!string.IsNullOrWhiteSpace(profile?.CompanyLegalName))
+        {
+            return profile.CompanyLegalName.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(profile?.TradingBrandName))
+        {
+            return profile.TradingBrandName.Trim();
+        }
+
+        if (user == null)
+        {
+            return "Institutional Investor";
+        }
+
+        if (!string.IsNullOrWhiteSpace(user.PreferredName))
+        {
+            return user.PreferredName.Trim();
+        }
+
+        var fullName = $"{user.FirstName} {user.LastName}".Trim();
+        return string.IsNullOrWhiteSpace(fullName) ? user.Email : fullName;
+    }
+
+    private static string ResolveType(UserInvestmentProfile? profile)
+    {
+        if (profile == null)
+        {
+            return "Institutional Investor";
+        }
+
+        var raw = profile.QiiInstitutionTypes?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault();
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return "Institutional Investor";
+        }
+
+        if (Enum.TryParse<QiiInstitutionType>(raw, ignoreCase: true, out var parsed))
+        {
+            if (parsed == QiiInstitutionType.OtherRegulatedInstitution
+                && !string.IsNullOrWhiteSpace(profile.QiiOtherInstitutionType))
+            {
+                return profile.QiiOtherInstitutionType.Trim();
+            }
+
+            return ToTypeLabel(parsed);
+        }
+
+        return raw;
+    }
+
+    private static string ToTypeLabel(QiiInstitutionType type) =>
+        type switch
+        {
+            QiiInstitutionType.Bank => "Bank",
+            QiiInstitutionType.AssetManagementCompany => "Asset Manager",
+            QiiInstitutionType.PensionFundAdministrator => "Pension Fund",
+            QiiInstitutionType.InsuranceCompany => "Insurance Company",
+            QiiInstitutionType.VentureCapitalOrPrivateEquityFund => "Fund Manager",
+            QiiInstitutionType.CorporateFinanceInstitution => "Merchant Bank",
+            QiiInstitutionType.OtherRegulatedInstitution => "Other Institution",
+            _ => type.ToString(),
+        };
+}

--- a/Antital.Application/Features/Fundraisers/Investors/GetFundraiserInvestorAnalytics/GetFundraiserInvestorAnalyticsQuery.cs
+++ b/Antital.Application/Features/Fundraisers/Investors/GetFundraiserInvestorAnalytics/GetFundraiserInvestorAnalyticsQuery.cs
@@ -1,0 +1,51 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Fundraisers.Investors.GetFundraiserInvestorAnalytics;
+
+public record GetFundraiserInvestorAnalyticsQuery : ICommandQuery<FundraiserInvestorAnalyticsResponse>;
+
+public class GetFundraiserInvestorAnalyticsQueryHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserDashboardRepository dashboardRepository,
+    IFundraiserInvestorMessagesRepository messagesRepository
+) : ICommandQueryHandler<GetFundraiserInvestorAnalyticsQuery, FundraiserInvestorAnalyticsResponse>
+{
+    public async Task<Result<FundraiserInvestorAnalyticsResponse>> Handle(
+        GetFundraiserInvestorAnalyticsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var offering = await dashboardRepository.GetPrimaryOfferingAsync(userId, cancellationToken);
+
+        if (offering == null)
+        {
+            var empty = new Result<FundraiserInvestorAnalyticsResponse>();
+            empty.AddValue(new FundraiserInvestorAnalyticsResponse(0m, null, 0, 0, 0));
+            empty.OK();
+            return empty;
+        }
+
+        var (totalCount, answeredCount, averageHours) = await messagesRepository.GetAnalyticsAsync(
+            offering.Id,
+            cancellationToken);
+
+        var unansweredCount = totalCount - answeredCount;
+        var responseRate = totalCount == 0
+            ? 0m
+            : decimal.Round((decimal)answeredCount / totalCount, 4, MidpointRounding.AwayFromZero);
+
+        var result = new Result<FundraiserInvestorAnalyticsResponse>();
+        result.AddValue(new FundraiserInvestorAnalyticsResponse(
+            responseRate,
+            averageHours.HasValue
+                ? Math.Round(averageHours.Value, 2, MidpointRounding.AwayFromZero)
+                : null,
+            totalCount,
+            answeredCount,
+            unansweredCount));
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Fundraisers/Investors/GetFundraiserQiiParticipation/GetFundraiserQiiParticipationQuery.cs
+++ b/Antital.Application/Features/Fundraisers/Investors/GetFundraiserQiiParticipation/GetFundraiserQiiParticipationQuery.cs
@@ -1,0 +1,44 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Fundraisers.Investors.GetFundraiserQiiParticipation;
+
+public record GetFundraiserQiiParticipationQuery : ICommandQuery<FundraiserQiiParticipationResponse>;
+
+public class GetFundraiserQiiParticipationQueryHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserDashboardRepository dashboardRepository,
+    IFundraiserQiiParticipationRepository qiiRepository
+) : ICommandQueryHandler<GetFundraiserQiiParticipationQuery, FundraiserQiiParticipationResponse>
+{
+    public async Task<Result<FundraiserQiiParticipationResponse>> Handle(
+        GetFundraiserQiiParticipationQuery request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var offering = await dashboardRepository.GetPrimaryOfferingAsync(userId, cancellationToken);
+
+        if (offering == null)
+        {
+            var empty = new Result<FundraiserQiiParticipationResponse>();
+            empty.AddValue(new FundraiserQiiParticipationResponse(null, []));
+            empty.OK();
+            return empty;
+        }
+
+        var holdings = await qiiRepository.ListQiiHoldingsAsync(offering.Id, cancellationToken);
+        var pendingOrders = await qiiRepository.ListQiiPendingOrdersAsync(offering.Id, cancellationToken);
+        var userIds = holdings.Select(h => h.UserId)
+            .Concat(pendingOrders.Select(o => o.UserId))
+            .Distinct()
+            .ToList();
+        var profiles = await qiiRepository.GetProfilesByUserIdsAsync(userIds, cancellationToken);
+        var items = FundraiserQiiParticipationMappers.BuildItems(holdings, pendingOrders, profiles);
+
+        var result = new Result<FundraiserQiiParticipationResponse>();
+        result.AddValue(new FundraiserQiiParticipationResponse(offering.Id, items));
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Fundraisers/Investors/ListFundraiserInvestorMessages/ListFundraiserInvestorMessagesQuery.cs
+++ b/Antital.Application/Features/Fundraisers/Investors/ListFundraiserInvestorMessages/ListFundraiserInvestorMessagesQuery.cs
@@ -1,0 +1,68 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Fundraisers.Investors.ListFundraiserInvestorMessages;
+
+public record ListFundraiserInvestorMessagesQuery(
+    string? Status = "all",
+    int Page = 1,
+    int PageSize = 20
+) : ICommandQuery<FundraiserInvestorMessagesResponse>;
+
+public class ListFundraiserInvestorMessagesQueryHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserDashboardRepository dashboardRepository,
+    IFundraiserInvestorMessagesRepository messagesRepository
+) : ICommandQueryHandler<ListFundraiserInvestorMessagesQuery, FundraiserInvestorMessagesResponse>
+{
+    private const int MaxPageSize = 50;
+
+    public async Task<Result<FundraiserInvestorMessagesResponse>> Handle(
+        ListFundraiserInvestorMessagesQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (!FundraiserInvestorMessageMappers.TryParseMessageStatusFilter(
+                request.Status,
+                out var answered,
+                out var statusError))
+        {
+            var invalid = new Result<FundraiserInvestorMessagesResponse>();
+            invalid.BadRequest(
+                "Invalid status.",
+                new Dictionary<string, string[]> { ["status"] = [statusError!] });
+            return invalid;
+        }
+
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var offering = await dashboardRepository.GetPrimaryOfferingAsync(userId, cancellationToken);
+
+        var page = request.Page < 1 ? 1 : request.Page;
+        var pageSize = request.PageSize < 1 ? 20 : Math.Min(request.PageSize, MaxPageSize);
+
+        if (offering == null)
+        {
+            var empty = new Result<FundraiserInvestorMessagesResponse>();
+            empty.AddValue(new FundraiserInvestorMessagesResponse([], page, pageSize, 0, 0));
+            empty.OK();
+            return empty;
+        }
+
+        var (items, totalCount, unansweredCount) = await messagesRepository.ListMessagesAsync(
+            offering.Id,
+            answered,
+            page,
+            pageSize,
+            cancellationToken);
+
+        var result = new Result<FundraiserInvestorMessagesResponse>();
+        result.AddValue(new FundraiserInvestorMessagesResponse(
+            items.Select(FundraiserInvestorMessageMappers.ToDto).ToList(),
+            page,
+            pageSize,
+            totalCount,
+            unansweredCount));
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Fundraisers/Investors/ReplyFundraiserInvestorMessage/ReplyFundraiserInvestorMessageCommand.cs
+++ b/Antital.Application/Features/Fundraisers/Investors/ReplyFundraiserInvestorMessage/ReplyFundraiserInvestorMessageCommand.cs
@@ -1,0 +1,66 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using BuildingBlocks.Domain.Interfaces;
+
+namespace Antital.Application.Features.Fundraisers.Investors.ReplyFundraiserInvestorMessage;
+
+public record ReplyFundraiserInvestorMessageCommand(
+    int MessageId,
+    string Reply
+) : ICommandQuery<FundraiserInvestorMessageDto>;
+
+public class ReplyFundraiserInvestorMessageCommandHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserDashboardRepository dashboardRepository,
+    IFundraiserInvestorMessagesRepository messagesRepository,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser
+) : ICommandQueryHandler<ReplyFundraiserInvestorMessageCommand, FundraiserInvestorMessageDto>
+{
+    public async Task<Result<FundraiserInvestorMessageDto>> Handle(
+        ReplyFundraiserInvestorMessageCommand request,
+        CancellationToken cancellationToken)
+    {
+        var reply = request.Reply?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(reply))
+        {
+            var invalid = new Result<FundraiserInvestorMessageDto>();
+            invalid.BadRequest(
+                "Reply is required.",
+                new Dictionary<string, string[]> { ["reply"] = ["Reply is required."] });
+            return invalid;
+        }
+
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var offering = await dashboardRepository.GetPrimaryOfferingAsync(userId, cancellationToken);
+        if (offering == null)
+        {
+            throw new NotFoundException("No owned fundraising campaign found.");
+        }
+
+        var message = await messagesRepository.GetByIdAsync(request.MessageId, cancellationToken);
+        if (message == null || message.OfferingId != offering.Id)
+        {
+            throw new NotFoundException("Investor message not found.");
+        }
+
+        message.Reply = reply;
+        message.RepliedAt = DateTime.UtcNow;
+        message.Updated(ResolveActor());
+
+        await messagesRepository.UpdateAsync(message, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        var result = new Result<FundraiserInvestorMessageDto>();
+        result.AddValue(FundraiserInvestorMessageMappers.ToDto(message));
+        result.OK();
+        return result;
+    }
+
+    private string ResolveActor() =>
+        !string.IsNullOrEmpty(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrEmpty(currentUser.IPAddress) ? currentUser.IPAddress : "System");
+}

--- a/Antital.Application/Features/Fundraisers/Investors/UpdateFundraiserInvestorMessage/UpdateFundraiserInvestorMessageCommand.cs
+++ b/Antital.Application/Features/Fundraisers/Investors/UpdateFundraiserInvestorMessage/UpdateFundraiserInvestorMessageCommand.cs
@@ -1,0 +1,99 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using BuildingBlocks.Domain.Interfaces;
+
+namespace Antital.Application.Features.Fundraisers.Investors.UpdateFundraiserInvestorMessage;
+
+public record UpdateFundraiserInvestorMessageCommand(
+    int MessageId,
+    string? Visibility,
+    string? Reply
+) : ICommandQuery<FundraiserInvestorMessageDto>;
+
+public class UpdateFundraiserInvestorMessageCommandHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserDashboardRepository dashboardRepository,
+    IFundraiserInvestorMessagesRepository messagesRepository,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser
+) : ICommandQueryHandler<UpdateFundraiserInvestorMessageCommand, FundraiserInvestorMessageDto>
+{
+    public async Task<Result<FundraiserInvestorMessageDto>> Handle(
+        UpdateFundraiserInvestorMessageCommand request,
+        CancellationToken cancellationToken)
+    {
+        if (request.Visibility == null && request.Reply == null)
+        {
+            var invalid = new Result<FundraiserInvestorMessageDto>();
+            invalid.BadRequest(
+                "At least one field is required.",
+                new Dictionary<string, string[]>
+                {
+                    ["body"] = ["Provide visibility and/or reply."],
+                });
+            return invalid;
+        }
+
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var offering = await dashboardRepository.GetPrimaryOfferingAsync(userId, cancellationToken);
+        if (offering == null)
+        {
+            throw new NotFoundException("No owned fundraising campaign found.");
+        }
+
+        var message = await messagesRepository.GetByIdAsync(request.MessageId, cancellationToken);
+        if (message == null || message.OfferingId != offering.Id)
+        {
+            throw new NotFoundException("Investor message not found.");
+        }
+
+        if (request.Visibility != null)
+        {
+            if (!FundraiserInvestorMessageMappers.TryParseVisibility(
+                    request.Visibility,
+                    out var visibility,
+                    out var visibilityError))
+            {
+                var invalid = new Result<FundraiserInvestorMessageDto>();
+                invalid.BadRequest(
+                    "Invalid visibility.",
+                    new Dictionary<string, string[]> { ["visibility"] = [visibilityError!] });
+                return invalid;
+            }
+
+            message.Visibility = visibility;
+        }
+
+        if (request.Reply != null)
+        {
+            var reply = request.Reply.Trim();
+            if (string.IsNullOrWhiteSpace(reply))
+            {
+                var invalid = new Result<FundraiserInvestorMessageDto>();
+                invalid.BadRequest(
+                    "Reply is required.",
+                    new Dictionary<string, string[]> { ["reply"] = ["Reply is required."] });
+                return invalid;
+            }
+
+            message.Reply = reply;
+            message.RepliedAt ??= DateTime.UtcNow;
+        }
+
+        message.Updated(ResolveActor());
+        await messagesRepository.UpdateAsync(message, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        var result = new Result<FundraiserInvestorMessageDto>();
+        result.AddValue(FundraiserInvestorMessageMappers.ToDto(message));
+        result.OK();
+        return result;
+    }
+
+    private string ResolveActor() =>
+        !string.IsNullOrEmpty(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrEmpty(currentUser.IPAddress) ? currentUser.IPAddress : "System");
+}

--- a/Antital.Domain/Enums/OfferingInvestorMessageVisibility.cs
+++ b/Antital.Domain/Enums/OfferingInvestorMessageVisibility.cs
@@ -1,0 +1,7 @@
+namespace Antital.Domain.Enums;
+
+public enum OfferingInvestorMessageVisibility
+{
+    Public = 0,
+    Private = 1,
+}

--- a/Antital.Domain/Interfaces/IFundraiserInvestorMessagesRepository.cs
+++ b/Antital.Domain/Interfaces/IFundraiserInvestorMessagesRepository.cs
@@ -1,0 +1,23 @@
+using Antital.Domain.Models;
+
+namespace Antital.Domain.Interfaces;
+
+public interface IFundraiserInvestorMessagesRepository
+{
+    Task<(IReadOnlyList<OfferingInvestorMessage> Items, int TotalCount, int UnansweredCount)> ListMessagesAsync(
+        int offeringId,
+        bool? answered,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken = default);
+
+    Task<OfferingInvestorMessage?> GetByIdAsync(int messageId, CancellationToken cancellationToken = default);
+
+    Task<(int TotalCount, int AnsweredCount, double? AverageResponseTimeHours)> GetAnalyticsAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default);
+
+    Task AddAsync(OfferingInvestorMessage message, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(OfferingInvestorMessage message, CancellationToken cancellationToken = default);
+}

--- a/Antital.Domain/Interfaces/IFundraiserQiiParticipationRepository.cs
+++ b/Antital.Domain/Interfaces/IFundraiserQiiParticipationRepository.cs
@@ -1,0 +1,18 @@
+using Antital.Domain.Models;
+
+namespace Antital.Domain.Interfaces;
+
+public interface IFundraiserQiiParticipationRepository
+{
+    Task<IReadOnlyList<InvestorHolding>> ListQiiHoldingsAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<InvestmentOrder>> ListQiiPendingOrdersAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyDictionary<int, UserInvestmentProfile>> GetProfilesByUserIdsAsync(
+        IReadOnlyCollection<int> userIds,
+        CancellationToken cancellationToken = default);
+}

--- a/Antital.Domain/Models/InvestmentOffering.cs
+++ b/Antital.Domain/Models/InvestmentOffering.cs
@@ -28,5 +28,6 @@ public class InvestmentOffering : TrackableEntity
     public ICollection<OfferingDocument> Documents { get; set; } = [];
     public ICollection<MediaAsset> MediaAssets { get; set; } = [];
     public ICollection<OfferingUpdate> Updates { get; set; } = [];
+    public ICollection<OfferingInvestorMessage> InvestorMessages { get; set; } = [];
     public ICollection<Testimonial> Testimonials { get; set; } = [];
 }

--- a/Antital.Domain/Models/OfferingInvestorMessage.cs
+++ b/Antital.Domain/Models/OfferingInvestorMessage.cs
@@ -1,0 +1,26 @@
+using Antital.Domain.Enums;
+using BuildingBlocks.Domain.Models;
+using System.ComponentModel.DataAnnotations;
+
+namespace Antital.Domain.Models;
+
+public class OfferingInvestorMessage : TrackableEntity
+{
+    public int OfferingId { get; set; }
+    public int AskerUserId { get; set; }
+
+    [MaxLength(4000)]
+    public string Question { get; set; } = string.Empty;
+
+    [MaxLength(4000)]
+    public string? Reply { get; set; }
+
+    public OfferingInvestorMessageVisibility Visibility { get; set; } =
+        OfferingInvestorMessageVisibility.Private;
+
+    public DateTime AskedAt { get; set; }
+    public DateTime? RepliedAt { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+    public virtual User AskerUser { get; set; } = null!;
+}

--- a/Antital.Infrastructure/AntitalDBContext.cs
+++ b/Antital.Infrastructure/AntitalDBContext.cs
@@ -26,6 +26,7 @@ public class AntitalDBContext(
     public DbSet<OfferingDocument> OfferingDocuments { get; set; }
     public DbSet<MediaAsset> MediaAssets { get; set; }
     public DbSet<OfferingUpdate> OfferingUpdates { get; set; }
+    public DbSet<OfferingInvestorMessage> OfferingInvestorMessages { get; set; }
     public DbSet<Testimonial> Testimonials { get; set; }
     public DbSet<OfferingCorporateProfile> OfferingCorporateProfiles { get; set; }
     public DbSet<InvestorWallet> InvestorWallets { get; set; }
@@ -359,6 +360,20 @@ public class AntitalDBContext(
             entity.Property(e => e.Title).HasMaxLength(300).IsRequired();
             entity.Property(e => e.Body).HasMaxLength(8000).IsRequired();
             entity.HasIndex(e => new { e.OfferingId, e.Status, e.PublishedAt })
+                .HasFilter("\"IsDeleted\" = false");
+        });
+
+        modelBuilder.Entity<OfferingInvestorMessage>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithMany(o => o.InvestorMessages).HasForeignKey(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne(e => e.AskerUser).WithMany().HasForeignKey(e => e.AskerUserId)
+                .OnDelete(DeleteBehavior.Restrict);
+            entity.Property(e => e.Question).HasMaxLength(4000).IsRequired();
+            entity.Property(e => e.Reply).HasMaxLength(4000);
+            entity.HasIndex(e => new { e.OfferingId, e.AskedAt })
+                .HasFilter("\"IsDeleted\" = false");
+            entity.HasIndex(e => new { e.OfferingId, e.RepliedAt })
                 .HasFilter("\"IsDeleted\" = false");
         });
 

--- a/Antital.Infrastructure/Migrations/20260723051744_AddOfferingInvestorMessages.Designer.cs
+++ b/Antital.Infrastructure/Migrations/20260723051744_AddOfferingInvestorMessages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Antital.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Antital.Infrastructure.Migrations
 {
     [DbContext(typeof(AntitalDBContext))]
-    partial class AntitalDBContextModelSnapshot : ModelSnapshot
+    [Migration("20260723051744_AddOfferingInvestorMessages")]
+    partial class AddOfferingInvestorMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Antital.Infrastructure/Migrations/20260723051744_AddOfferingInvestorMessages.cs
+++ b/Antital.Infrastructure/Migrations/20260723051744_AddOfferingInvestorMessages.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Antital.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOfferingInvestorMessages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OfferingInvestorMessages",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    AskerUserId = table.Column<int>(type: "integer", nullable: false),
+                    Question = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
+                    Reply = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    Visibility = table.Column<int>(type: "integer", nullable: false),
+                    AskedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    RepliedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OfferingInvestorMessages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OfferingInvestorMessages_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_OfferingInvestorMessages_Users_AskerUserId",
+                        column: x => x.AskerUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingInvestorMessages_AskerUserId",
+                table: "OfferingInvestorMessages",
+                column: "AskerUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingInvestorMessages_OfferingId_AskedAt",
+                table: "OfferingInvestorMessages",
+                columns: new[] { "OfferingId", "AskedAt" },
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingInvestorMessages_OfferingId_RepliedAt",
+                table: "OfferingInvestorMessages",
+                columns: new[] { "OfferingId", "RepliedAt" },
+                filter: "\"IsDeleted\" = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OfferingInvestorMessages");
+        }
+    }
+}

--- a/Antital.Infrastructure/Repositories/FundraiserInvestorMessagesRepository.cs
+++ b/Antital.Infrastructure/Repositories/FundraiserInvestorMessagesRepository.cs
@@ -1,0 +1,82 @@
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Antital.Infrastructure.Repositories;
+
+public class FundraiserInvestorMessagesRepository(AntitalDBContext context)
+    : IFundraiserInvestorMessagesRepository
+{
+    public async Task<(IReadOnlyList<OfferingInvestorMessage> Items, int TotalCount, int UnansweredCount)> ListMessagesAsync(
+        int offeringId,
+        bool? answered,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        var baseQuery = context.OfferingInvestorMessages
+            .AsNoTracking()
+            .Include(m => m.AskerUser)
+            .Where(m => m.OfferingId == offeringId && !m.IsDeleted);
+
+        var unansweredCount = await baseQuery.CountAsync(m => m.RepliedAt == null, cancellationToken);
+
+        var filtered = answered switch
+        {
+            true => baseQuery.Where(m => m.RepliedAt != null),
+            false => baseQuery.Where(m => m.RepliedAt == null),
+            null => baseQuery,
+        };
+
+        var totalCount = await filtered.CountAsync(cancellationToken);
+
+        var items = await filtered
+            .OrderByDescending(m => m.RepliedAt == null)
+            .ThenByDescending(m => m.AskedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return (items, totalCount, unansweredCount);
+    }
+
+    public Task<OfferingInvestorMessage?> GetByIdAsync(
+        int messageId,
+        CancellationToken cancellationToken = default) =>
+        context.OfferingInvestorMessages
+            .Include(m => m.AskerUser)
+            .FirstOrDefaultAsync(m => m.Id == messageId && !m.IsDeleted, cancellationToken);
+
+    public async Task<(int TotalCount, int AnsweredCount, double? AverageResponseTimeHours)> GetAnalyticsAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default)
+    {
+        var messages = await context.OfferingInvestorMessages
+            .AsNoTracking()
+            .Where(m => m.OfferingId == offeringId && !m.IsDeleted)
+            .Select(m => new { m.AskedAt, m.RepliedAt })
+            .ToListAsync(cancellationToken);
+
+        var totalCount = messages.Count;
+        var answered = messages.Where(m => m.RepliedAt.HasValue).ToList();
+        var answeredCount = answered.Count;
+
+        double? averageHours = null;
+        if (answeredCount > 0)
+        {
+            averageHours = answered
+                .Average(m => (m.RepliedAt!.Value - m.AskedAt).TotalHours);
+        }
+
+        return (totalCount, answeredCount, averageHours);
+    }
+
+    public async Task AddAsync(OfferingInvestorMessage message, CancellationToken cancellationToken = default) =>
+        await context.OfferingInvestorMessages.AddAsync(message, cancellationToken);
+
+    public Task UpdateAsync(OfferingInvestorMessage message, CancellationToken cancellationToken = default)
+    {
+        context.OfferingInvestorMessages.Update(message);
+        return Task.CompletedTask;
+    }
+}

--- a/Antital.Infrastructure/Repositories/FundraiserQiiParticipationRepository.cs
+++ b/Antital.Infrastructure/Repositories/FundraiserQiiParticipationRepository.cs
@@ -1,0 +1,66 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Antital.Infrastructure.Repositories;
+
+public class FundraiserQiiParticipationRepository(AntitalDBContext context)
+    : IFundraiserQiiParticipationRepository
+{
+    public async Task<IReadOnlyList<InvestorHolding>> ListQiiHoldingsAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default)
+    {
+        return await context.InvestorHoldings
+            .AsNoTracking()
+            .Include(h => h.User)
+            .Where(h =>
+                h.OfferingId == offeringId
+                && !h.IsDeleted
+                && context.UserInvestmentProfiles.Any(p =>
+                    p.UserId == h.UserId
+                    && !p.IsDeleted
+                    && p.InvestorCategory == InvestorCategory.QualifiedInstitutionalInvestor))
+            .OrderByDescending(h => h.InvestedAt)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<InvestmentOrder>> ListQiiPendingOrdersAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default)
+    {
+        return await context.InvestmentOrders
+            .AsNoTracking()
+            .Include(o => o.User)
+            .Where(o =>
+                o.OfferingId == offeringId
+                && !o.IsDeleted
+                && o.Status == InvestmentOrderStatus.PendingPayment
+                && context.UserInvestmentProfiles.Any(p =>
+                    p.UserId == o.UserId
+                    && !p.IsDeleted
+                    && p.InvestorCategory == InvestorCategory.QualifiedInstitutionalInvestor))
+            .OrderByDescending(o => o.CreatedAt)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyDictionary<int, UserInvestmentProfile>> GetProfilesByUserIdsAsync(
+        IReadOnlyCollection<int> userIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (userIds.Count == 0)
+        {
+            return new Dictionary<int, UserInvestmentProfile>();
+        }
+
+        var profiles = await context.UserInvestmentProfiles
+            .AsNoTracking()
+            .Where(p => userIds.Contains(p.UserId) && !p.IsDeleted)
+            .ToListAsync(cancellationToken);
+
+        return profiles
+            .GroupBy(p => p.UserId)
+            .ToDictionary(g => g.Key, g => g.First());
+    }
+}

--- a/Antital.Infrastructure/Seed/FundraiserInvestorMessagesSeed.cs
+++ b/Antital.Infrastructure/Seed/FundraiserInvestorMessagesSeed.cs
@@ -1,0 +1,121 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Antital.Infrastructure.Seed;
+
+/// <summary>
+/// Seeds sample investor inbox messages on owned offerings for local fundraiser testing.
+/// Idempotent: skips an offering when it already has messages.
+/// </summary>
+public static class FundraiserInvestorMessagesSeed
+{
+    public static async Task SeedAsync(
+        AntitalDBContext context,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        var ownedOfferings = await context.InvestmentOfferings
+            .Where(o => !o.IsDeleted && o.OwnerUserId != null)
+            .OrderBy(o => o.Id)
+            .ToListAsync(cancellationToken);
+
+        if (ownedOfferings.Count == 0)
+        {
+            return;
+        }
+
+        var askers = await context.Users
+            .Where(u => !u.IsDeleted &&
+                        (u.UserType == UserTypeEnum.IndividualInvestor ||
+                         u.UserType == UserTypeEnum.CorporateInvestor))
+            .OrderBy(u => u.Id)
+            .Take(5)
+            .ToListAsync(cancellationToken);
+
+        if (askers.Count == 0)
+        {
+            logger.LogInformation("Fundraiser investor messages seed skipped: no investor users found.");
+            return;
+        }
+
+        var seededCount = 0;
+        foreach (var offering in ownedOfferings)
+        {
+            var hasMessages = await context.OfferingInvestorMessages
+                .AnyAsync(m => m.OfferingId == offering.Id && !m.IsDeleted, cancellationToken);
+            if (hasMessages)
+            {
+                continue;
+            }
+
+            var askerA = askers[0];
+            var askerB = askers[Math.Min(1, askers.Count - 1)];
+            var askerC = askers[Math.Min(2, askers.Count - 1)];
+            var now = DateTime.UtcNow;
+
+            var messages = new[]
+            {
+                CreateMessage(
+                    offering.Id,
+                    askerA.Id,
+                    "What are your projected returns for the next 24 months?",
+                    OfferingInvestorMessageVisibility.Private,
+                    now.AddHours(-1),
+                    reply: null,
+                    repliedAt: null),
+                CreateMessage(
+                    offering.Id,
+                    askerB.Id,
+                    "Will there be a secondary market for these units?",
+                    OfferingInvestorMessageVisibility.Public,
+                    now.AddHours(-3),
+                    reply: null,
+                    repliedAt: null),
+                CreateMessage(
+                    offering.Id,
+                    askerC.Id,
+                    "What is the minimum investment amount for this offering?",
+                    OfferingInvestorMessageVisibility.Private,
+                    now.AddHours(-3),
+                    reply: "The minimum investment is 10M.",
+                    repliedAt: now.AddHours(-2)),
+            };
+
+            await context.OfferingInvestorMessages.AddRangeAsync(messages, cancellationToken);
+            seededCount += messages.Length;
+        }
+
+        if (seededCount == 0)
+        {
+            return;
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+        logger.LogInformation("Seeded {Count} fundraiser investor inbox messages.", seededCount);
+    }
+
+    private static OfferingInvestorMessage CreateMessage(
+        int offeringId,
+        int askerUserId,
+        string question,
+        OfferingInvestorMessageVisibility visibility,
+        DateTime askedAt,
+        string? reply,
+        DateTime? repliedAt)
+    {
+        var message = new OfferingInvestorMessage
+        {
+            OfferingId = offeringId,
+            AskerUserId = askerUserId,
+            Question = question,
+            Visibility = visibility,
+            AskedAt = askedAt,
+            Reply = reply,
+            RepliedAt = repliedAt,
+        };
+        message.Created("Seed");
+        return message;
+    }
+}

--- a/Antital.Infrastructure/Seed/FundraiserQiiParticipationSeed.cs
+++ b/Antital.Infrastructure/Seed/FundraiserQiiParticipationSeed.cs
@@ -1,0 +1,214 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Antital.Infrastructure.Seed;
+
+/// <summary>
+/// Seeds sample QII corporate investors with confirmed holdings / pending orders
+/// on each fundraiser's primary owned offering (same selection rule as dashboard).
+/// Idempotent per offering.
+/// </summary>
+public static class FundraiserQiiParticipationSeed
+{
+    private const string SeedActor = "Seed";
+    private const string PreferredFundraiserEmail = "johneseyin@gmail.com";
+
+    public static async Task SeedAsync(
+        AntitalDBContext context,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        var owners = await context.InvestmentOfferings
+            .AsNoTracking()
+            .Where(o => !o.IsDeleted && o.OwnerUserId != null)
+            .Select(o => o.OwnerUserId!.Value)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        if (owners.Count == 0)
+        {
+            return;
+        }
+
+        // Prefer the known local fundraiser first so demo data lands on their primary campaign.
+        var preferred = await context.Users
+            .AsNoTracking()
+            .Where(u => !u.IsDeleted && u.Email == PreferredFundraiserEmail)
+            .Select(u => (int?)u.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (preferred.HasValue && owners.Contains(preferred.Value))
+        {
+            owners.Remove(preferred.Value);
+            owners.Insert(0, preferred.Value);
+        }
+
+        var confirmed = await EnsureQiiUserAsync(
+            context,
+            "qii-stanbic-seed@example.com",
+            "Stanbic IBTC Asset Mgmt",
+            QiiInstitutionType.AssetManagementCompany,
+            cancellationToken);
+        var pending = await EnsureQiiUserAsync(
+            context,
+            "qii-arm-seed@example.com",
+            "ARM Investment Managers",
+            QiiInstitutionType.VentureCapitalOrPrivateEquityFund,
+            cancellationToken);
+
+        var seededCount = 0;
+        foreach (var ownerUserId in owners)
+        {
+            var offering = await GetPrimaryOfferingAsync(context, ownerUserId, cancellationToken);
+            if (offering == null)
+            {
+                continue;
+            }
+
+            var hasQii = await (
+                from h in context.InvestorHoldings
+                join p in context.UserInvestmentProfiles on h.UserId equals p.UserId
+                where h.OfferingId == offering.Id
+                      && !h.IsDeleted
+                      && !p.IsDeleted
+                      && p.InvestorCategory == InvestorCategory.QualifiedInstitutionalInvestor
+                select h.Id
+            ).AnyAsync(cancellationToken);
+
+            var hasPending = await (
+                from o in context.InvestmentOrders
+                join p in context.UserInvestmentProfiles on o.UserId equals p.UserId
+                where o.OfferingId == offering.Id
+                      && !o.IsDeleted
+                      && !p.IsDeleted
+                      && o.Status == InvestmentOrderStatus.PendingPayment
+                      && p.InvestorCategory == InvestorCategory.QualifiedInstitutionalInvestor
+                select o.Id
+            ).AnyAsync(cancellationToken);
+
+            if (hasQii || hasPending)
+            {
+                continue;
+            }
+
+            var now = DateTime.UtcNow;
+            var holding = new InvestorHolding
+            {
+                UserId = confirmed.Id,
+                OfferingId = offering.Id,
+                InvestedAmount = 40_000_000m,
+                CurrentValue = 40_000_000m,
+                Returns = 0m,
+                UnitHolding = 400,
+                InvestedAt = now.AddDays(-20),
+            };
+            holding.Created(SeedActor);
+
+            var order = new InvestmentOrder
+            {
+                UserId = pending.Id,
+                OfferingId = offering.Id,
+                Units = 185,
+                SharePrice = 100_000m,
+                Subtotal = 18_500_000m,
+                PlatformFeePercent = 0m,
+                PlatformFee = 0m,
+                TotalAmount = 18_500_000m,
+                Currency = "NGN",
+                Status = InvestmentOrderStatus.PendingPayment,
+                ExpiresAt = now.AddDays(2),
+            };
+            order.Created(SeedActor);
+
+            context.InvestorHoldings.Add(holding);
+            context.InvestmentOrders.Add(order);
+            seededCount++;
+        }
+
+        if (seededCount == 0)
+        {
+            return;
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+        logger.LogInformation(
+            "Seeded QII participation samples on {Count} primary owned offering(s).",
+            seededCount);
+    }
+
+    private static async Task<InvestmentOffering?> GetPrimaryOfferingAsync(
+        AntitalDBContext context,
+        int ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        return await context.InvestmentOfferings
+            .AsNoTracking()
+            .Include(o => o.DealTerms)
+            .Where(o => o.OwnerUserId == ownerUserId && !o.IsDeleted)
+            .OrderByDescending(o => o.Status == OfferingStatus.Published)
+            .ThenBy(o => o.DealTerms != null && o.DealTerms.Deadline >= now ? 0 : 1)
+            .ThenBy(o => o.DealTerms != null ? o.DealTerms.Deadline : DateTime.MaxValue)
+            .ThenByDescending(o => o.PublishedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private static async Task<User> EnsureQiiUserAsync(
+        AntitalDBContext context,
+        string email,
+        string companyName,
+        QiiInstitutionType institutionType,
+        CancellationToken cancellationToken)
+    {
+        var user = await context.Users.FirstOrDefaultAsync(
+            u => u.Email == email && !u.IsDeleted,
+            cancellationToken);
+
+        if (user == null)
+        {
+            user = new User
+            {
+                Email = email,
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
+                UserType = UserTypeEnum.CorporateInvestor,
+                IsEmailVerified = true,
+                FirstName = "QII",
+                LastName = "Investor",
+                PhoneNumber = "+2348011111111",
+                DateOfBirth = new DateTime(1985, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                Nationality = "Nigerian",
+                CountryOfResidence = "Nigeria",
+                StateOfResidence = "Lagos",
+                ResidentialAddress = "Victoria Island",
+                HasAgreedToTerms = true,
+            };
+            user.Created(SeedActor);
+            context.Users.Add(user);
+            await context.SaveChangesAsync(cancellationToken);
+        }
+
+        var profile = await context.UserInvestmentProfiles.FirstOrDefaultAsync(
+            p => p.UserId == user.Id && !p.IsDeleted,
+            cancellationToken);
+
+        if (profile == null)
+        {
+            profile = new UserInvestmentProfile
+            {
+                UserId = user.Id,
+                InvestorCategory = InvestorCategory.QualifiedInstitutionalInvestor,
+                CompanyLegalName = companyName,
+                QiiInstitutionTypes = institutionType.ToString(),
+                HasValidQiiRegistrationOrLicense = true,
+                ConfirmsSecNigeriaQiiCriteria = true,
+            };
+            profile.Created(SeedActor);
+            context.UserInvestmentProfiles.Add(profile);
+            await context.SaveChangesAsync(cancellationToken);
+        }
+
+        return user;
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/FundraisersControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/FundraisersControllerTests.cs
@@ -232,6 +232,187 @@ public class FundraisersControllerTests : IClassFixture<CustomWebApplicationFact
         result.Value.PublicPath.Should().Be("/explore/campaign-context");
     }
 
+    [Fact]
+    public async Task GetQiiParticipation_WithoutAuth_Returns401()
+    {
+        var response = await _client.GetAsync("/api/fundraisers/me/investors/qii");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetQiiParticipation_ConfirmedAndPending_ReturnsRows()
+    {
+        var fundraiser = SeedUser("fundraiser-qii@example.com", UserTypeEnum.FundRaiser);
+        var confirmed = SeedUser("qii-confirmed@example.com", UserTypeEnum.CorporateInvestor);
+        var pending = SeedUser("qii-pending@example.com", UserTypeEnum.CorporateInvestor);
+        await _context.SaveChangesAsync();
+
+        var offering = await SeedOwnedOfferingAsync(fundraiser.Id, "qii-campaign");
+        await SeedQiiProfileAsync(confirmed.Id, "Stanbic IBTC Asset Mgmt", QiiInstitutionType.AssetManagementCompany);
+        await SeedQiiProfileAsync(pending.Id, "ARM Investment Managers", QiiInstitutionType.VentureCapitalOrPrivateEquityFund);
+
+        var holding = new InvestorHolding
+        {
+            UserId = confirmed.Id,
+            OfferingId = offering.Id,
+            InvestedAmount = 40_000_000m,
+            CurrentValue = 40_000_000m,
+            Returns = 0m,
+            UnitHolding = 400,
+            InvestedAt = DateTime.UtcNow.AddDays(-10),
+        };
+        holding.Created("TestUser");
+
+        var order = new InvestmentOrder
+        {
+            UserId = pending.Id,
+            OfferingId = offering.Id,
+            Units = 185,
+            SharePrice = 100_000m,
+            Subtotal = 18_500_000m,
+            PlatformFeePercent = 0m,
+            PlatformFee = 0m,
+            TotalAmount = 18_500_000m,
+            Currency = "NGN",
+            Status = InvestmentOrderStatus.PendingPayment,
+            ExpiresAt = DateTime.UtcNow.AddDays(1),
+        };
+        order.Created("TestUser");
+
+        _context.InvestorHoldings.Add(holding);
+        _context.InvestmentOrders.Add(order);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/investors/qii");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserQiiParticipationResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.OfferingId.Should().Be(offering.Id);
+        result.Value.Items.Should().HaveCount(2);
+        result.Value.Items.Should().Contain(i =>
+            i.Institution == "Stanbic IBTC Asset Mgmt"
+            && i.Type == "Asset Manager"
+            && i.CommitmentAmount == 40_000_000m
+            && i.Status == "confirmed");
+        result.Value.Items.Should().Contain(i =>
+            i.Institution == "ARM Investment Managers"
+            && i.Type == "Fund Manager"
+            && i.CommitmentAmount == 18_500_000m
+            && i.Status == "pending");
+    }
+
+    [Fact]
+    public async Task ListInvestorMessages_WithoutAuth_Returns401()
+    {
+        var response = await _client.GetAsync("/api/fundraisers/me/investors/messages");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ListInvestorMessages_NoOwnedOffering_ReturnsEmpty()
+    {
+        var fundraiser = SeedUser("fundraiser-inbox-empty@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/investors/messages");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserInvestorMessagesResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Should().BeEmpty();
+        result.Value.TotalCount.Should().Be(0);
+        result.Value.NewCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ReplyAndPatchInvestorMessage_UpdatesVisibilityAndAnalytics()
+    {
+        var fundraiser = SeedUser("fundraiser-inbox@example.com", UserTypeEnum.FundRaiser);
+        var asker = SeedUser("inbox-asker@example.com", UserTypeEnum.IndividualInvestor);
+        asker.FirstName = "Ahmed";
+        asker.LastName = "Lawal";
+        await _context.SaveChangesAsync();
+
+        var offering = await SeedOwnedOfferingAsync(fundraiser.Id, "inbox-campaign");
+        var message = new OfferingInvestorMessage
+        {
+            OfferingId = offering.Id,
+            AskerUserId = asker.Id,
+            Question = "What is the minimum investment?",
+            Visibility = OfferingInvestorMessageVisibility.Public,
+            AskedAt = DateTime.UtcNow.AddHours(-4),
+        };
+        message.Created("TestUser");
+        _context.OfferingInvestorMessages.Add(message);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+
+        var listBefore = await authClient.GetAsync("/api/fundraisers/me/investors/messages?status=unanswered");
+        var unanswered = await listBefore.Content.ReadFromJsonAsync<Result<FundraiserInvestorMessagesResponse>>(JsonOptions);
+        unanswered!.Value!.Items.Should().ContainSingle(i => i.Id == message.Id);
+        unanswered.Value.NewCount.Should().Be(1);
+        unanswered.Value.Items[0].Author.DisplayName.Should().Be("Ahmed Lawal");
+
+        var replyResponse = await authClient.PostAsJsonAsync(
+            $"/api/fundraisers/me/investors/messages/{message.Id}/reply",
+            new ReplyFundraiserInvestorMessageRequest("The minimum investment is 10M."));
+        replyResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var replied = await replyResponse.Content.ReadFromJsonAsync<Result<FundraiserInvestorMessageDto>>(JsonOptions);
+        replied!.Value!.Reply.Should().Be("The minimum investment is 10M.");
+        replied.Value.Status.Should().Be("answered");
+        replied.Value.RepliedAt.Should().NotBeNull();
+
+        var patchResponse = await authClient.PatchAsJsonAsync(
+            $"/api/fundraisers/me/investors/messages/{message.Id}",
+            new UpdateFundraiserInvestorMessageRequest("private", null));
+        patchResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var patched = await patchResponse.Content.ReadFromJsonAsync<Result<FundraiserInvestorMessageDto>>(JsonOptions);
+        patched!.Value!.Visibility.Should().Be("private");
+
+        var analyticsResponse = await authClient.GetAsync("/api/fundraisers/me/investors/analytics");
+        analyticsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var analytics = await analyticsResponse.Content.ReadFromJsonAsync<Result<FundraiserInvestorAnalyticsResponse>>(JsonOptions);
+        analytics!.Value!.TotalMessages.Should().Be(1);
+        analytics.Value.AnsweredCount.Should().Be(1);
+        analytics.Value.UnansweredCount.Should().Be(0);
+        analytics.Value.ResponseRate.Should().Be(1m);
+        analytics.Value.AverageResponseTimeHours.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ReplyInvestorMessage_WrongOwner_Returns404()
+    {
+        var owner = SeedUser("fundraiser-inbox-owner@example.com", UserTypeEnum.FundRaiser);
+        var other = SeedUser("fundraiser-inbox-other@example.com", UserTypeEnum.FundRaiser);
+        var asker = SeedUser("inbox-asker-2@example.com", UserTypeEnum.IndividualInvestor);
+        await _context.SaveChangesAsync();
+
+        var offering = await SeedOwnedOfferingAsync(owner.Id, "inbox-owner-campaign");
+        var message = new OfferingInvestorMessage
+        {
+            OfferingId = offering.Id,
+            AskerUserId = asker.Id,
+            Question = "Private question",
+            Visibility = OfferingInvestorMessageVisibility.Private,
+            AskedAt = DateTime.UtcNow.AddHours(-1),
+        };
+        message.Created("TestUser");
+        _context.OfferingInvestorMessages.Add(message);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(other.Id, other.Email);
+        var response = await authClient.PostAsJsonAsync(
+            $"/api/fundraisers/me/investors/messages/{message.Id}/reply",
+            new ReplyFundraiserInvestorMessageRequest("Nope"));
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
     private User SeedUser(string email, UserTypeEnum userType)
     {
         var user = new User
@@ -325,6 +506,22 @@ public class FundraisersControllerTests : IClassFixture<CustomWebApplicationFact
         await _context.SaveChangesAsync();
     }
 
+    private async Task SeedQiiProfileAsync(int userId, string companyName, QiiInstitutionType institutionType)
+    {
+        var profile = new UserInvestmentProfile
+        {
+            UserId = userId,
+            InvestorCategory = InvestorCategory.QualifiedInstitutionalInvestor,
+            CompanyLegalName = companyName,
+            QiiInstitutionTypes = institutionType.ToString(),
+            HasValidQiiRegistrationOrLicense = true,
+            ConfirmsSecNigeriaQiiCriteria = true,
+        };
+        profile.Created("TestUser");
+        _context.UserInvestmentProfiles.Add(profile);
+        await _context.SaveChangesAsync();
+    }
+
     private HttpClient CreateAuthorizedClient(int userId, string email)
     {
         var client = _factory.CreateClient();
@@ -353,8 +550,12 @@ public class FundraisersControllerTests : IClassFixture<CustomWebApplicationFact
 
     private void CleanupDatabase()
     {
+        _context.OfferingInvestorMessages.RemoveRange(_context.OfferingInvestorMessages);
         _context.OfferingUpdates.RemoveRange(_context.OfferingUpdates);
+        _context.PaymentTransactions.RemoveRange(_context.PaymentTransactions);
+        _context.InvestmentOrders.RemoveRange(_context.InvestmentOrders);
         _context.InvestorHoldings.RemoveRange(_context.InvestorHoldings);
+        _context.UserInvestmentProfiles.RemoveRange(_context.UserInvestmentProfiles);
         _context.InvestmentOfferings.RemoveRange(_context.InvestmentOfferings.IgnoreQueryFilters());
         _context.Users.RemoveRange(_context.Users);
         _context.SaveChanges();


### PR DESCRIPTION
## Summary
- Add fundraiser-owned investor inbox APIs (list, reply, visibility/edit) plus response analytics.
- Add QII participation list derived from QII holdings and pending payment orders on the primary owned offering.
- Include migration, local seeds, and integration coverage for auth, ownership, reply/visibility, and QII confirmed/pending rows.

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~FundraisersControllerTests`
- [x] Login as fundraiser and call `GET /api/fundraisers/me/investors/qii`
- [x] Call messages list/reply/patch and confirm analytics updates
- [x] Confirm seed data lands on primary owned offering after migrate/restart


Made with [Cursor](https://cursor.com)