### PR TITLE
Add fundraiser onboarding application-fee Paystack checkout

### DIFF
--- a/Antital.API/Configs/DependencyInjection.cs
+++ b/Antital.API/Configs/DependencyInjection.cs
@@ -9,6 +9,7 @@ using Antital.Infrastructure.Integrations.Paystack;
 using Antital.Application.Features.Investors;
 using Antital.Application.Features.Fundraisers;
 using Antital.Application.Features.Onboarding;
+using Antital.Application.Features.Onboarding.ApplicationFeePayment;
 using Antital.Application.Services;
 using Antital.Domain.Interfaces;
 using Antital.Infrastructure.Repositories;
@@ -129,6 +130,7 @@ public static class DependencyInjection
         services.AddScoped<IFundraiserUserAccess, FundraiserUserAccess>();
         services.AddScoped<IInvestmentCheckoutAccess, InvestmentCheckoutAccess>();
         services.AddScoped<IInvestmentPaymentConfirmationService, InvestmentPaymentConfirmationService>();
+        services.AddScoped<IApplicationFeePaymentConfirmationService, ApplicationFeePaymentConfirmationService>();
         services.AddScoped<IConfirmInvestmentOrderService, ConfirmInvestmentOrderService>();
         services.AddScoped<PaystackSignatureValidator>();
         services.AddScoped<InvestmentOfferingAccess>();

--- a/Antital.API/Controllers/OnboardingController.cs
+++ b/Antital.API/Controllers/OnboardingController.cs
@@ -1,7 +1,11 @@
 using Antital.Application.DTOs.Onboarding;
+using Antital.Application.Features.Investments.Paystack;
+using Antital.Application.Features.Onboarding.GetApplicationFee;
 using Antital.Application.Features.Onboarding.GetOnboarding;
+using Antital.Application.Features.Onboarding.InitializeApplicationFeePayment;
 using Antital.Application.Features.Onboarding.SaveOnboarding;
 using Antital.Application.Features.Onboarding.SubmitOnboarding;
+using Antital.Application.Features.Onboarding.VerifyApplicationFeePayment;
 using BuildingBlocks.API.Controllers;
 using BuildingBlocks.Application.Features;
 using MediatR;
@@ -90,6 +94,57 @@ public class OnboardingController(IMediator mediator) : BaseController
     public async Task<IActionResult> Submit(CancellationToken cancellationToken)
     {
         var result = await mediator.Send(new SubmitOnboardingCommand(), cancellationToken);
+        return ApiResult(result);
+    }
+
+    /// <summary>
+    /// Fundraiser application fee quote and payment status.
+    /// </summary>
+    [HttpGet("application-fee")]
+    [SwaggerOperation("Get Application Fee", "Returns configured fee amount and current payment status for the fundraiser.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<ApplicationFeeStatusResponse>))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser or email not verified", typeof(void))]
+    public async Task<IActionResult> GetApplicationFee(CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetApplicationFeeQuery(), cancellationToken);
+        return ApiResult(result);
+    }
+
+    /// <summary>
+    /// Initialize Paystack checkout for the fundraiser onboarding application fee.
+    /// </summary>
+    [HttpPost("application-fee/pay")]
+    [SwaggerOperation("Initialize Application Fee Payment", "Starts Paystack checkout for the fundraiser application fee.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<InitializeApplicationFeePaymentResponse>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Already paid or payment not configured", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser or email not verified", typeof(void))]
+    public async Task<IActionResult> InitializeApplicationFeePayment(
+        [FromBody] InitializeApplicationFeePaymentRequest request,
+        CancellationToken cancellationToken)
+    {
+        var channel = PaystackChannelMapper.ParseChannel(request.Channel);
+        var result = await mediator.Send(new InitializeApplicationFeePaymentCommand(channel), cancellationToken);
+        return ApiResult(result);
+    }
+
+    /// <summary>
+    /// Verify Paystack application-fee payment after redirect (local-dev friendly when webhooks cannot reach localhost).
+    /// </summary>
+    [HttpPost("application-fee/verify")]
+    [SwaggerOperation("Verify Application Fee Payment", "Confirms Paystack payment and marks the application fee paid.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<ApplicationFeeStatusResponse>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Payment not complete or invalid reference", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser or email not verified", typeof(void))]
+    public async Task<IActionResult> VerifyApplicationFeePayment(
+        [FromBody] VerifyApplicationFeePaymentRequest? request,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(
+            new VerifyApplicationFeePaymentCommand(request?.Reference),
+            cancellationToken);
         return ApiResult(result);
     }
 }

--- a/Antital.Application/DTOs/Onboarding/ApplicationFeeDtos.cs
+++ b/Antital.Application/DTOs/Onboarding/ApplicationFeeDtos.cs
@@ -1,0 +1,23 @@
+namespace Antital.Application.DTOs.Onboarding;
+
+public record ApplicationFeeStatusResponse(
+    decimal Amount,
+    string Currency,
+    bool ApplicationFeePaid,
+    string? PaymentMethod,
+    string? PaymentReference,
+    string? PaymentStatus
+);
+
+public record InitializeApplicationFeePaymentRequest(string Channel);
+
+public record InitializeApplicationFeePaymentResponse(
+    string AuthorizationUrl,
+    string AccessCode,
+    string Reference,
+    string PublicKey,
+    decimal Amount,
+    string Currency
+);
+
+public record VerifyApplicationFeePaymentRequest(string? Reference = null);

--- a/Antital.Application/Features/Files/UploadFile/UploadFileCommand.cs
+++ b/Antital.Application/Features/Files/UploadFile/UploadFileCommand.cs
@@ -29,6 +29,9 @@ public class UploadFileCommandHandler(
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "application/vnd.ms-excel",
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        // Fundraiser onboarding business docs accept PowerPoint.
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     };
 
     public async Task<Result<FileUploadDto>> Handle(
@@ -81,7 +84,7 @@ public class UploadFileCommandHandler(
                 {
                     ["file"] =
                     [
-                        "Allowed types: PDF, images (jpeg/png/webp/gif), Word, Excel, CSV."
+                        "Allowed types: PDF, images (jpeg/png/webp/gif), Word, Excel, CSV, PowerPoint."
                     ]
                 });
         }

--- a/Antital.Application/Features/Investments/Paystack/PaystackReferenceGenerator.cs
+++ b/Antital.Application/Features/Investments/Paystack/PaystackReferenceGenerator.cs
@@ -4,4 +4,33 @@ public static class PaystackReferenceGenerator
 {
     public static string CreateForOrder(int orderId) =>
         $"ANT-ORD-{orderId}-{Guid.NewGuid():N}";
+
+    public static string CreateForApplicationFee(int userId) =>
+        $"ANT-FEE-{userId}-{Guid.NewGuid():N}";
+
+    public static bool TryParseApplicationFeeUserId(string? reference, out int userId)
+    {
+        userId = 0;
+        if (string.IsNullOrWhiteSpace(reference))
+        {
+            return false;
+        }
+
+        var parts = reference.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        // ANT-FEE-{userId}-{guid}
+        if (parts.Length < 4
+            || !string.Equals(parts[0], "ANT", StringComparison.OrdinalIgnoreCase)
+            || !string.Equals(parts[1], "FEE", StringComparison.OrdinalIgnoreCase)
+            || !int.TryParse(parts[2], out userId)
+            || userId <= 0)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static bool IsApplicationFeeReference(string? reference) =>
+        !string.IsNullOrWhiteSpace(reference)
+        && reference.StartsWith("ANT-FEE-", StringComparison.OrdinalIgnoreCase);
 }

--- a/Antital.Application/Features/Investments/ProcessPaystackWebhook/ProcessPaystackWebhookCommandHandler.cs
+++ b/Antital.Application/Features/Investments/ProcessPaystackWebhook/ProcessPaystackWebhookCommandHandler.cs
@@ -1,10 +1,12 @@
 using System.Text.Json;
+using Antital.Application.Features.Onboarding.ApplicationFeePayment;
 using BuildingBlocks.Application.Features;
 
 namespace Antital.Application.Features.Investments.ProcessPaystackWebhook;
 
 public class ProcessPaystackWebhookCommandHandler(
-    IInvestmentPaymentConfirmationService paymentConfirmationService
+    IInvestmentPaymentConfirmationService paymentConfirmationService,
+    IApplicationFeePaymentConfirmationService applicationFeePaymentConfirmationService
 ) : ICommandQueryHandler<ProcessPaystackWebhookCommand, bool>
 {
     public async Task<Result<bool>> Handle(ProcessPaystackWebhookCommand request, CancellationToken cancellationToken)
@@ -36,10 +38,7 @@ public class ProcessPaystackWebhookCommandHandler(
         var handled = eventName switch
         {
             "charge.success" => await HandleSuccessAsync(data, reference, request.RawBody, cancellationToken),
-            "charge.failed" => await paymentConfirmationService.TryMarkFailedChargeAsync(
-                reference,
-                request.RawBody,
-                cancellationToken),
+            "charge.failed" => await HandleFailedAsync(reference, request.RawBody, cancellationToken),
             _ => false,
         };
 
@@ -70,10 +69,36 @@ public class ProcessPaystackWebhookCommandHandler(
             ? channelElement.GetString()
             : null;
 
-        return await paymentConfirmationService.TryConfirmSuccessfulChargeAsync(
+        if (await paymentConfirmationService.TryConfirmSuccessfulChargeAsync(
+                reference,
+                amountKobo,
+                channel,
+                rawPayload,
+                cancellationToken))
+        {
+            return true;
+        }
+
+        return await applicationFeePaymentConfirmationService.TryConfirmSuccessfulChargeAsync(
             reference,
             amountKobo,
             channel,
+            rawPayload,
+            cancellationToken);
+    }
+
+    private async Task<bool> HandleFailedAsync(
+        string reference,
+        string rawPayload,
+        CancellationToken cancellationToken)
+    {
+        if (await paymentConfirmationService.TryMarkFailedChargeAsync(reference, rawPayload, cancellationToken))
+        {
+            return true;
+        }
+
+        return await applicationFeePaymentConfirmationService.TryMarkFailedChargeAsync(
+            reference,
             rawPayload,
             cancellationToken);
     }

--- a/Antital.Application/Features/Onboarding/ApplicationFeePayment/ApplicationFeePaymentConfirmationService.cs
+++ b/Antital.Application/Features/Onboarding/ApplicationFeePayment/ApplicationFeePaymentConfirmationService.cs
@@ -1,0 +1,128 @@
+using Antital.Application.Features.Investments.Paystack;
+using Antital.Domain.Configuration;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Domain.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace Antital.Application.Features.Onboarding.ApplicationFeePayment;
+
+public interface IApplicationFeePaymentConfirmationService
+{
+    Task<bool> TryConfirmSuccessfulChargeAsync(
+        string reference,
+        int amountKobo,
+        string? channel,
+        string rawPayload,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> TryMarkFailedChargeAsync(
+        string reference,
+        string rawPayload,
+        CancellationToken cancellationToken = default);
+}
+
+public class ApplicationFeePaymentConfirmationService(
+    IUserInvestmentProfileRepository profileRepository,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser,
+    IOptions<PaystackSettings> paystackOptions
+) : IApplicationFeePaymentConfirmationService
+{
+    public async Task<bool> TryConfirmSuccessfulChargeAsync(
+        string reference,
+        int amountKobo,
+        string? channel,
+        string rawPayload,
+        CancellationToken cancellationToken = default)
+    {
+        if (!PaystackReferenceGenerator.TryParseApplicationFeeUserId(reference, out var userId))
+        {
+            return false;
+        }
+
+        var profile = await profileRepository.GetByUserIdAsync(userId, cancellationToken);
+        if (profile == null)
+        {
+            return false;
+        }
+
+        if (profile.FundRaiserApplicationFeePaid == true
+            && string.Equals(profile.FundRaiserPaymentReference, reference, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // Accept confirm when reference matches the pending init, or when profile has no ref yet (race).
+        if (!string.IsNullOrWhiteSpace(profile.FundRaiserPaymentReference)
+            && !string.Equals(profile.FundRaiserPaymentReference, reference, StringComparison.Ordinal))
+        {
+            // Newer init may have replaced the reference; still allow matching ANT-FEE for this user.
+            if (!reference.StartsWith($"ANT-FEE-{userId}-", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        var expectedKobo = PaystackAmountConverter.ToKobo(paystackOptions.Value.ApplicationFeeAmountNgn);
+        if (amountKobo != expectedKobo)
+        {
+            return false;
+        }
+
+        var actor = ResolveActor();
+        profile.FundRaiserPaymentReference = reference;
+        profile.FundRaiserPaymentStatus = "Paid";
+        profile.FundRaiserApplicationFeePaid = true;
+        if (!string.IsNullOrWhiteSpace(channel) && string.IsNullOrWhiteSpace(profile.FundRaiserPaymentMethod))
+        {
+            profile.FundRaiserPaymentMethod = channel;
+        }
+
+        profile.Updated(actor);
+        await profileRepository.UpdateAsync(profile, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    public async Task<bool> TryMarkFailedChargeAsync(
+        string reference,
+        string rawPayload,
+        CancellationToken cancellationToken = default)
+    {
+        if (!PaystackReferenceGenerator.TryParseApplicationFeeUserId(reference, out var userId))
+        {
+            return false;
+        }
+
+        var profile = await profileRepository.GetByUserIdAsync(userId, cancellationToken);
+        if (profile == null)
+        {
+            return false;
+        }
+
+        if (profile.FundRaiserApplicationFeePaid == true)
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(profile.FundRaiserPaymentReference)
+            && !string.Equals(profile.FundRaiserPaymentReference, reference, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var actor = ResolveActor();
+        profile.FundRaiserPaymentReference = reference;
+        profile.FundRaiserPaymentStatus = "Failed";
+        profile.FundRaiserApplicationFeePaid = false;
+        profile.Updated(actor);
+        await profileRepository.UpdateAsync(profile, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
+    private string ResolveActor() =>
+        !string.IsNullOrEmpty(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrEmpty(currentUser.IPAddress) ? currentUser.IPAddress : "PaystackWebhook");
+}

--- a/Antital.Application/Features/Onboarding/GetApplicationFee/GetApplicationFeeQuery.cs
+++ b/Antital.Application/Features/Onboarding/GetApplicationFee/GetApplicationFeeQuery.cs
@@ -1,0 +1,6 @@
+using Antital.Application.DTOs.Onboarding;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Onboarding.GetApplicationFee;
+
+public record GetApplicationFeeQuery : ICommandQuery<ApplicationFeeStatusResponse>;

--- a/Antital.Application/Features/Onboarding/GetApplicationFee/GetApplicationFeeQueryHandler.cs
+++ b/Antital.Application/Features/Onboarding/GetApplicationFee/GetApplicationFeeQueryHandler.cs
@@ -1,0 +1,48 @@
+using Antital.Application.DTOs.Onboarding;
+using Antital.Domain.Configuration;
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using Microsoft.Extensions.Options;
+
+namespace Antital.Application.Features.Onboarding.GetApplicationFee;
+
+public class GetApplicationFeeQueryHandler(
+    IOnboardingUserAccess onboardingUserAccess,
+    IUserInvestmentProfileRepository profileRepository,
+    IOptions<PaystackSettings> paystackOptions
+) : ICommandQueryHandler<GetApplicationFeeQuery, ApplicationFeeStatusResponse>
+{
+    public async Task<Result<ApplicationFeeStatusResponse>> Handle(
+        GetApplicationFeeQuery request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, user) = await onboardingUserAccess.RequireVerifiedUserAsync(cancellationToken);
+        EnsureFundRaiser(user.UserType);
+
+        var settings = paystackOptions.Value;
+        var profile = await profileRepository.GetByUserIdAsync(userId, cancellationToken);
+
+        var response = new ApplicationFeeStatusResponse(
+            settings.ApplicationFeeAmountNgn,
+            "NGN",
+            profile?.FundRaiserApplicationFeePaid == true,
+            profile?.FundRaiserPaymentMethod,
+            profile?.FundRaiserPaymentReference,
+            profile?.FundRaiserPaymentStatus);
+
+        var result = new Result<ApplicationFeeStatusResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+
+    private static void EnsureFundRaiser(UserTypeEnum userType)
+    {
+        if (userType != UserTypeEnum.FundRaiser)
+        {
+            throw new ForbiddenException("Only fundraisers can access application fee payment.");
+        }
+    }
+}

--- a/Antital.Application/Features/Onboarding/InitializeApplicationFeePayment/InitializeApplicationFeePaymentCommand.cs
+++ b/Antital.Application/Features/Onboarding/InitializeApplicationFeePayment/InitializeApplicationFeePaymentCommand.cs
@@ -1,0 +1,8 @@
+using Antital.Application.DTOs.Onboarding;
+using Antital.Domain.Enums;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Onboarding.InitializeApplicationFeePayment;
+
+public record InitializeApplicationFeePaymentCommand(PaymentChannel Channel)
+    : ICommandQuery<InitializeApplicationFeePaymentResponse>;

--- a/Antital.Application/Features/Onboarding/InitializeApplicationFeePayment/InitializeApplicationFeePaymentCommandHandler.cs
+++ b/Antital.Application/Features/Onboarding/InitializeApplicationFeePayment/InitializeApplicationFeePaymentCommandHandler.cs
@@ -1,0 +1,119 @@
+using Antital.Application.DTOs.Onboarding;
+using Antital.Application.Features.Investments.Paystack;
+using Antital.Domain.Configuration;
+using Antital.Domain.Enums;
+using Antital.Domain.Integrations.Paystack;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using BuildingBlocks.Domain.Interfaces;
+using Microsoft.Extensions.Options;
+
+namespace Antital.Application.Features.Onboarding.InitializeApplicationFeePayment;
+
+public class InitializeApplicationFeePaymentCommandHandler(
+    IOnboardingUserAccess onboardingUserAccess,
+    IUserInvestmentProfileRepository profileRepository,
+    IPaystackClient paystackClient,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser,
+    IOptions<PaystackSettings> paystackOptions
+) : ICommandQueryHandler<InitializeApplicationFeePaymentCommand, InitializeApplicationFeePaymentResponse>
+{
+    public async Task<Result<InitializeApplicationFeePaymentResponse>> Handle(
+        InitializeApplicationFeePaymentCommand request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, user) = await onboardingUserAccess.RequireVerifiedUserAsync(cancellationToken);
+        if (user.UserType != UserTypeEnum.FundRaiser)
+        {
+            throw new ForbiddenException("Only fundraisers can pay the application fee.");
+        }
+
+        var settings = paystackOptions.Value;
+        if (string.IsNullOrWhiteSpace(settings.SecretKey)
+            || string.IsNullOrWhiteSpace(settings.ApplicationFeeCallbackUrl))
+        {
+            throw new BadRequestException(
+                "Payment is not configured.",
+                new Dictionary<string, string[]> { ["payment"] = ["Paystack application fee is not configured."] });
+        }
+
+        if (settings.ApplicationFeeAmountNgn <= 0)
+        {
+            throw new BadRequestException(
+                "Application fee amount is not configured.",
+                new Dictionary<string, string[]> { ["payment"] = ["Invalid application fee amount."] });
+        }
+
+        var profile = await profileRepository.GetByUserIdAsync(userId, cancellationToken);
+        if (profile?.FundRaiserApplicationFeePaid == true)
+        {
+            throw new BadRequestException(
+                "Application fee already paid.",
+                new Dictionary<string, string[]> { ["payment"] = ["Application fee already paid."] });
+        }
+
+        var reference = PaystackReferenceGenerator.CreateForApplicationFee(userId);
+        var amountKobo = PaystackAmountConverter.ToKobo(settings.ApplicationFeeAmountNgn);
+        var initializeResult = await paystackClient.InitializeTransactionAsync(
+            new PaystackInitializeRequest(
+                user.Email,
+                amountKobo,
+                reference,
+                settings.ApplicationFeeCallbackUrl,
+                PaystackChannelMapper.ToPaystackChannels(request.Channel)),
+            cancellationToken);
+
+        if (!initializeResult.Success
+            || string.IsNullOrWhiteSpace(initializeResult.AuthorizationUrl)
+            || string.IsNullOrWhiteSpace(initializeResult.AccessCode)
+            || string.IsNullOrWhiteSpace(initializeResult.Reference))
+        {
+            throw new BadRequestException(
+                initializeResult.Message ?? "Unable to initialize payment.",
+                new Dictionary<string, string[]> { ["payment"] = ["Paystack initialization failed."] });
+        }
+
+        var isNew = profile == null;
+        profile ??= new UserInvestmentProfile { UserId = userId };
+
+        var actor = ResolveActor();
+        profile.FundRaiserPaymentMethod = request.Channel.ToString().ToLowerInvariant();
+        profile.FundRaiserPaymentReference = initializeResult.Reference;
+        profile.FundRaiserPaymentStatus = "Pending";
+        profile.FundRaiserApplicationFeePaid = false;
+
+        if (isNew)
+        {
+            profile.Created(actor);
+            await profileRepository.AddAsync(profile, cancellationToken);
+        }
+        else
+        {
+            profile.Updated(actor);
+            await profileRepository.UpdateAsync(profile, cancellationToken);
+        }
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        var response = new InitializeApplicationFeePaymentResponse(
+            initializeResult.AuthorizationUrl,
+            initializeResult.AccessCode,
+            initializeResult.Reference,
+            settings.PublicKey,
+            settings.ApplicationFeeAmountNgn,
+            "NGN");
+
+        var result = new Result<InitializeApplicationFeePaymentResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+
+    private string ResolveActor() =>
+        !string.IsNullOrEmpty(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrEmpty(currentUser.IPAddress) ? currentUser.IPAddress : "System");
+}

--- a/Antital.Application/Features/Onboarding/InitializeApplicationFeePayment/InitializeApplicationFeePaymentCommandValidator.cs
+++ b/Antital.Application/Features/Onboarding/InitializeApplicationFeePayment/InitializeApplicationFeePaymentCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace Antital.Application.Features.Onboarding.InitializeApplicationFeePayment;
+
+public class InitializeApplicationFeePaymentCommandValidator
+    : AbstractValidator<InitializeApplicationFeePaymentCommand>
+{
+    public InitializeApplicationFeePaymentCommandValidator()
+    {
+        RuleFor(x => x.Channel).IsInEnum();
+    }
+}

--- a/Antital.Application/Features/Onboarding/SaveOnboarding/SaveOnboardingCommandHandler.cs
+++ b/Antital.Application/Features/Onboarding/SaveOnboarding/SaveOnboardingCommandHandler.cs
@@ -298,6 +298,17 @@ public class SaveOnboardingCommandHandler(
         var isNew = profile == null;
         profile ??= new UserInvestmentProfile { UserId = userId };
 
+        // Application fee paid flag is set only by Paystack verify/webhook — reject client-trusted paid claims.
+        if (payload.ApplicationFeePaid && profile.FundRaiserApplicationFeePaid != true)
+        {
+            throw new BadRequestException(
+                "Application fee must be paid via Paystack before saving payment progress.",
+                new Dictionary<string, string[]>
+                {
+                    ["FundRaiserPaymentPayload"] = ["Complete Paystack application-fee checkout first."],
+                });
+        }
+
         profile.FundRaiserPaymentMethod = payload.PaymentMethod;
         profile.FundRaiserPaymentReference = payload.PaymentReference;
         profile.FundRaiserPaymentStatus = payload.PaymentStatus;

--- a/Antital.Application/Features/Onboarding/VerifyApplicationFeePayment/VerifyApplicationFeePaymentCommand.cs
+++ b/Antital.Application/Features/Onboarding/VerifyApplicationFeePayment/VerifyApplicationFeePaymentCommand.cs
@@ -1,0 +1,7 @@
+using Antital.Application.DTOs.Onboarding;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Onboarding.VerifyApplicationFeePayment;
+
+public record VerifyApplicationFeePaymentCommand(string? Reference = null)
+    : ICommandQuery<ApplicationFeeStatusResponse>;

--- a/Antital.Application/Features/Onboarding/VerifyApplicationFeePayment/VerifyApplicationFeePaymentCommandHandler.cs
+++ b/Antital.Application/Features/Onboarding/VerifyApplicationFeePayment/VerifyApplicationFeePaymentCommandHandler.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using Antital.Application.DTOs.Onboarding;
+using Antital.Application.Features.Investments.Paystack;
+using Antital.Application.Features.Onboarding.ApplicationFeePayment;
+using Antital.Domain.Configuration;
+using Antital.Domain.Enums;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Exceptions;
+using BuildingBlocks.Application.Features;
+using Microsoft.Extensions.Options;
+
+namespace Antital.Application.Features.Onboarding.VerifyApplicationFeePayment;
+
+/// <summary>
+/// Confirms application-fee payment via Paystack verify API (local-dev friendly when webhooks cannot reach localhost).
+/// </summary>
+public class VerifyApplicationFeePaymentCommandHandler(
+    IOnboardingUserAccess onboardingUserAccess,
+    IUserInvestmentProfileRepository profileRepository,
+    IPaystackClient paystackClient,
+    IApplicationFeePaymentConfirmationService paymentConfirmationService,
+    IOptions<PaystackSettings> paystackOptions
+) : ICommandQueryHandler<VerifyApplicationFeePaymentCommand, ApplicationFeeStatusResponse>
+{
+    public async Task<Result<ApplicationFeeStatusResponse>> Handle(
+        VerifyApplicationFeePaymentCommand request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, user) = await onboardingUserAccess.RequireVerifiedUserAsync(cancellationToken);
+        if (user.UserType != UserTypeEnum.FundRaiser)
+        {
+            throw new ForbiddenException("Only fundraisers can verify application fee payment.");
+        }
+
+        var settings = paystackOptions.Value;
+        var profile = await profileRepository.GetByUserIdAsync(userId, cancellationToken);
+        if (profile?.FundRaiserApplicationFeePaid == true)
+        {
+            return Success(settings, profile);
+        }
+
+        var reference = !string.IsNullOrWhiteSpace(request.Reference)
+            ? request.Reference.Trim()
+            : profile?.FundRaiserPaymentReference;
+
+        if (string.IsNullOrWhiteSpace(reference))
+        {
+            throw new BadRequestException(
+                "Payment has not been initialized.",
+                new Dictionary<string, string[]> { ["payment"] = ["Missing Paystack reference."] });
+        }
+
+        if (!PaystackReferenceGenerator.TryParseApplicationFeeUserId(reference, out var referenceUserId)
+            || referenceUserId != userId)
+        {
+            throw new BadRequestException(
+                "Invalid payment reference.",
+                new Dictionary<string, string[]> { ["payment"] = ["Reference does not belong to this user."] });
+        }
+
+        var verifyResult = await paystackClient.VerifyTransactionAsync(reference, cancellationToken);
+        if (!verifyResult.Success)
+        {
+            throw new BadRequestException(
+                verifyResult.Message ?? "Payment is not complete yet.",
+                new Dictionary<string, string[]> { ["payment"] = ["Paystack verification failed."] });
+        }
+
+        var rawPayload = JsonSerializer.Serialize(new
+        {
+            @event = "charge.success",
+            data = new
+            {
+                reference,
+                amount = verifyResult.AmountKobo,
+                channel = verifyResult.Channel,
+                status = verifyResult.Status,
+            },
+        });
+
+        await paymentConfirmationService.TryConfirmSuccessfulChargeAsync(
+            reference,
+            verifyResult.AmountKobo,
+            verifyResult.Channel,
+            rawPayload,
+            cancellationToken);
+
+        var updated = await profileRepository.GetByUserIdAsync(userId, cancellationToken)
+            ?? throw new NotFoundException("Investment profile not found.");
+
+        if (updated.FundRaiserApplicationFeePaid != true)
+        {
+            throw new BadRequestException(
+                "Payment could not be confirmed.",
+                new Dictionary<string, string[]> { ["payment"] = ["Application fee is still unpaid."] });
+        }
+
+        return Success(settings, updated);
+    }
+
+    private static Result<ApplicationFeeStatusResponse> Success(
+        PaystackSettings settings,
+        Domain.Models.UserInvestmentProfile profile)
+    {
+        var response = new ApplicationFeeStatusResponse(
+            settings.ApplicationFeeAmountNgn,
+            "NGN",
+            profile.FundRaiserApplicationFeePaid == true,
+            profile.FundRaiserPaymentMethod,
+            profile.FundRaiserPaymentReference,
+            profile.FundRaiserPaymentStatus);
+
+        var result = new Result<ApplicationFeeStatusResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Domain/Configuration/PaystackSettings.cs
+++ b/Antital.Domain/Configuration/PaystackSettings.cs
@@ -8,6 +8,10 @@ public class PaystackSettings
     public string PublicKey { get; set; } = string.Empty;
     public string WebhookSecret { get; set; } = string.Empty;
     public string CallbackUrl { get; set; } = string.Empty;
+    /// <summary>Paystack redirect after fundraiser application-fee payment.</summary>
+    public string ApplicationFeeCallbackUrl { get; set; } = string.Empty;
+    /// <summary>Fundraiser onboarding application fee in NGN (major units).</summary>
+    public decimal ApplicationFeeAmountNgn { get; set; } = 25_750m;
     public decimal PlatformFeePercent { get; set; } = 2.5m;
     public int OrderExpiryMinutes { get; set; } = 30;
 }

--- a/Antital.Test/Application/Features/Investments/ProcessPaystackWebhookCommandHandlerTests.cs
+++ b/Antital.Test/Application/Features/Investments/ProcessPaystackWebhookCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using Antital.Application.Features.Investments.ProcessPaystackWebhook;
+using Antital.Application.Features.Onboarding.ApplicationFeePayment;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -8,11 +9,14 @@ namespace Antital.Test.Application.Features.Investments;
 public class ProcessPaystackWebhookCommandHandlerTests
 {
     private readonly Mock<IInvestmentPaymentConfirmationService> _paymentConfirmationService = new();
+    private readonly Mock<IApplicationFeePaymentConfirmationService> _applicationFeeConfirmationService = new();
 
     [Fact]
     public async Task Handle_MissingEvent_ReturnsIgnoredWithoutCallingPaymentService()
     {
-        var handler = new ProcessPaystackWebhookCommandHandler(_paymentConfirmationService.Object);
+        var handler = new ProcessPaystackWebhookCommandHandler(
+            _paymentConfirmationService.Object,
+            _applicationFeeConfirmationService.Object);
         const string payload = """{"data":{"reference":"ANT-ORD-1-abc","amount":102500}}""";
 
         var result = await handler.Handle(new ProcessPaystackWebhookCommand(payload), CancellationToken.None);
@@ -20,12 +24,15 @@ public class ProcessPaystackWebhookCommandHandlerTests
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().BeFalse();
         _paymentConfirmationService.VerifyNoOtherCalls();
+        _applicationFeeConfirmationService.VerifyNoOtherCalls();
     }
 
     [Fact]
     public async Task Handle_MissingData_ReturnsIgnoredWithoutCallingPaymentService()
     {
-        var handler = new ProcessPaystackWebhookCommandHandler(_paymentConfirmationService.Object);
+        var handler = new ProcessPaystackWebhookCommandHandler(
+            _paymentConfirmationService.Object,
+            _applicationFeeConfirmationService.Object);
         const string payload = """{"event":"charge.success"}""";
 
         var result = await handler.Handle(new ProcessPaystackWebhookCommand(payload), CancellationToken.None);
@@ -33,5 +40,6 @@ public class ProcessPaystackWebhookCommandHandlerTests
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().BeFalse();
         _paymentConfirmationService.VerifyNoOtherCalls();
+        _applicationFeeConfirmationService.VerifyNoOtherCalls();
     }
 }

--- a/Antital.Test/Application/Features/Onboarding/SaveOnboardingCommandHandlerTests.cs
+++ b/Antital.Test/Application/Features/Onboarding/SaveOnboardingCommandHandlerTests.cs
@@ -600,7 +600,14 @@ public class SaveOnboardingCommandHandlerTests
         _userAccessMock.Setup(x => x.RequireVerifiedUserAsync(It.IsAny<CancellationToken>())).ReturnsAsync((1, fundRaiserUser));
 
         var existingOnboarding = new UserOnboarding { UserId = 1, CurrentStep = OnboardingStep.Review, Status = OnboardingStatus.Draft };
-        var existingProfile = new UserInvestmentProfile { UserId = 1 };
+        var existingProfile = new UserInvestmentProfile
+        {
+            UserId = 1,
+            FundRaiserApplicationFeePaid = true,
+            FundRaiserPaymentReference = "ANT-FEE-1-abc",
+            FundRaiserPaymentStatus = "Paid",
+            FundRaiserPaymentMethod = "card",
+        };
         _onboardingRepoMock.Setup(x => x.GetOrCreateForUserAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(existingOnboarding);
         _profileRepoMock.Setup(x => x.GetByUserIdAsync(1, It.IsAny<CancellationToken>())).ReturnsAsync(existingProfile);
 

--- a/Antital.Test/Integration/API/Controllers/OnboardingControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/OnboardingControllerTests.cs
@@ -449,6 +449,14 @@ public class OnboardingControllerTests : IClassFixture<CustomWebApplicationFacto
             CurrentStep = OnboardingStep.Review,
             Status = OnboardingStatus.Draft
         });
+        _context.UserInvestmentProfiles.Add(new UserInvestmentProfile
+        {
+            UserId = user.Id,
+            FundRaiserApplicationFeePaid = true,
+            FundRaiserPaymentMethod = "card",
+            FundRaiserPaymentReference = "ANT-FEE-seed",
+            FundRaiserPaymentStatus = "Paid",
+        });
         await _context.SaveChangesAsync();
 
         using var authClient = CreateAuthorizedClient(userId: user.Id);

--- a/Antital.Test/Integration/WebApplicationFactory.cs
+++ b/Antital.Test/Integration/WebApplicationFactory.cs
@@ -52,6 +52,8 @@ public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<Progr
                 { "Paystack:PublicKey", "pk_test_public_key" },
                 { "Paystack:WebhookSecret", PaystackTestHelper.TestSecretKey },
                 { "Paystack:CallbackUrl", "http://localhost:3000/marketplace/invest/callback" },
+                { "Paystack:ApplicationFeeCallbackUrl", "http://localhost:3000/onboarding/fundraiser/application-fee/callback" },
+                { "Paystack:ApplicationFeeAmountNgn", "25750" },
                 { "Cloudinary:CloudName", "test-cloud" },
                 { "Cloudinary:ApiKey", "test-key" },
                 { "Cloudinary:ApiSecret", "test-secret" },

--- a/AntitalAPI.AppHost/AppHost.cs
+++ b/AntitalAPI.AppHost/AppHost.cs
@@ -22,5 +22,8 @@ var ui = builder.AddJavaScriptApp("ui", "../../../React/antital-ui")
 api.WithEnvironment(
     "Paystack__CallbackUrl",
     ReferenceExpression.Create($"{ui.GetEndpoint("http")}/marketplace/invest/callback"));
+api.WithEnvironment(
+    "Paystack__ApplicationFeeCallbackUrl",
+    ReferenceExpression.Create($"{ui.GetEndpoint("http")}/onboarding/fundraiser/application-fee/callback"));
 
 builder.Build().Run();


### PR DESCRIPTION
## Summary
- Add `GET/POST /api/onboarding/application-fee` quote, pay, and verify endpoints for fundraiser application fees.
- Confirm `ANT-FEE-*` payments via Paystack verify and webhook, and reject client-trusted paid flags on onboarding save.
- Wire Aspire `Paystack__ApplicationFeeCallbackUrl` and allow PPT/PPTX uploads used by onboarding docs.

## Test plan
- [x] Restart Aspire and confirm `Paystack__ApplicationFeeCallbackUrl` points at `/onboarding/fundraiser/application-fee/callback`
- [x] As a fundraiser with unpaid fee, open application-fee step and confirm amount is ₦25,750
- [x] Pay with Paystack test card/Success and land on review with fee marked Completed
- [x] Confirm profile stores `ANT-FEE-{userId}-…` reference and `FundRaiserApplicationFeePaid = true`
- [x] Confirm `PUT /api/onboarding` cannot set fee paid without prior Paystack confirmation


Made with [Cursor](https://cursor.com)