### PR TITLE
Add fundraiser analytics API

### DIFF
--- a/Antital.API/Configs/AppUseExtensions.cs
+++ b/Antital.API/Configs/AppUseExtensions.cs
@@ -122,6 +122,7 @@ public static class AppUseExtensions
                     WalletTransactionSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
                     FundraiserInvestorMessagesSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
                     FundraiserQiiParticipationSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
+                    FundraiserAnalyticsEngagementSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
                 }
             }
             catch (Exception ex)

--- a/Antital.API/Configs/DependencyInjection.cs
+++ b/Antital.API/Configs/DependencyInjection.cs
@@ -72,6 +72,7 @@ public static class DependencyInjection
         services.AddScoped(typeof(IFundraiserCampaignUpdatesRepository), typeof(FundraiserCampaignUpdatesRepository));
         services.AddScoped(typeof(IFundraiserInvestorMessagesRepository), typeof(FundraiserInvestorMessagesRepository));
         services.AddScoped(typeof(IFundraiserQiiParticipationRepository), typeof(FundraiserQiiParticipationRepository));
+        services.AddScoped(typeof(IFundraiserAnalyticsRepository), typeof(FundraiserAnalyticsRepository));
         services.AddScoped(typeof(IInvestmentOrderRepository), typeof(InvestmentOrderRepository));
         services.AddScoped(typeof(IInvestorPaymentMethodRepository), typeof(InvestorPaymentMethodRepository));
         services.AddScoped(typeof(IInvestorWatchlistRepository), typeof(InvestorWatchlistRepository));

--- a/Antital.API/Controllers/FundraisersController.cs
+++ b/Antital.API/Controllers/FundraisersController.cs
@@ -2,6 +2,7 @@ using Antital.Application.DTOs.Fundraisers;
 using Antital.Application.Features.Fundraisers.CampaignUpdates.CreateFundraiserCampaignUpdate;
 using Antital.Application.Features.Fundraisers.CampaignUpdates.ListFundraiserCampaignUpdates;
 using Antital.Application.Features.Fundraisers.CampaignUpdates.UpdateFundraiserCampaignUpdate;
+using Antital.Application.Features.Fundraisers.GetFundraiserAnalytics;
 using Antital.Application.Features.Fundraisers.GetFundraiserCampaign;
 using Antital.Application.Features.Fundraisers.GetFundraiserDashboard;
 using Antital.Application.Features.Fundraisers.Investors.GetFundraiserInvestorAnalytics;
@@ -109,6 +110,22 @@ public class FundraisersController(IMediator mediator) : BaseController
         var result = await mediator.Send(
             new UpdateFundraiserCampaignUpdateCommand(updateId, request.Title, request.Body, request.Publish),
             cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpGet("me/analytics")]
+    [SwaggerOperation(
+        "Get Fundraiser Analytics",
+        "Returns engagement overview, traffic series, investor diversity, and conversion metrics for the primary owned offering.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserAnalyticsResponse>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid period", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    public async Task<IActionResult> GetAnalytics(
+        [FromQuery] string period = "last-7-days",
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(new GetFundraiserAnalyticsQuery(period), cancellationToken);
         return ApiResult(result);
     }
 

--- a/Antital.Application/DTOs/Fundraisers/FundraiserAnalyticsDtos.cs
+++ b/Antital.Application/DTOs/Fundraisers/FundraiserAnalyticsDtos.cs
@@ -1,0 +1,38 @@
+namespace Antital.Application.DTOs.Fundraisers;
+
+public record FundraiserAnalyticsOverviewDto(
+    int TotalPageViews,
+    int CampaignLikes,
+    int SocialShares);
+
+public record FundraiserAnalyticsTrafficPointDto(
+    DateTime Date,
+    string Label,
+    int Value);
+
+public record FundraiserAnalyticsTrafficDto(
+    double AveragePerDay,
+    string Unit,
+    IReadOnlyList<FundraiserAnalyticsTrafficPointDto> Points);
+
+public record FundraiserAnalyticsBucketDto(
+    string Label,
+    int Percentage);
+
+public record FundraiserAnalyticsDiversityDto(
+    string? TopLocation,
+    IReadOnlyList<FundraiserAnalyticsBucketDto> Geographic,
+    IReadOnlyList<FundraiserAnalyticsBucketDto> Categories);
+
+public record FundraiserAnalyticsConversionDto(
+    decimal ViewToInvestmentRate,
+    double? AverageTimeToInvestHours,
+    decimal ReturnVisitorRate);
+
+public record FundraiserAnalyticsResponse(
+    int? OfferingId,
+    string? OfferingSlug,
+    FundraiserAnalyticsOverviewDto Overview,
+    FundraiserAnalyticsTrafficDto Traffic,
+    FundraiserAnalyticsDiversityDto Diversity,
+    FundraiserAnalyticsConversionDto Conversion);

--- a/Antital.Application/Features/Fundraisers/GetFundraiserAnalytics/FundraiserAnalyticsMappers.cs
+++ b/Antital.Application/Features/Fundraisers/GetFundraiserAnalytics/FundraiserAnalyticsMappers.cs
@@ -1,0 +1,260 @@
+using System.ComponentModel;
+using System.Reflection;
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+
+namespace Antital.Application.Features.Fundraisers.GetFundraiserAnalytics;
+
+internal static class FundraiserAnalyticsMappers
+{
+    private static readonly HashSet<string> WestAfrica = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Nigeria", "Ghana", "Senegal", "Ivory Coast", "Côte d'Ivoire", "Cote d'Ivoire",
+        "Benin", "Togo", "Mali", "Niger", "Burkina Faso", "Liberia", "Sierra Leone",
+        "Guinea", "Gambia", "Cape Verde", "NG", "GH",
+    };
+
+    private static readonly HashSet<string> Europe = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "United Kingdom", "UK", "England", "France", "Germany", "Netherlands", "Spain",
+        "Italy", "Ireland", "Belgium", "Portugal", "Sweden", "Switzerland", "GB", "DE", "FR",
+    };
+
+    private static readonly HashSet<string> Americas = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "United States", "USA", "US", "Canada", "Brazil", "Mexico", "Argentina", "CA",
+    };
+
+    public static bool TryParsePeriod(string? period, out DateTime fromUtc, out DateTime toUtcExclusive, out string? error)
+    {
+        error = null;
+        var today = DateTime.UtcNow.Date;
+        toUtcExclusive = today.AddDays(1);
+
+        if (string.IsNullOrWhiteSpace(period) || period.Equals("last-7-days", StringComparison.OrdinalIgnoreCase))
+        {
+            fromUtc = today.AddDays(-6);
+            return true;
+        }
+
+        if (period.Equals("last-14-days", StringComparison.OrdinalIgnoreCase))
+        {
+            fromUtc = today.AddDays(-13);
+            return true;
+        }
+
+        if (period.Equals("last-30-days", StringComparison.OrdinalIgnoreCase))
+        {
+            fromUtc = today.AddDays(-29);
+            return true;
+        }
+
+        fromUtc = today;
+        error = "Period must be last-7-days, last-14-days, or last-30-days.";
+        return false;
+    }
+
+    public static FundraiserAnalyticsResponse Empty() =>
+        new(
+            null,
+            null,
+            new FundraiserAnalyticsOverviewDto(0, 0, 0),
+            new FundraiserAnalyticsTrafficDto(0, "views", []),
+            new FundraiserAnalyticsDiversityDto(null, [], []),
+            new FundraiserAnalyticsConversionDto(0m, null, 0m));
+
+    public static FundraiserAnalyticsResponse ToResponse(
+        InvestmentOffering offering,
+        IReadOnlyList<OfferingEngagementDaily> engagement,
+        DateTime fromUtc,
+        DateTime toUtcExclusive,
+        int campaignLikes,
+        IReadOnlyList<InvestorHolding> holdings,
+        IReadOnlyDictionary<int, UserInvestmentProfile> profiles,
+        IReadOnlyList<InvestmentOrder> paidOrders)
+    {
+        var byDate = engagement
+            .GroupBy(e => e.Date.Date)
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var points = new List<FundraiserAnalyticsTrafficPointDto>();
+        for (var day = fromUtc.Date; day < toUtcExclusive; day = day.AddDays(1))
+        {
+            byDate.TryGetValue(day, out var row);
+            var views = row?.PageViews ?? 0;
+            points.Add(new FundraiserAnalyticsTrafficPointDto(
+                day,
+                day.ToString("ddd", System.Globalization.CultureInfo.InvariantCulture),
+                views));
+        }
+
+        var totalViews = points.Sum(p => p.Value);
+        var totalShares = engagement.Sum(e => e.Shares);
+        var totalUnique = engagement.Sum(e => e.UniqueVisitors);
+        var dayCount = points.Count == 0 ? 1 : points.Count;
+        var averagePerDay = Math.Round((double)totalViews / dayCount, 1, MidpointRounding.AwayFromZero);
+
+        var investors = holdings
+            .GroupBy(h => h.UserId)
+            .Select(g => g.First())
+            .ToList();
+        var investorCount = investors.Count;
+
+        var viewToInvest = totalViews <= 0
+            ? 0m
+            : decimal.Round((decimal)investorCount / totalViews, 4, MidpointRounding.AwayFromZero);
+
+        var returnVisitorRate = totalViews <= 0
+            ? 0m
+            : decimal.Round(
+                Math.Clamp((decimal)(totalViews - totalUnique) / totalViews, 0m, 1m),
+                4,
+                MidpointRounding.AwayFromZero);
+
+        double? avgHours = null;
+        var durations = paidOrders
+            .Where(o => o.PaidAt.HasValue)
+            .Select(o => (o.PaidAt!.Value - o.CreatedAt).TotalHours)
+            .Where(h => h >= 0)
+            .ToList();
+        if (durations.Count > 0)
+        {
+            avgHours = Math.Round(durations.Average(), 2, MidpointRounding.AwayFromZero);
+        }
+
+        return new FundraiserAnalyticsResponse(
+            offering.Id,
+            offering.Slug,
+            new FundraiserAnalyticsOverviewDto(totalViews, campaignLikes, totalShares),
+            new FundraiserAnalyticsTrafficDto(averagePerDay, "views", points),
+            BuildDiversity(investors, profiles),
+            new FundraiserAnalyticsConversionDto(viewToInvest, avgHours, returnVisitorRate));
+    }
+
+    private static FundraiserAnalyticsDiversityDto BuildDiversity(
+        IReadOnlyList<InvestorHolding> uniqueHolders,
+        IReadOnlyDictionary<int, UserInvestmentProfile> profiles)
+    {
+        if (uniqueHolders.Count == 0)
+        {
+            return new FundraiserAnalyticsDiversityDto(null, [], []);
+        }
+
+        var geoCounts = uniqueHolders
+            .GroupBy(h => ResolveRegion(h.User?.CountryOfResidence))
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var geoOrder = new[] { "West Africa", "Europe", "Americas", "Other" };
+        var geographic = ToPercentageBuckets(geoOrder.Select(label => (label, geoCounts.GetValueOrDefault(label))));
+
+        var categoryCounts = uniqueHolders
+            .GroupBy(h =>
+            {
+                if (!profiles.TryGetValue(h.UserId, out var profile))
+                {
+                    return "Uncategorized";
+                }
+
+                return GetEnumDescription(profile.InvestorCategory);
+            })
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        var categories = ToPercentageBuckets(
+            categoryCounts.OrderByDescending(kv => kv.Value).Select(kv => (kv.Key, kv.Value)));
+
+        var topLocation = uniqueHolders
+            .Select(h => FormatLocation(h.User?.StateOfResidence, h.User?.CountryOfResidence))
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .GroupBy(s => s!)
+            .OrderByDescending(g => g.Count())
+            .Select(g => g.Key)
+            .FirstOrDefault();
+
+        return new FundraiserAnalyticsDiversityDto(topLocation, geographic, categories);
+    }
+
+    private static IReadOnlyList<FundraiserAnalyticsBucketDto> ToPercentageBuckets(
+        IEnumerable<(string Label, int Count)> items)
+    {
+        var list = items.Where(i => i.Count > 0).ToList();
+        var total = list.Sum(i => i.Count);
+        if (total == 0)
+        {
+            return [];
+        }
+
+        var buckets = list
+            .Select(i => new FundraiserAnalyticsBucketDto(
+                i.Label,
+                (int)Math.Round(100.0 * i.Count / total, MidpointRounding.AwayFromZero)))
+            .ToList();
+
+        // Fix rounding so percentages sum to 100 when possible.
+        var drift = 100 - buckets.Sum(b => b.Percentage);
+        if (drift != 0 && buckets.Count > 0)
+        {
+            var first = buckets[0];
+            buckets[0] = first with { Percentage = first.Percentage + drift };
+        }
+
+        return buckets;
+    }
+
+    private static string ResolveRegion(string? country)
+    {
+        if (string.IsNullOrWhiteSpace(country))
+        {
+            return "Other";
+        }
+
+        var trimmed = country.Trim();
+        if (WestAfrica.Contains(trimmed) || trimmed.Contains("Nigeria", StringComparison.OrdinalIgnoreCase))
+        {
+            return "West Africa";
+        }
+
+        if (Europe.Contains(trimmed))
+        {
+            return "Europe";
+        }
+
+        if (Americas.Contains(trimmed))
+        {
+            return "Americas";
+        }
+
+        return "Other";
+    }
+
+    private static string? FormatLocation(string? state, string? country)
+    {
+        var statePart = string.IsNullOrWhiteSpace(state) ? null : state.Trim();
+        var countryPart = string.IsNullOrWhiteSpace(country) ? null : AbbreviateCountry(country.Trim());
+        if (statePart == null && countryPart == null)
+        {
+            return null;
+        }
+
+        if (statePart != null && countryPart != null)
+        {
+            return $"{statePart}, {countryPart}";
+        }
+
+        return statePart ?? countryPart;
+    }
+
+    private static string AbbreviateCountry(string country) =>
+        country.Equals("Nigeria", StringComparison.OrdinalIgnoreCase) ? "NG"
+        : country.Equals("United Kingdom", StringComparison.OrdinalIgnoreCase) || country.Equals("UK", StringComparison.OrdinalIgnoreCase) ? "GB"
+        : country.Equals("United States", StringComparison.OrdinalIgnoreCase) || country.Equals("USA", StringComparison.OrdinalIgnoreCase) ? "US"
+        : country.Length <= 3 ? country.ToUpperInvariant()
+        : country;
+
+    private static string GetEnumDescription(InvestorCategory category)
+    {
+        var field = category.GetType().GetField(category.ToString());
+        var attribute = field?.GetCustomAttribute<DescriptionAttribute>();
+        return attribute?.Description ?? category.ToString();
+    }
+}

--- a/Antital.Application/Features/Fundraisers/GetFundraiserAnalytics/GetFundraiserAnalyticsQuery.cs
+++ b/Antital.Application/Features/Fundraisers/GetFundraiserAnalytics/GetFundraiserAnalyticsQuery.cs
@@ -1,0 +1,70 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Fundraisers.GetFundraiserAnalytics;
+
+public record GetFundraiserAnalyticsQuery(string? Period = "last-7-days")
+    : ICommandQuery<FundraiserAnalyticsResponse>;
+
+public class GetFundraiserAnalyticsQueryHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserDashboardRepository dashboardRepository,
+    IFundraiserAnalyticsRepository analyticsRepository
+) : ICommandQueryHandler<GetFundraiserAnalyticsQuery, FundraiserAnalyticsResponse>
+{
+    public async Task<Result<FundraiserAnalyticsResponse>> Handle(
+        GetFundraiserAnalyticsQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (!FundraiserAnalyticsMappers.TryParsePeriod(
+                request.Period,
+                out var fromUtc,
+                out var toUtcExclusive,
+                out var periodError))
+        {
+            var invalid = new Result<FundraiserAnalyticsResponse>();
+            invalid.BadRequest(
+                "Invalid period.",
+                new Dictionary<string, string[]> { ["period"] = [periodError!] });
+            return invalid;
+        }
+
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var offering = await dashboardRepository.GetPrimaryOfferingAsync(userId, cancellationToken);
+
+        if (offering == null)
+        {
+            var empty = new Result<FundraiserAnalyticsResponse>();
+            empty.AddValue(FundraiserAnalyticsMappers.Empty());
+            empty.OK();
+            return empty;
+        }
+
+        var engagement = await analyticsRepository.GetEngagementAsync(
+            offering.Id,
+            fromUtc,
+            toUtcExclusive,
+            cancellationToken);
+        var likes = await analyticsRepository.GetCampaignLikesAsync(offering.Id, cancellationToken);
+        var holdings = await analyticsRepository.GetHoldingsWithUsersAsync(offering.Id, cancellationToken);
+        var userIds = holdings.Select(h => h.UserId).Distinct().ToList();
+        var profiles = await analyticsRepository.GetProfilesByUserIdsAsync(userIds, cancellationToken);
+        var paidOrders = await analyticsRepository.GetPaidOrdersAsync(offering.Id, cancellationToken);
+
+        var response = FundraiserAnalyticsMappers.ToResponse(
+            offering,
+            engagement,
+            fromUtc,
+            toUtcExclusive,
+            likes,
+            holdings,
+            profiles,
+            paidOrders);
+
+        var result = new Result<FundraiserAnalyticsResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Domain/Interfaces/IFundraiserAnalyticsRepository.cs
+++ b/Antital.Domain/Interfaces/IFundraiserAnalyticsRepository.cs
@@ -1,0 +1,30 @@
+using Antital.Domain.Models;
+
+namespace Antital.Domain.Interfaces;
+
+public interface IFundraiserAnalyticsRepository
+{
+    Task<IReadOnlyList<OfferingEngagementDaily>> GetEngagementAsync(
+        int offeringId,
+        DateTime fromUtcInclusive,
+        DateTime toUtcExclusive,
+        CancellationToken cancellationToken = default);
+
+    Task<int> GetCampaignLikesAsync(int offeringId, CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<InvestorHolding>> GetHoldingsWithUsersAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyDictionary<int, UserInvestmentProfile>> GetProfilesByUserIdsAsync(
+        IReadOnlyCollection<int> userIds,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<InvestmentOrder>> GetPaidOrdersAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default);
+
+    Task AddRangeAsync(
+        IEnumerable<OfferingEngagementDaily> rows,
+        CancellationToken cancellationToken = default);
+}

--- a/Antital.Domain/Models/InvestmentOffering.cs
+++ b/Antital.Domain/Models/InvestmentOffering.cs
@@ -29,5 +29,6 @@ public class InvestmentOffering : TrackableEntity
     public ICollection<MediaAsset> MediaAssets { get; set; } = [];
     public ICollection<OfferingUpdate> Updates { get; set; } = [];
     public ICollection<OfferingInvestorMessage> InvestorMessages { get; set; } = [];
+    public ICollection<OfferingEngagementDaily> EngagementDailies { get; set; } = [];
     public ICollection<Testimonial> Testimonials { get; set; } = [];
 }

--- a/Antital.Domain/Models/OfferingEngagementDaily.cs
+++ b/Antital.Domain/Models/OfferingEngagementDaily.cs
@@ -1,0 +1,20 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+/// <summary>
+/// Daily engagement counters for an offering (page views, unique visitors, shares).
+/// </summary>
+public class OfferingEngagementDaily : TrackableEntity
+{
+    public int OfferingId { get; set; }
+
+    /// <summary>UTC calendar date (time component ignored).</summary>
+    public DateTime Date { get; set; }
+
+    public int PageViews { get; set; }
+    public int UniqueVisitors { get; set; }
+    public int Shares { get; set; }
+
+    public virtual InvestmentOffering Offering { get; set; } = null!;
+}

--- a/Antital.Infrastructure/AntitalDBContext.cs
+++ b/Antital.Infrastructure/AntitalDBContext.cs
@@ -27,6 +27,7 @@ public class AntitalDBContext(
     public DbSet<MediaAsset> MediaAssets { get; set; }
     public DbSet<OfferingUpdate> OfferingUpdates { get; set; }
     public DbSet<OfferingInvestorMessage> OfferingInvestorMessages { get; set; }
+    public DbSet<OfferingEngagementDaily> OfferingEngagementDailies { get; set; }
     public DbSet<Testimonial> Testimonials { get; set; }
     public DbSet<OfferingCorporateProfile> OfferingCorporateProfiles { get; set; }
     public DbSet<InvestorWallet> InvestorWallets { get; set; }
@@ -374,6 +375,15 @@ public class AntitalDBContext(
             entity.HasIndex(e => new { e.OfferingId, e.AskedAt })
                 .HasFilter("\"IsDeleted\" = false");
             entity.HasIndex(e => new { e.OfferingId, e.RepliedAt })
+                .HasFilter("\"IsDeleted\" = false");
+        });
+
+        modelBuilder.Entity<OfferingEngagementDaily>(entity =>
+        {
+            entity.HasOne(e => e.Offering).WithMany(o => o.EngagementDailies).HasForeignKey(e => e.OfferingId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasIndex(e => new { e.OfferingId, e.Date })
+                .IsUnique()
                 .HasFilter("\"IsDeleted\" = false");
         });
 

--- a/Antital.Infrastructure/Migrations/20260724004044_AddOfferingEngagementDaily.Designer.cs
+++ b/Antital.Infrastructure/Migrations/20260724004044_AddOfferingEngagementDaily.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Antital.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Antital.Infrastructure.Migrations
 {
     [DbContext(typeof(AntitalDBContext))]
-    partial class AntitalDBContextModelSnapshot : ModelSnapshot
+    [Migration("20260724004044_AddOfferingEngagementDaily")]
+    partial class AddOfferingEngagementDaily
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Antital.Infrastructure/Migrations/20260724004044_AddOfferingEngagementDaily.cs
+++ b/Antital.Infrastructure/Migrations/20260724004044_AddOfferingEngagementDaily.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Antital.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOfferingEngagementDaily : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OfferingEngagementDailies",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    OfferingId = table.Column<int>(type: "integer", nullable: false),
+                    Date = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    PageViews = table.Column<int>(type: "integer", nullable: false),
+                    UniqueVisitors = table.Column<int>(type: "integer", nullable: false),
+                    Shares = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OfferingEngagementDailies", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OfferingEngagementDailies_InvestmentOfferings_OfferingId",
+                        column: x => x.OfferingId,
+                        principalTable: "InvestmentOfferings",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingEngagementDailies_OfferingId_Date",
+                table: "OfferingEngagementDailies",
+                columns: new[] { "OfferingId", "Date" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OfferingEngagementDailies");
+        }
+    }
+}

--- a/Antital.Infrastructure/Repositories/FundraiserAnalyticsRepository.cs
+++ b/Antital.Infrastructure/Repositories/FundraiserAnalyticsRepository.cs
@@ -1,0 +1,74 @@
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Antital.Infrastructure.Repositories;
+
+public class FundraiserAnalyticsRepository(AntitalDBContext context) : IFundraiserAnalyticsRepository
+{
+    public async Task<IReadOnlyList<OfferingEngagementDaily>> GetEngagementAsync(
+        int offeringId,
+        DateTime fromUtcInclusive,
+        DateTime toUtcExclusive,
+        CancellationToken cancellationToken = default) =>
+        await context.OfferingEngagementDailies
+            .AsNoTracking()
+            .Where(e =>
+                e.OfferingId == offeringId
+                && !e.IsDeleted
+                && e.Date >= fromUtcInclusive
+                && e.Date < toUtcExclusive)
+            .OrderBy(e => e.Date)
+            .ToListAsync(cancellationToken);
+
+    public async Task<int> GetCampaignLikesAsync(int offeringId, CancellationToken cancellationToken = default) =>
+        await context.OfferingUpdates
+            .AsNoTracking()
+            .Where(u => u.OfferingId == offeringId && !u.IsDeleted)
+            .SumAsync(u => (int?)u.LikeCount ?? 0, cancellationToken);
+
+    public async Task<IReadOnlyList<InvestorHolding>> GetHoldingsWithUsersAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default) =>
+        await context.InvestorHoldings
+            .AsNoTracking()
+            .Include(h => h.User)
+            .Where(h => h.OfferingId == offeringId && !h.IsDeleted)
+            .ToListAsync(cancellationToken);
+
+    public async Task<IReadOnlyDictionary<int, UserInvestmentProfile>> GetProfilesByUserIdsAsync(
+        IReadOnlyCollection<int> userIds,
+        CancellationToken cancellationToken = default)
+    {
+        if (userIds.Count == 0)
+        {
+            return new Dictionary<int, UserInvestmentProfile>();
+        }
+
+        var profiles = await context.UserInvestmentProfiles
+            .AsNoTracking()
+            .Where(p => userIds.Contains(p.UserId) && !p.IsDeleted)
+            .ToListAsync(cancellationToken);
+
+        return profiles
+            .GroupBy(p => p.UserId)
+            .ToDictionary(g => g.Key, g => g.First());
+    }
+
+    public async Task<IReadOnlyList<InvestmentOrder>> GetPaidOrdersAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default) =>
+        await context.InvestmentOrders
+            .AsNoTracking()
+            .Where(o =>
+                o.OfferingId == offeringId
+                && !o.IsDeleted
+                && o.Status == Domain.Enums.InvestmentOrderStatus.Paid
+                && o.PaidAt != null)
+            .ToListAsync(cancellationToken);
+
+    public async Task AddRangeAsync(
+        IEnumerable<OfferingEngagementDaily> rows,
+        CancellationToken cancellationToken = default) =>
+        await context.OfferingEngagementDailies.AddRangeAsync(rows, cancellationToken);
+}

--- a/Antital.Infrastructure/Seed/FundraiserAnalyticsEngagementSeed.cs
+++ b/Antital.Infrastructure/Seed/FundraiserAnalyticsEngagementSeed.cs
@@ -1,0 +1,71 @@
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Antital.Infrastructure.Seed;
+
+/// <summary>
+/// Seeds ~7 days of engagement counters on owned offerings for local analytics demos.
+/// Idempotent: skips an offering that already has engagement rows.
+/// </summary>
+public static class FundraiserAnalyticsEngagementSeed
+{
+    private const string SeedActor = "Seed";
+
+    public static async Task SeedAsync(
+        AntitalDBContext context,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        var ownedOfferings = await context.InvestmentOfferings
+            .Where(o => !o.IsDeleted && o.OwnerUserId != null)
+            .OrderBy(o => o.Id)
+            .ToListAsync(cancellationToken);
+
+        if (ownedOfferings.Count == 0)
+        {
+            return;
+        }
+
+        var seededDays = 0;
+        var today = DateTime.UtcNow.Date;
+        var pattern = new[] { 2300, 4400, 3500, 1000, 9600, 3500, 5100 };
+
+        foreach (var offering in ownedOfferings)
+        {
+            var hasRows = await context.OfferingEngagementDailies
+                .AnyAsync(e => e.OfferingId == offering.Id && !e.IsDeleted, cancellationToken);
+            if (hasRows)
+            {
+                continue;
+            }
+
+            for (var i = 0; i < 7; i++)
+            {
+                var date = today.AddDays(-6 + i);
+                var views = pattern[i % pattern.Length];
+                var unique = (int)Math.Round(views * 0.72, MidpointRounding.AwayFromZero);
+                var shares = Math.Max(1, views / 25);
+                var row = new OfferingEngagementDaily
+                {
+                    OfferingId = offering.Id,
+                    Date = date,
+                    PageViews = views,
+                    UniqueVisitors = unique,
+                    Shares = shares,
+                };
+                row.Created(SeedActor);
+                context.OfferingEngagementDailies.Add(row);
+                seededDays++;
+            }
+        }
+
+        if (seededDays == 0)
+        {
+            return;
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+        logger.LogInformation("Seeded {Count} offering engagement daily rows.", seededDays);
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/FundraisersControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/FundraisersControllerTests.cs
@@ -233,6 +233,143 @@ public class FundraisersControllerTests : IClassFixture<CustomWebApplicationFact
     }
 
     [Fact]
+    public async Task GetAnalytics_WithoutAuth_Returns401()
+    {
+        var response = await _client.GetAsync("/api/fundraisers/me/analytics");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetAnalytics_InvalidPeriod_ReturnsValidationError()
+    {
+        var fundraiser = SeedUser("fundraiser-analytics-period@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/analytics?period=yesterday");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserAnalyticsResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeFalse();
+        result.ValidationErrors.Should().ContainKey("period");
+    }
+
+    [Fact]
+    public async Task GetAnalytics_NoOwnedOffering_ReturnsEmptyZeros()
+    {
+        var fundraiser = SeedUser("fundraiser-analytics-empty@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/analytics");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserAnalyticsResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.OfferingId.Should().BeNull();
+        result.Value.Overview.TotalPageViews.Should().Be(0);
+        result.Value.Traffic.Points.Should().BeEmpty();
+        result.Value.Diversity.Geographic.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAnalytics_OwnedOffering_ReturnsAggregates()
+    {
+        var fundraiser = SeedUser("fundraiser-analytics@example.com", UserTypeEnum.FundRaiser);
+        var investor = SeedUser("analytics-holder@example.com", UserTypeEnum.IndividualInvestor);
+        investor.CountryOfResidence = "Nigeria";
+        investor.StateOfResidence = "Lagos";
+        await _context.SaveChangesAsync();
+
+        var offering = await SeedOwnedOfferingAsync(fundraiser.Id, "analytics-campaign");
+
+        var profile = new UserInvestmentProfile
+        {
+            UserId = investor.Id,
+            InvestorCategory = InvestorCategory.Retail,
+        };
+        profile.Created("TestUser");
+        _context.UserInvestmentProfiles.Add(profile);
+
+        var holding = new InvestorHolding
+        {
+            UserId = investor.Id,
+            OfferingId = offering.Id,
+            InvestedAmount = 5_000_000m,
+            CurrentValue = 5_000_000m,
+            Returns = 0m,
+            UnitHolding = 50,
+            InvestedAt = DateTime.UtcNow.AddDays(-3),
+        };
+        holding.Created("TestUser");
+        _context.InvestorHoldings.Add(holding);
+
+        var update = new OfferingUpdate
+        {
+            OfferingId = offering.Id,
+            Title = "Update",
+            Body = "Body",
+            Status = OfferingUpdateStatus.Published,
+            PublishedAt = DateTime.UtcNow.AddDays(-1),
+            LikeCount = 42,
+        };
+        update.Created("TestUser");
+        _context.OfferingUpdates.Add(update);
+
+        var today = DateTime.UtcNow.Date;
+        for (var i = 0; i < 7; i++)
+        {
+            var row = new OfferingEngagementDaily
+            {
+                OfferingId = offering.Id,
+                Date = today.AddDays(-6 + i),
+                PageViews = 1000 + (i * 100),
+                UniqueVisitors = 700 + (i * 50),
+                Shares = 10 + i,
+            };
+            row.Created("TestUser");
+            _context.OfferingEngagementDailies.Add(row);
+        }
+
+        var paid = new InvestmentOrder
+        {
+            UserId = investor.Id,
+            OfferingId = offering.Id,
+            Units = 50,
+            SharePrice = 100m,
+            Subtotal = 5_000m,
+            PlatformFeePercent = 0m,
+            PlatformFee = 0m,
+            TotalAmount = 5_000m,
+            Currency = "NGN",
+            Status = InvestmentOrderStatus.Paid,
+            PaidAt = DateTime.UtcNow.AddHours(24),
+        };
+        paid.Created("TestUser");
+        _context.InvestmentOrders.Add(paid);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/analytics?period=last-7-days");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserAnalyticsResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.OfferingId.Should().Be(offering.Id);
+        result.Value.OfferingSlug.Should().Be("analytics-campaign");
+        result.Value.Overview.CampaignLikes.Should().Be(42);
+        result.Value.Overview.TotalPageViews.Should().Be(9100);
+        result.Value.Overview.SocialShares.Should().Be(91);
+        result.Value.Traffic.Points.Should().HaveCount(7);
+        result.Value.Traffic.Unit.Should().Be("views");
+        result.Value.Diversity.TopLocation.Should().Be("Lagos, NG");
+        result.Value.Diversity.Geographic.Should().Contain(b => b.Label == "West Africa" && b.Percentage == 100);
+        result.Value.Diversity.Categories.Should().Contain(b => b.Label == "Retail Investor");
+        result.Value.Conversion.AverageTimeToInvestHours.Should().NotBeNull();
+        result.Value.Conversion.ViewToInvestmentRate.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
     public async Task GetQiiParticipation_WithoutAuth_Returns401()
     {
         var response = await _client.GetAsync("/api/fundraisers/me/investors/qii");
@@ -550,6 +687,7 @@ public class FundraisersControllerTests : IClassFixture<CustomWebApplicationFact
 
     private void CleanupDatabase()
     {
+        _context.OfferingEngagementDailies.RemoveRange(_context.OfferingEngagementDailies);
         _context.OfferingInvestorMessages.RemoveRange(_context.OfferingInvestorMessages);
         _context.OfferingUpdates.RemoveRange(_context.OfferingUpdates);
         _context.PaymentTransactions.RemoveRange(_context.PaymentTransactions);


### PR DESCRIPTION
## Summary
- Add `OfferingEngagementDaily` model, migration, and engagement seed data for the primary owned offering
- Expose `GET /api/fundraisers/me/analytics` with overview, traffic, diversity, and conversion metrics
- Cover the endpoint with fundraiser controller integration tests

Closes related work for [antital-ui#212](https://github.com/BloydIntel/antital-ui/issues/212).

## Test plan
- [x] Run fundraiser controller integration tests for analytics
- [x] Call `GET /api/fundraisers/me/analytics?period=last-7-days` as a fundraiser and confirm overview/traffic/diversity/conversion payload
- [x] Confirm empty owned-offering case returns an empty analytics envelope
- [x] Pair with UI PR and verify `/analytics` against local Aspire


Made with [Cursor](https://cursor.com)