### PR TITLE
Add Cloudinary upload and fundraiser documents API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,9 @@ EmailSettings__SmtpUser=CHANGEME_SMTP_USER
 EmailSettings__SmtpPassword=CHANGEME_SMTP_PASSWORD
 EmailSettings__EnableSsl=false
 EmailSettings__BaseUrl=http://localhost:3000
+
+# Cloudinary (flat aliases also supported: Cloudinary_Cloud_Name, Cloudinary_API_Key, Cloudinary_API_Secret, Cloudinary_FolderName)
+Cloudinary__CloudName=CHANGEME_CLOUDINARY_CLOUD_NAME
+Cloudinary__ApiKey=CHANGEME_CLOUDINARY_API_KEY
+Cloudinary__ApiSecret=CHANGEME_CLOUDINARY_API_SECRET
+Cloudinary__FolderName=antital

--- a/Antital.API/Configs/AppUseExtensions.cs
+++ b/Antital.API/Configs/AppUseExtensions.cs
@@ -123,6 +123,7 @@ public static class AppUseExtensions
                     FundraiserInvestorMessagesSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
                     FundraiserQiiParticipationSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
                     FundraiserAnalyticsEngagementSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
+                    FundraiserDocumentsSeed.SeedAsync(context, logger, CancellationToken.None).GetAwaiter().GetResult();
                 }
             }
             catch (Exception ex)

--- a/Antital.API/Configs/DependencyInjection.cs
+++ b/Antital.API/Configs/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Antital.Application.Features.Investments;
 using Antital.Application.Features.Investments.Checkout;
 using Antital.Application.Features.Investments.ConfirmInvestmentOrder;
 using Antital.Application.Features.Investments.ProcessPaystackWebhook;
+using Antital.Infrastructure.Integrations.Cloudinary;
 using Antital.Infrastructure.Integrations.Paystack;
 using Antital.Application.Features.Investors;
 using Antital.Application.Features.Fundraisers;
@@ -73,6 +74,7 @@ public static class DependencyInjection
         services.AddScoped(typeof(IFundraiserInvestorMessagesRepository), typeof(FundraiserInvestorMessagesRepository));
         services.AddScoped(typeof(IFundraiserQiiParticipationRepository), typeof(FundraiserQiiParticipationRepository));
         services.AddScoped(typeof(IFundraiserAnalyticsRepository), typeof(FundraiserAnalyticsRepository));
+        services.AddScoped(typeof(IFundraiserDocumentsRepository), typeof(FundraiserDocumentsRepository));
         services.AddScoped(typeof(IInvestmentOrderRepository), typeof(InvestmentOrderRepository));
         services.AddScoped(typeof(IInvestorPaymentMethodRepository), typeof(InvestorPaymentMethodRepository));
         services.AddScoped(typeof(IInvestorWatchlistRepository), typeof(InvestorWatchlistRepository));
@@ -112,6 +114,7 @@ public static class DependencyInjection
         // Register EmailSettings
         services.Configure<EmailSettings>(configuration.GetSection("EmailSettings"));
         services.Configure<PaystackSettings>(configuration.GetSection(PaystackSettings.SectionName));
+        services.Configure<CloudinarySettings>(opts => BindCloudinarySettings(opts, configuration));
         services.AddHttpClient(EmailService.MailgunHttpClientName);
 
         // Register authentication services
@@ -129,6 +132,7 @@ public static class DependencyInjection
         services.AddScoped<IConfirmInvestmentOrderService, ConfirmInvestmentOrderService>();
         services.AddScoped<PaystackSignatureValidator>();
         services.AddScoped<InvestmentOfferingAccess>();
+        services.AddScoped<IFileUploadService, CloudinaryFileUploadService>();
 
         services.AddHttpClient<IPaystackClient, PaystackClient>((serviceProvider, client) =>
         {
@@ -142,5 +146,31 @@ public static class DependencyInjection
         });
 
         return services;
+    }
+
+    /// <summary>
+    /// Binds nested Cloudinary:* and flat Cloudinary_* env aliases used in local secrets.
+    /// </summary>
+    private static void BindCloudinarySettings(CloudinarySettings opts, IConfiguration configuration)
+    {
+        configuration.GetSection(CloudinarySettings.SectionName).Bind(opts);
+
+        opts.CloudName = FirstNonEmpty(opts.CloudName, configuration["Cloudinary_Cloud_Name"]);
+        opts.ApiKey = FirstNonEmpty(opts.ApiKey, configuration["Cloudinary_API_Key"]);
+        opts.ApiSecret = FirstNonEmpty(opts.ApiSecret, configuration["Cloudinary_API_Secret"]);
+        opts.FolderName = FirstNonEmpty(opts.FolderName, configuration["Cloudinary_FolderName"], "antital");
+    }
+
+    private static string FirstNonEmpty(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value.Trim();
+            }
+        }
+
+        return string.Empty;
     }
 }

--- a/Antital.API/Controllers/FilesController.cs
+++ b/Antital.API/Controllers/FilesController.cs
@@ -1,0 +1,53 @@
+using Antital.Application.DTOs.Files;
+using Antital.Application.Features.Files.UploadFile;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.API.Controllers;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Antital.API.Controllers;
+
+[SwaggerTag("Files")]
+[Route("api/files")]
+[Authorize]
+[ApiController]
+public class FilesController(IMediator mediator) : BaseController
+{
+    [HttpPost("upload")]
+    [RequestSizeLimit(FileUploadLimits.MaxFileBytes)]
+    [RequestFormLimits(MultipartBodyLengthLimit = FileUploadLimits.MaxFileBytes)]
+    [SwaggerOperation(
+        "Upload File",
+        "Uploads a file to Cloudinary via the shared storage service. Reusable by documents, onboarding, and other flows.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FileUploadDto>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Invalid file", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [Consumes("multipart/form-data")]
+    public async Task<IActionResult> Upload(
+        IFormFile? file,
+        [FromForm] string? folder,
+        CancellationToken cancellationToken)
+    {
+        if (file is null || file.Length <= 0)
+        {
+            throw new BadRequestException(
+                "Invalid file.",
+                new Dictionary<string, string[]> { ["file"] = ["File is required."] });
+        }
+
+        await using var stream = file.OpenReadStream();
+        var result = await mediator.Send(
+            new UploadFileCommand(
+                stream,
+                file.FileName,
+                file.ContentType,
+                file.Length,
+                folder),
+            cancellationToken);
+        return ApiResult(result);
+    }
+}

--- a/Antital.API/Controllers/FundraisersController.cs
+++ b/Antital.API/Controllers/FundraisersController.cs
@@ -2,6 +2,8 @@ using Antital.Application.DTOs.Fundraisers;
 using Antital.Application.Features.Fundraisers.CampaignUpdates.CreateFundraiserCampaignUpdate;
 using Antital.Application.Features.Fundraisers.CampaignUpdates.ListFundraiserCampaignUpdates;
 using Antital.Application.Features.Fundraisers.CampaignUpdates.UpdateFundraiserCampaignUpdate;
+using Antital.Application.Features.Fundraisers.Documents.ListFundraiserDocuments;
+using Antital.Application.Features.Fundraisers.Documents.UploadFundraiserDocument;
 using Antital.Application.Features.Fundraisers.GetFundraiserAnalytics;
 using Antital.Application.Features.Fundraisers.GetFundraiserCampaign;
 using Antital.Application.Features.Fundraisers.GetFundraiserDashboard;
@@ -10,7 +12,9 @@ using Antital.Application.Features.Fundraisers.Investors.GetFundraiserQiiPartici
 using Antital.Application.Features.Fundraisers.Investors.ListFundraiserInvestorMessages;
 using Antital.Application.Features.Fundraisers.Investors.ReplyFundraiserInvestorMessage;
 using Antital.Application.Features.Fundraisers.Investors.UpdateFundraiserInvestorMessage;
+using Antital.Domain.Interfaces;
 using BuildingBlocks.API.Controllers;
+using BuildingBlocks.Application.Exceptions;
 using BuildingBlocks.Application.Features;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -212,6 +216,57 @@ public class FundraisersController(IMediator mediator) : BaseController
     public async Task<IActionResult> GetInvestorAnalytics(CancellationToken cancellationToken = default)
     {
         var result = await mediator.Send(new GetFundraiserInvestorAnalyticsQuery(), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpGet("me/documents")]
+    [SwaggerOperation(
+        "List Fundraiser Documents",
+        "Returns offering documents for the authenticated fundraiser's primary owned campaign.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserDocumentsResponse>))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    public async Task<IActionResult> ListDocuments(CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(new ListFundraiserDocumentsQuery(), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpPost("me/documents")]
+    [RequestSizeLimit(FileUploadLimits.MaxFileBytes)]
+    [RequestFormLimits(MultipartBodyLengthLimit = FileUploadLimits.MaxFileBytes)]
+    [Consumes("multipart/form-data")]
+    [SwaggerOperation(
+        "Upload Fundraiser Document",
+        "Uploads a document via Cloudinary and attaches it to the primary owned offering as Pending Approval.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserDocumentDto>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status404NotFound, "No owned campaign", typeof(void))]
+    public async Task<IActionResult> UploadDocument(
+        IFormFile? file,
+        [FromForm] string? title,
+        [FromForm] string category = "Core",
+        CancellationToken cancellationToken = default)
+    {
+        if (file is null || file.Length <= 0)
+        {
+            throw new BadRequestException(
+                "Invalid file.",
+                new Dictionary<string, string[]> { ["file"] = ["File is required."] });
+        }
+
+        await using var stream = file.OpenReadStream();
+        var result = await mediator.Send(
+            new UploadFundraiserDocumentCommand(
+                stream,
+                file.FileName,
+                file.ContentType,
+                file.Length,
+                title ?? string.Empty,
+                category),
+            cancellationToken);
         return ApiResult(result);
     }
 }

--- a/Antital.API/appsettings.Development.json
+++ b/Antital.API/appsettings.Development.json
@@ -54,5 +54,11 @@
     "FromEmail": "crownedprinz@www.thekyub.com",
     "FromName": "Antital",
     "BaseUrl": "http://localhost:3000"
+  },
+  "Cloudinary": {
+    "CloudName": "",
+    "ApiKey": "",
+    "ApiSecret": "",
+    "FolderName": "Antital"
   }
 }

--- a/Antital.Application/DTOs/Files/FileUploadDto.cs
+++ b/Antital.Application/DTOs/Files/FileUploadDto.cs
@@ -1,0 +1,9 @@
+namespace Antital.Application.DTOs.Files;
+
+public record FileUploadDto(
+    string Url,
+    string PublicId,
+    long Bytes,
+    string ContentType,
+    string OriginalFileName,
+    string ResourceType);

--- a/Antital.Application/DTOs/Fundraisers/FundraiserDocumentsDtos.cs
+++ b/Antital.Application/DTOs/Fundraisers/FundraiserDocumentsDtos.cs
@@ -1,0 +1,16 @@
+namespace Antital.Application.DTOs.Fundraisers;
+
+public record FundraiserDocumentDto(
+    int Id,
+    string Title,
+    string Category,
+    string Status,
+    string FileUrl,
+    long FileSizeBytes,
+    string ContentType,
+    DateTime LastUpdatedAt);
+
+public record FundraiserDocumentsResponse(
+    int? OfferingId,
+    string? OfferingSlug,
+    IReadOnlyList<FundraiserDocumentDto> Items);

--- a/Antital.Application/Features/Files/UploadFile/UploadFileCommand.cs
+++ b/Antital.Application/Features/Files/UploadFile/UploadFileCommand.cs
@@ -1,0 +1,102 @@
+using Antital.Application.DTOs.Files;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Files.UploadFile;
+
+public record UploadFileCommand(
+    Stream Content,
+    string FileName,
+    string ContentType,
+    long Length,
+    string? Folder = null
+) : ICommandQuery<FileUploadDto>;
+
+public class UploadFileCommandHandler(
+    IFileUploadService fileUploadService
+) : ICommandQueryHandler<UploadFileCommand, FileUploadDto>
+{
+    private static readonly HashSet<string> AllowedContentTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "application/pdf",
+        "image/jpeg",
+        "image/png",
+        "image/webp",
+        "image/gif",
+        "text/csv",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    };
+
+    public async Task<Result<FileUploadDto>> Handle(
+        UploadFileCommand request,
+        CancellationToken cancellationToken)
+    {
+        Validate(request);
+
+        var uploaded = await fileUploadService.UploadAsync(
+            request.Content,
+            request.FileName,
+            request.ContentType,
+            request.Folder,
+            cancellationToken);
+
+        var result = new Result<FileUploadDto>();
+        result.AddValue(
+            new FileUploadDto(
+                uploaded.Url,
+                uploaded.PublicId,
+                uploaded.Bytes,
+                uploaded.ContentType,
+                uploaded.OriginalFileName,
+                uploaded.ResourceType));
+        result.OK();
+        return result;
+    }
+
+    private static void Validate(UploadFileCommand request)
+    {
+        if (request.Content is null || request.Length <= 0)
+        {
+            throw new BadRequestException(
+                "Invalid file.",
+                new Dictionary<string, string[]> { ["file"] = ["File is required."] });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.FileName))
+        {
+            throw new BadRequestException(
+                "Invalid file.",
+                new Dictionary<string, string[]> { ["file"] = ["File name is required."] });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ContentType) || !AllowedContentTypes.Contains(request.ContentType))
+        {
+            throw new BadRequestException(
+                "Unsupported file type.",
+                new Dictionary<string, string[]>
+                {
+                    ["file"] =
+                    [
+                        "Allowed types: PDF, images (jpeg/png/webp/gif), Word, Excel, CSV."
+                    ]
+                });
+        }
+
+        if (request.Length > FileUploadLimits.MaxFileBytes)
+        {
+            throw new BadRequestException(
+                "File too large.",
+                new Dictionary<string, string[]>
+                {
+                    ["file"] =
+                    [
+                        $"Maximum file size is {FileUploadLimits.MaxFileBytes / (1024 * 1024)} MB."
+                    ]
+                });
+        }
+    }
+}

--- a/Antital.Application/Features/Fundraisers/Documents/FundraiserDocumentsMappers.cs
+++ b/Antital.Application/Features/Fundraisers/Documents/FundraiserDocumentsMappers.cs
@@ -1,0 +1,67 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+
+namespace Antital.Application.Features.Fundraisers.Documents;
+
+public static class FundraiserDocumentsMappers
+{
+    public static FundraiserDocumentsResponse Empty() =>
+        new(null, null, []);
+
+    public static FundraiserDocumentDto ToDto(OfferingDocument document) =>
+        new(
+            document.Id,
+            document.Title,
+            ToCategoryLabel(document.Category),
+            ToStatusLabel(document.ReviewStatus),
+            document.FileUrl,
+            document.FileSizeBytes,
+            document.ContentType,
+            document.UpdatedAt ?? document.CreatedAt);
+
+    public static string ToCategoryLabel(DocumentCategory category) =>
+        category switch
+        {
+            DocumentCategory.Core => "Core",
+            DocumentCategory.Financial => "Financial",
+            DocumentCategory.Analytics => "Analytics",
+            DocumentCategory.Regulatory => "Regulatory",
+            _ => "Core",
+        };
+
+    public static string ToStatusLabel(DocumentReviewStatus status) =>
+        status switch
+        {
+            DocumentReviewStatus.Approved => "Approved",
+            DocumentReviewStatus.PendingApproval => "Pending Approval",
+            DocumentReviewStatus.RevisionRequested => "Revision Requested",
+            _ => "Pending Approval",
+        };
+
+    public static bool TryParseCategory(string? value, out DocumentCategory category)
+    {
+        category = DocumentCategory.Core;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var normalized = value.Trim().Replace(" ", "", StringComparison.Ordinal);
+        if (Enum.TryParse(normalized, ignoreCase: true, out DocumentCategory parsed))
+        {
+            category = parsed;
+            return true;
+        }
+
+        return false;
+    }
+
+    public static DocumentType ToLegacyDocumentType(DocumentCategory category) =>
+        category switch
+        {
+            DocumentCategory.Core => DocumentType.Prospectus,
+            DocumentCategory.Financial => DocumentType.FinancialModel,
+            _ => DocumentType.Other,
+        };
+}

--- a/Antital.Application/Features/Fundraisers/Documents/ListFundraiserDocuments/ListFundraiserDocumentsQuery.cs
+++ b/Antital.Application/Features/Fundraisers/Documents/ListFundraiserDocuments/ListFundraiserDocumentsQuery.cs
@@ -1,0 +1,40 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Fundraisers.Documents.ListFundraiserDocuments;
+
+public record ListFundraiserDocumentsQuery : ICommandQuery<FundraiserDocumentsResponse>;
+
+public class ListFundraiserDocumentsQueryHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserDashboardRepository dashboardRepository,
+    IFundraiserDocumentsRepository documentsRepository
+) : ICommandQueryHandler<ListFundraiserDocumentsQuery, FundraiserDocumentsResponse>
+{
+    public async Task<Result<FundraiserDocumentsResponse>> Handle(
+        ListFundraiserDocumentsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var offering = await dashboardRepository.GetPrimaryOfferingAsync(userId, cancellationToken);
+
+        if (offering == null)
+        {
+            var empty = new Result<FundraiserDocumentsResponse>();
+            empty.AddValue(FundraiserDocumentsMappers.Empty());
+            empty.OK();
+            return empty;
+        }
+
+        var documents = await documentsRepository.ListByOfferingAsync(offering.Id, cancellationToken);
+        var result = new Result<FundraiserDocumentsResponse>();
+        result.AddValue(
+            new FundraiserDocumentsResponse(
+                offering.Id,
+                offering.Slug,
+                documents.Select(FundraiserDocumentsMappers.ToDto).ToList()));
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Fundraisers/Documents/UploadFundraiserDocument/UploadFundraiserDocumentCommand.cs
+++ b/Antital.Application/Features/Fundraisers/Documents/UploadFundraiserDocument/UploadFundraiserDocumentCommand.cs
@@ -1,0 +1,117 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using BuildingBlocks.Domain.Interfaces;
+
+namespace Antital.Application.Features.Fundraisers.Documents.UploadFundraiserDocument;
+
+public record UploadFundraiserDocumentCommand(
+    Stream Content,
+    string FileName,
+    string ContentType,
+    long Length,
+    string Title,
+    string Category
+) : ICommandQuery<FundraiserDocumentDto>;
+
+public class UploadFundraiserDocumentCommandHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserDashboardRepository dashboardRepository,
+    IFundraiserDocumentsRepository documentsRepository,
+    IFileUploadService fileUploadService,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser
+) : ICommandQueryHandler<UploadFundraiserDocumentCommand, FundraiserDocumentDto>
+{
+    public async Task<Result<FundraiserDocumentDto>> Handle(
+        UploadFundraiserDocumentCommand request,
+        CancellationToken cancellationToken)
+    {
+        var title = request.Title?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            title = Path.GetFileNameWithoutExtension(request.FileName)?.Trim() ?? string.Empty;
+        }
+
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            throw new BadRequestException(
+                "Title is required.",
+                new Dictionary<string, string[]> { ["title"] = ["Title is required."] });
+        }
+
+        if (!FundraiserDocumentsMappers.TryParseCategory(request.Category, out var category))
+        {
+            throw new BadRequestException(
+                "Invalid category.",
+                new Dictionary<string, string[]>
+                {
+                    ["category"] = ["Category must be Core, Financial, Analytics, or Regulatory."]
+                });
+        }
+
+        if (request.Length <= 0)
+        {
+            throw new BadRequestException(
+                "Invalid file.",
+                new Dictionary<string, string[]> { ["file"] = ["File is required."] });
+        }
+
+        if (request.Length > FileUploadLimits.MaxFileBytes)
+        {
+            throw new BadRequestException(
+                "File too large.",
+                new Dictionary<string, string[]>
+                {
+                    ["file"] =
+                    [
+                        $"Maximum file size is {FileUploadLimits.MaxFileBytes / (1024 * 1024)} MB."
+                    ]
+                });
+        }
+
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var offering = await dashboardRepository.GetPrimaryOfferingAsync(userId, cancellationToken);
+        if (offering == null)
+        {
+            throw new NotFoundException("No owned fundraising campaign found.");
+        }
+
+        var uploaded = await fileUploadService.UploadAsync(
+            request.Content,
+            request.FileName,
+            request.ContentType,
+            folder: $"antital/offerings/{offering.Id}/documents",
+            cancellationToken);
+
+        var document = new OfferingDocument
+        {
+            OfferingId = offering.Id,
+            Title = title.Length > 300 ? title[..300] : title,
+            FileUrl = uploaded.Url,
+            DocumentType = FundraiserDocumentsMappers.ToLegacyDocumentType(category),
+            Category = category,
+            ReviewStatus = DocumentReviewStatus.PendingApproval,
+            FileSizeBytes = uploaded.Bytes > 0 ? uploaded.Bytes : request.Length,
+            ContentType = uploaded.ContentType,
+            CloudinaryPublicId = uploaded.PublicId,
+        };
+        document.Created(ResolveActor());
+
+        await documentsRepository.AddAsync(document, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        var result = new Result<FundraiserDocumentDto>();
+        result.AddValue(FundraiserDocumentsMappers.ToDto(document));
+        result.OK();
+        return result;
+    }
+
+    private string ResolveActor() =>
+        !string.IsNullOrEmpty(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrEmpty(currentUser.IPAddress) ? currentUser.IPAddress : "System");
+}

--- a/Antital.Domain/Configuration/CloudinarySettings.cs
+++ b/Antital.Domain/Configuration/CloudinarySettings.cs
@@ -1,0 +1,18 @@
+namespace Antital.Domain.Configuration;
+
+public class CloudinarySettings
+{
+    public const string SectionName = "Cloudinary";
+
+    /// <summary>Flat env alias: Cloudinary_Cloud_Name</summary>
+    public string CloudName { get; set; } = string.Empty;
+
+    /// <summary>Flat env alias: Cloudinary_API_Key</summary>
+    public string ApiKey { get; set; } = string.Empty;
+
+    /// <summary>Flat env alias: Cloudinary_API_Secret</summary>
+    public string ApiSecret { get; set; } = string.Empty;
+
+    /// <summary>Flat env alias: Cloudinary_FolderName</summary>
+    public string FolderName { get; set; } = "antital";
+}

--- a/Antital.Domain/Enums/DocumentCategory.cs
+++ b/Antital.Domain/Enums/DocumentCategory.cs
@@ -1,0 +1,10 @@
+namespace Antital.Domain.Enums;
+
+/// <summary>Fundraiser document management categories (UI: Core / Financial / Analytics / Regulatory).</summary>
+public enum DocumentCategory
+{
+    Core = 0,
+    Financial = 1,
+    Analytics = 2,
+    Regulatory = 3,
+}

--- a/Antital.Domain/Enums/DocumentReviewStatus.cs
+++ b/Antital.Domain/Enums/DocumentReviewStatus.cs
@@ -1,0 +1,9 @@
+namespace Antital.Domain.Enums;
+
+/// <summary>Review workflow status for fundraiser offering documents.</summary>
+public enum DocumentReviewStatus
+{
+    PendingApproval = 0,
+    Approved = 1,
+    RevisionRequested = 2,
+}

--- a/Antital.Domain/Interfaces/IFileUploadService.cs
+++ b/Antital.Domain/Interfaces/IFileUploadService.cs
@@ -1,0 +1,24 @@
+namespace Antital.Domain.Interfaces;
+
+public static class FileUploadLimits
+{
+    public const long MaxFileBytes = 20 * 1024 * 1024;
+}
+
+public record FileUploadResult(
+    string Url,
+    string PublicId,
+    long Bytes,
+    string ContentType,
+    string OriginalFileName,
+    string ResourceType);
+
+public interface IFileUploadService
+{
+    Task<FileUploadResult> UploadAsync(
+        Stream content,
+        string fileName,
+        string contentType,
+        string? folder = null,
+        CancellationToken cancellationToken = default);
+}

--- a/Antital.Domain/Interfaces/IFundraiserDocumentsRepository.cs
+++ b/Antital.Domain/Interfaces/IFundraiserDocumentsRepository.cs
@@ -1,0 +1,12 @@
+using Antital.Domain.Models;
+
+namespace Antital.Domain.Interfaces;
+
+public interface IFundraiserDocumentsRepository
+{
+    Task<IReadOnlyList<OfferingDocument>> ListByOfferingAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default);
+
+    Task AddAsync(OfferingDocument document, CancellationToken cancellationToken = default);
+}

--- a/Antital.Domain/Models/OfferingDocument.cs
+++ b/Antital.Domain/Models/OfferingDocument.cs
@@ -9,6 +9,11 @@ public class OfferingDocument : TrackableEntity
     public string Title { get; set; } = string.Empty;
     public string FileUrl { get; set; } = string.Empty;
     public DocumentType DocumentType { get; set; }
+    public DocumentCategory Category { get; set; } = DocumentCategory.Core;
+    public DocumentReviewStatus ReviewStatus { get; set; } = DocumentReviewStatus.PendingApproval;
+    public long FileSizeBytes { get; set; }
+    public string ContentType { get; set; } = "application/octet-stream";
+    public string? CloudinaryPublicId { get; set; }
     public int? PageCount { get; set; }
 
     public virtual InvestmentOffering Offering { get; set; } = null!;

--- a/Antital.Infrastructure/Antital.Infrastructure.csproj
+++ b/Antital.Infrastructure/Antital.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
 	  <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+	  <PackageReference Include="CloudinaryDotNet" Version="1.27.5" />
 	  <PackageReference Include="Dapper" Version="2.1.35" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8" />
 	  <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />

--- a/Antital.Infrastructure/AntitalDBContext.cs
+++ b/Antital.Infrastructure/AntitalDBContext.cs
@@ -344,7 +344,11 @@ public class AntitalDBContext(
             entity.HasOne(e => e.Offering).WithMany(o => o.Documents).HasForeignKey(e => e.OfferingId)
                 .OnDelete(DeleteBehavior.Cascade);
             entity.Property(e => e.Title).HasMaxLength(300).IsRequired();
-            entity.Property(e => e.FileUrl).HasMaxLength(500).IsRequired();
+            entity.Property(e => e.FileUrl).HasMaxLength(1000).IsRequired();
+            entity.Property(e => e.ContentType).HasMaxLength(150).IsRequired();
+            entity.Property(e => e.CloudinaryPublicId).HasMaxLength(300);
+            entity.HasIndex(e => new { e.OfferingId, e.Category })
+                .HasFilter("\"IsDeleted\" = false");
         });
 
         modelBuilder.Entity<MediaAsset>(entity =>

--- a/Antital.Infrastructure/Integrations/Cloudinary/CloudinaryFileUploadService.cs
+++ b/Antital.Infrastructure/Integrations/Cloudinary/CloudinaryFileUploadService.cs
@@ -1,0 +1,81 @@
+using Antital.Domain.Configuration;
+using Antital.Domain.Interfaces;
+using CloudinaryDotNet;
+using CloudinaryDotNet.Actions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Antital.Infrastructure.Integrations.Cloudinary;
+
+public class CloudinaryFileUploadService(
+    IOptions<CloudinarySettings> options,
+    ILogger<CloudinaryFileUploadService> logger
+) : IFileUploadService
+{
+    public async Task<FileUploadResult> UploadAsync(
+        Stream content,
+        string fileName,
+        string contentType,
+        string? folder = null,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureConfigured();
+
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentType);
+
+        var settings = options.Value;
+        var account = new Account(settings.CloudName, settings.ApiKey, settings.ApiSecret);
+        var cloudinary = new CloudinaryDotNet.Cloudinary(account)
+        {
+            Api = { Secure = true }
+        };
+
+        var targetFolder = string.IsNullOrWhiteSpace(folder)
+            ? settings.FolderName
+            : folder.Trim().Trim('/');
+
+        var uploadParams = new RawUploadParams
+        {
+            File = new FileDescription(fileName, content),
+            Folder = targetFolder,
+            UseFilename = true,
+            UniqueFilename = true,
+            Overwrite = false,
+        };
+
+        var resourceType = contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase)
+            ? "image"
+            : "raw";
+
+        var uploadResult = await cloudinary.UploadAsync(uploadParams, resourceType, cancellationToken);
+
+        if (uploadResult.Error != null || string.IsNullOrWhiteSpace(uploadResult.SecureUrl?.ToString()))
+        {
+            var message = uploadResult.Error?.Message ?? "Unable to upload file to storage.";
+            logger.LogWarning("Cloudinary upload failed for {FileName}: {Error}", fileName, message);
+            throw new InvalidOperationException($"Cloudinary upload failed: {message}");
+        }
+
+        return new FileUploadResult(
+            uploadResult.SecureUrl.ToString(),
+            uploadResult.PublicId,
+            uploadResult.Bytes,
+            contentType,
+            fileName,
+            uploadResult.ResourceType ?? resourceType);
+    }
+
+    private void EnsureConfigured()
+    {
+        var settings = options.Value;
+        if (string.IsNullOrWhiteSpace(settings.CloudName)
+            || string.IsNullOrWhiteSpace(settings.ApiKey)
+            || string.IsNullOrWhiteSpace(settings.ApiSecret))
+        {
+            throw new InvalidOperationException(
+                "Cloudinary is not configured. Set Cloudinary:CloudName/ApiKey/ApiSecret or Cloudinary_Cloud_Name/Cloudinary_API_Key/Cloudinary_API_Secret.");
+        }
+    }
+}

--- a/Antital.Infrastructure/Migrations/20260724011958_AddOfferingDocumentManagementFields.Designer.cs
+++ b/Antital.Infrastructure/Migrations/20260724011958_AddOfferingDocumentManagementFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Antital.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Antital.Infrastructure.Migrations
 {
     [DbContext(typeof(AntitalDBContext))]
-    partial class AntitalDBContextModelSnapshot : ModelSnapshot
+    [Migration("20260724011958_AddOfferingDocumentManagementFields")]
+    partial class AddOfferingDocumentManagementFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Antital.Infrastructure/Migrations/20260724011958_AddOfferingDocumentManagementFields.cs
+++ b/Antital.Infrastructure/Migrations/20260724011958_AddOfferingDocumentManagementFields.cs
@@ -1,0 +1,113 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Antital.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOfferingDocumentManagementFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OfferingDocuments_OfferingId",
+                table: "OfferingDocuments");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FileUrl",
+                table: "OfferingDocuments",
+                type: "character varying(1000)",
+                maxLength: 1000,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(500)",
+                oldMaxLength: 500);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Category",
+                table: "OfferingDocuments",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CloudinaryPublicId",
+                table: "OfferingDocuments",
+                type: "character varying(300)",
+                maxLength: 300,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ContentType",
+                table: "OfferingDocuments",
+                type: "character varying(150)",
+                maxLength: 150,
+                nullable: false,
+                defaultValue: "application/pdf");
+
+            migrationBuilder.AddColumn<long>(
+                name: "FileSizeBytes",
+                table: "OfferingDocuments",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ReviewStatus",
+                table: "OfferingDocuments",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingDocuments_OfferingId_Category",
+                table: "OfferingDocuments",
+                columns: new[] { "OfferingId", "Category" },
+                filter: "\"IsDeleted\" = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_OfferingDocuments_OfferingId_Category",
+                table: "OfferingDocuments");
+
+            migrationBuilder.DropColumn(
+                name: "Category",
+                table: "OfferingDocuments");
+
+            migrationBuilder.DropColumn(
+                name: "CloudinaryPublicId",
+                table: "OfferingDocuments");
+
+            migrationBuilder.DropColumn(
+                name: "ContentType",
+                table: "OfferingDocuments");
+
+            migrationBuilder.DropColumn(
+                name: "FileSizeBytes",
+                table: "OfferingDocuments");
+
+            migrationBuilder.DropColumn(
+                name: "ReviewStatus",
+                table: "OfferingDocuments");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FileUrl",
+                table: "OfferingDocuments",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(1000)",
+                oldMaxLength: 1000);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OfferingDocuments_OfferingId",
+                table: "OfferingDocuments",
+                column: "OfferingId");
+        }
+    }
+}

--- a/Antital.Infrastructure/Repositories/FundraiserDocumentsRepository.cs
+++ b/Antital.Infrastructure/Repositories/FundraiserDocumentsRepository.cs
@@ -1,0 +1,23 @@
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Antital.Infrastructure.Repositories;
+
+public class FundraiserDocumentsRepository(AntitalDBContext context) : IFundraiserDocumentsRepository
+{
+    public async Task<IReadOnlyList<OfferingDocument>> ListByOfferingAsync(
+        int offeringId,
+        CancellationToken cancellationToken = default) =>
+        await context.OfferingDocuments
+            .AsNoTracking()
+            .Where(d => d.OfferingId == offeringId && !d.IsDeleted)
+            .OrderByDescending(d => d.UpdatedAt ?? d.CreatedAt)
+            .ThenBy(d => d.Title)
+            .ToListAsync(cancellationToken);
+
+    public async Task AddAsync(OfferingDocument document, CancellationToken cancellationToken = default)
+    {
+        await context.OfferingDocuments.AddAsync(document, cancellationToken);
+    }
+}

--- a/Antital.Infrastructure/Seed/FundraiserDocumentsSeed.cs
+++ b/Antital.Infrastructure/Seed/FundraiserDocumentsSeed.cs
@@ -1,0 +1,145 @@
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Antital.Infrastructure.Seed;
+
+/// <summary>
+/// Seeds demo document-management rows on each fundraiser's primary owned offering.
+/// Idempotent: skips offerings that already have 5+ documents.
+/// </summary>
+public static class FundraiserDocumentsSeed
+{
+    private const string SeedActor = "Seed";
+    private const string PreferredFundraiserEmail = "johneseyin@gmail.com";
+
+    private static readonly (string Title, DocumentCategory Category, DocumentReviewStatus Status, long Bytes, string Url)[] DemoDocs =
+    [
+        ("Offering Memorandum.Pdf", DocumentCategory.Core, DocumentReviewStatus.Approved, 2_400_000L,
+            "https://res.cloudinary.com/demo/raw/upload/v1/antital/docs/offering-memorandum.pdf"),
+        ("Financial Audit Report 2024.pdf", DocumentCategory.Financial, DocumentReviewStatus.Approved, 5_100_000L,
+            "https://res.cloudinary.com/demo/raw/upload/v1/antital/docs/financial-audit-2024.pdf"),
+        ("Projected Valuation Model.xlsx", DocumentCategory.Analytics, DocumentReviewStatus.PendingApproval, 1_200_000L,
+            "https://res.cloudinary.com/demo/raw/upload/v1/antital/docs/valuation-model.xlsx"),
+        ("Environmental Impact Study.pdf", DocumentCategory.Analytics, DocumentReviewStatus.PendingApproval, 1_400_000L,
+            "https://res.cloudinary.com/demo/raw/upload/v1/antital/docs/environmental-impact.pdf"),
+        ("Offering Memorandum Revision.Pdf", DocumentCategory.Regulatory, DocumentReviewStatus.RevisionRequested, 8_400_000L,
+            "https://res.cloudinary.com/demo/raw/upload/v1/antital/docs/offering-memorandum-revision.pdf"),
+    ];
+
+    public static async Task SeedAsync(
+        AntitalDBContext context,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        var owners = await context.InvestmentOfferings
+            .AsNoTracking()
+            .Where(o => !o.IsDeleted && o.OwnerUserId != null)
+            .Select(o => o.OwnerUserId!.Value)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        if (owners.Count == 0)
+        {
+            return;
+        }
+
+        var preferred = await context.Users
+            .AsNoTracking()
+            .Where(u => !u.IsDeleted && u.Email == PreferredFundraiserEmail)
+            .Select(u => (int?)u.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (preferred.HasValue && owners.Contains(preferred.Value))
+        {
+            owners.Remove(preferred.Value);
+            owners.Insert(0, preferred.Value);
+        }
+
+        var seeded = 0;
+        foreach (var ownerUserId in owners)
+        {
+            var offering = await GetPrimaryOfferingAsync(context, ownerUserId, cancellationToken);
+            if (offering == null)
+            {
+                continue;
+            }
+
+            var existingCount = await context.OfferingDocuments
+                .CountAsync(d => d.OfferingId == offering.Id && !d.IsDeleted, cancellationToken);
+            if (existingCount >= DemoDocs.Length)
+            {
+                continue;
+            }
+
+            // Replace sparse seed prospectus with full demo set for management UI.
+            var existing = await context.OfferingDocuments
+                .Where(d => d.OfferingId == offering.Id && !d.IsDeleted)
+                .ToListAsync(cancellationToken);
+            foreach (var doc in existing)
+            {
+                doc.Deleted(SeedActor);
+            }
+
+            var created = 0;
+            for (var i = 0; i < DemoDocs.Length; i++)
+            {
+                var demo = DemoDocs[i];
+                var entity = new OfferingDocument
+                {
+                    OfferingId = offering.Id,
+                    Title = demo.Title,
+                    FileUrl = demo.Url,
+                    DocumentType = MapDocumentType(demo.Category),
+                    Category = demo.Category,
+                    ReviewStatus = demo.Status,
+                    FileSizeBytes = demo.Bytes,
+                    ContentType = demo.Title.EndsWith(".xlsx", StringComparison.OrdinalIgnoreCase)
+                        ? "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                        : "application/pdf",
+                    CloudinaryPublicId = $"antital/docs/seed-{offering.Id}-{i + 1}",
+                    PageCount = demo.Category == DocumentCategory.Core ? 45 : null,
+                };
+                entity.Created(SeedActor);
+                context.OfferingDocuments.Add(entity);
+                created++;
+            }
+
+            seeded += created;
+        }
+
+        if (seeded == 0)
+        {
+            return;
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+        logger.LogInformation("Seeded {Count} fundraiser offering documents.", seeded);
+    }
+
+    private static DocumentType MapDocumentType(DocumentCategory category) =>
+        category switch
+        {
+            DocumentCategory.Core => DocumentType.Prospectus,
+            DocumentCategory.Financial => DocumentType.FinancialModel,
+            _ => DocumentType.Other,
+        };
+
+    private static async Task<InvestmentOffering?> GetPrimaryOfferingAsync(
+        AntitalDBContext context,
+        int ownerUserId,
+        CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        return await context.InvestmentOfferings
+            .AsNoTracking()
+            .Include(o => o.DealTerms)
+            .Where(o => o.OwnerUserId == ownerUserId && !o.IsDeleted)
+            .OrderByDescending(o => o.Status == OfferingStatus.Published)
+            .ThenBy(o => o.DealTerms != null && o.DealTerms.Deadline >= now ? 0 : 1)
+            .ThenBy(o => o.DealTerms != null ? o.DealTerms.Deadline : DateTime.MaxValue)
+            .ThenByDescending(o => o.PublishedAt)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+}

--- a/Antital.Infrastructure/Seed/InvestmentOfferingSeed.cs
+++ b/Antital.Infrastructure/Seed/InvestmentOfferingSeed.cs
@@ -345,6 +345,10 @@ public static class InvestmentOfferingSeed
             Title = "Official Prospectus & Financial Model",
             FileUrl = "/documents/greentech-prospectus.pdf",
             DocumentType = DocumentType.Prospectus,
+            Category = DocumentCategory.Core,
+            ReviewStatus = DocumentReviewStatus.Approved,
+            FileSizeBytes = 2_400_000,
+            ContentType = "application/pdf",
             PageCount = 45,
         };
         doc.Created(SeedUser);

--- a/Antital.Test/Fakes/FakeFileUploadService.cs
+++ b/Antital.Test/Fakes/FakeFileUploadService.cs
@@ -1,0 +1,31 @@
+using Antital.Domain.Interfaces;
+
+namespace Antital.Test.Fakes;
+
+public class FakeFileUploadService : IFileUploadService
+{
+    public Func<string, string, string?, FileUploadResult>? UploadHandler { get; set; }
+
+    public Task<FileUploadResult> UploadAsync(
+        Stream content,
+        string fileName,
+        string contentType,
+        string? folder = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (UploadHandler != null)
+        {
+            return Task.FromResult(UploadHandler(fileName, contentType, folder));
+        }
+
+        var publicId = $"test/{Guid.NewGuid():N}";
+        return Task.FromResult(
+            new FileUploadResult(
+                $"https://res.cloudinary.com/test/raw/upload/{publicId}/{fileName}",
+                publicId,
+                content.CanSeek ? content.Length : 0,
+                contentType,
+                fileName,
+                contentType.StartsWith("image/", StringComparison.OrdinalIgnoreCase) ? "image" : "raw"));
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/FilesControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/FilesControllerTests.cs
@@ -1,0 +1,153 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using Antital.Application.DTOs.Files;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Test.Integration;
+using BuildingBlocks.Application.Features;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Antital.Test.Integration.API.Controllers;
+
+[Collection("IntegrationTests")]
+public class FilesControllerTests : IClassFixture<CustomWebApplicationFactory<Program>>, IDisposable
+{
+    private readonly CustomWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+    private readonly IServiceScope _scope;
+    private readonly AntitalDBContext _context;
+    private readonly IConfiguration _config;
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    public FilesControllerTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+        _scope = _factory.Services.CreateScope();
+        _context = _scope.ServiceProvider.GetRequiredService<AntitalDBContext>();
+        _config = _scope.ServiceProvider.GetRequiredService<IConfiguration>();
+        CleanupDatabase();
+    }
+
+    [Fact]
+    public async Task Upload_WithoutAuth_Returns401()
+    {
+        using var content = BuildMultipart("doc.pdf", "application/pdf", "hello");
+        var response = await _client.PostAsync("/api/files/upload", content);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Upload_WithAuth_ReturnsCloudinaryMetadata()
+    {
+        var user = SeedUser("uploader@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        using var content = BuildMultipart("Offering.pdf", "application/pdf", "pdf-bytes");
+        content.Add(new StringContent("antital/docs"), "folder");
+
+        var response = await authClient.PostAsync("/api/files/upload", content);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FileUploadDto>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.OriginalFileName.Should().Be("Offering.pdf");
+        result.Value.ContentType.Should().Be("application/pdf");
+        result.Value.Url.Should().Contain("cloudinary.com");
+        result.Value.PublicId.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Upload_UnsupportedType_Returns400()
+    {
+        var user = SeedUser("bad-type@example.com", UserTypeEnum.IndividualInvestor);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        using var content = BuildMultipart("note.exe", "application/octet-stream", "malware");
+
+        var response = await authClient.PostAsync("/api/files/upload", content);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    private static MultipartFormDataContent BuildMultipart(string fileName, string contentType, string body)
+    {
+        var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(Encoding.UTF8.GetBytes(body));
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+        content.Add(fileContent, "file", fileName);
+        return content;
+    }
+
+    private User SeedUser(string email, UserTypeEnum userType)
+    {
+        var user = new User
+        {
+            Email = email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
+            UserType = userType,
+            IsEmailVerified = true,
+            FirstName = "Jane",
+            LastName = "Okonkwo",
+            PhoneNumber = "+2348012345678",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            Nationality = "Nigerian",
+            CountryOfResidence = "Nigeria",
+            StateOfResidence = "Lagos",
+            ResidentialAddress = "123 Main Street",
+            HasAgreedToTerms = true,
+        };
+        _context.Users.Add(user);
+        return user;
+    }
+
+    private HttpClient CreateAuthorizedClient(int userId, string email)
+    {
+        var client = _factory.CreateClient();
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_config["Jwt:Key"]!);
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _config["Jwt:Issuer"],
+            Audience = _config["Jwt:Audience"],
+            Expires = DateTime.UtcNow.AddHours(1),
+            Subject = new ClaimsIdentity(
+            [
+                new Claim("UserId", userId.ToString()),
+                new Claim(ClaimTypes.Email, email),
+            ]),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256),
+        };
+
+        var token = tokenHandler.CreateToken(descriptor);
+        var jwt = tokenHandler.WriteToken(token);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jwt);
+        return client;
+    }
+
+    private void CleanupDatabase()
+    {
+        _context.Users.RemoveRange(_context.Users);
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        CleanupDatabase();
+        _scope.Dispose();
+        _client.Dispose();
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/FundraisersControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/FundraisersControllerTests.cs
@@ -233,6 +233,122 @@ public class FundraisersControllerTests : IClassFixture<CustomWebApplicationFact
     }
 
     [Fact]
+    public async Task ListDocuments_WithoutAuth_Returns401()
+    {
+        var response = await _client.GetAsync("/api/fundraisers/me/documents");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task ListDocuments_InvestorUser_Returns403()
+    {
+        var user = SeedUser("investor-docs@example.com", UserTypeEnum.IndividualInvestor);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/documents");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task ListDocuments_NoOwnedOffering_ReturnsEmpty()
+    {
+        var fundraiser = SeedUser("fundraiser-docs-empty@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/documents");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserDocumentsResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.OfferingId.Should().BeNull();
+        result.Value.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ListDocuments_OwnedOffering_ReturnsDocuments()
+    {
+        var fundraiser = SeedUser("fundraiser-docs-list@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+        var offering = await SeedOwnedOfferingAsync(fundraiser.Id, "docs-campaign");
+
+        var doc = new OfferingDocument
+        {
+            OfferingId = offering.Id,
+            Title = "Offering Memorandum.Pdf",
+            FileUrl = "https://res.cloudinary.com/test/raw/upload/docs/memo.pdf",
+            DocumentType = DocumentType.Prospectus,
+            Category = DocumentCategory.Core,
+            ReviewStatus = DocumentReviewStatus.Approved,
+            FileSizeBytes = 2_400_000,
+            ContentType = "application/pdf",
+            CloudinaryPublicId = "docs/memo",
+        };
+        doc.Created("TestUser");
+        _context.OfferingDocuments.Add(doc);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/documents");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserDocumentsResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.OfferingId.Should().Be(offering.Id);
+        result.Value.Items.Should().ContainSingle(d =>
+            d.Title == "Offering Memorandum.Pdf"
+            && d.Category == "Core"
+            && d.Status == "Approved"
+            && d.FileSizeBytes == 2_400_000);
+    }
+
+    [Fact]
+    public async Task UploadDocument_NoOwnedOffering_Returns404()
+    {
+        var fundraiser = SeedUser("fundraiser-docs-upload-empty@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+        using var content = BuildDocumentMultipart("memo.pdf", "application/pdf", "pdf", "Core", "Memo");
+        var response = await authClient.PostAsync("/api/fundraisers/me/documents", content);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UploadDocument_OwnedOffering_CreatesPendingDocument()
+    {
+        var fundraiser = SeedUser("fundraiser-docs-upload@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+        var offering = await SeedOwnedOfferingAsync(fundraiser.Id, "docs-upload-campaign");
+
+        using var authClient = CreateAuthorizedClient(fundraiser.Id, fundraiser.Email);
+        using var content = BuildDocumentMultipart(
+            "valuation.xlsx",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "sheet-bytes",
+            "Analytics",
+            "Projected Valuation Model.xlsx");
+
+        var response = await authClient.PostAsync("/api/fundraisers/me/documents", content);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserDocumentDto>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Title.Should().Be("Projected Valuation Model.xlsx");
+        result.Value.Category.Should().Be("Analytics");
+        result.Value.Status.Should().Be("Pending Approval");
+        result.Value.FileUrl.Should().Contain("cloudinary.com");
+
+        var stored = await _context.OfferingDocuments
+            .AsNoTracking()
+            .SingleAsync(d => d.OfferingId == offering.Id && !d.IsDeleted);
+        stored.ReviewStatus.Should().Be(DocumentReviewStatus.PendingApproval);
+        stored.Category.Should().Be(DocumentCategory.Analytics);
+        stored.CloudinaryPublicId.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
     public async Task GetAnalytics_WithoutAuth_Returns401()
     {
         var response = await _client.GetAsync("/api/fundraisers/me/analytics");
@@ -659,6 +775,22 @@ public class FundraisersControllerTests : IClassFixture<CustomWebApplicationFact
         await _context.SaveChangesAsync();
     }
 
+    private static MultipartFormDataContent BuildDocumentMultipart(
+        string fileName,
+        string contentType,
+        string body,
+        string category,
+        string title)
+    {
+        var content = new MultipartFormDataContent();
+        var fileContent = new ByteArrayContent(Encoding.UTF8.GetBytes(body));
+        fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
+        content.Add(fileContent, "file", fileName);
+        content.Add(new StringContent(category), "category");
+        content.Add(new StringContent(title), "title");
+        return content;
+    }
+
     private HttpClient CreateAuthorizedClient(int userId, string email)
     {
         var client = _factory.CreateClient();
@@ -690,6 +822,7 @@ public class FundraisersControllerTests : IClassFixture<CustomWebApplicationFact
         _context.OfferingEngagementDailies.RemoveRange(_context.OfferingEngagementDailies);
         _context.OfferingInvestorMessages.RemoveRange(_context.OfferingInvestorMessages);
         _context.OfferingUpdates.RemoveRange(_context.OfferingUpdates);
+        _context.OfferingDocuments.RemoveRange(_context.OfferingDocuments);
         _context.PaymentTransactions.RemoveRange(_context.PaymentTransactions);
         _context.InvestmentOrders.RemoveRange(_context.InvestmentOrders);
         _context.InvestorHoldings.RemoveRange(_context.InvestorHoldings);

--- a/Antital.Test/Integration/WebApplicationFactory.cs
+++ b/Antital.Test/Integration/WebApplicationFactory.cs
@@ -20,6 +20,7 @@ namespace Antital.Test.Integration;
 public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<Program> where TProgram : class
 {
     public FakePaystackClient FakePaystackClient { get; } = new();
+    public FakeFileUploadService FakeFileUploadService { get; } = new();
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -51,6 +52,10 @@ public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<Progr
                 { "Paystack:PublicKey", "pk_test_public_key" },
                 { "Paystack:WebhookSecret", PaystackTestHelper.TestSecretKey },
                 { "Paystack:CallbackUrl", "http://localhost:3000/marketplace/invest/callback" },
+                { "Cloudinary:CloudName", "test-cloud" },
+                { "Cloudinary:ApiKey", "test-key" },
+                { "Cloudinary:ApiSecret", "test-secret" },
+                { "Cloudinary:FolderName", "antital-test" },
             });
         });
 
@@ -94,6 +99,9 @@ public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<Progr
             services.RemoveAll(typeof(IPaystackClient));
             services.RemoveAll(typeof(PaystackClient));
             services.AddSingleton<IPaystackClient>(FakePaystackClient);
+
+            services.RemoveAll(typeof(IFileUploadService));
+            services.AddSingleton<IFileUploadService>(FakeFileUploadService);
         });
         
         // Workaround: Configure Kestrel to use a real server instead of TestServer


### PR DESCRIPTION
## Summary
- Add reusable `IFileUploadService` with Cloudinary implementation and `POST /api/files/upload`
- Extend `OfferingDocument` with category, review status, size, content type, and Cloudinary public id
- Expose `GET/POST /api/fundraisers/me/documents` for the primary owned offering, with seed data and integration tests

Closes related work for [antital-ui#213](https://github.com/BloydIntel/antital-ui/issues/213).

## Test plan
- [x] Run `FilesControllerTests` and fundraiser documents tests
- [x] Configure Cloudinary secrets and call `POST /api/files/upload`
- [x] As fundraiser, list and upload via `GET/POST /api/fundraisers/me/documents`
- [x] As investor, confirm fundraiser documents endpoints return 403
- [x] Pair with UI PR and verify `/documents` upload end-to-end


Made with [Cursor](https://cursor.com)