### PR TITLE
Add fundraiser settings profile and notification APIs

### DIFF
--- a/Antital.API/Configs/DependencyInjection.cs
+++ b/Antital.API/Configs/DependencyInjection.cs
@@ -79,6 +79,7 @@ public static class DependencyInjection
         services.AddScoped(typeof(IInvestmentOrderRepository), typeof(InvestmentOrderRepository));
         services.AddScoped(typeof(IInvestorPaymentMethodRepository), typeof(InvestorPaymentMethodRepository));
         services.AddScoped(typeof(IInvestorWatchlistRepository), typeof(InvestorWatchlistRepository));
+        services.AddScoped(typeof(IFundraiserNotificationPreferencesRepository), typeof(FundraiserNotificationPreferencesRepository));
 
         return services;
     }

--- a/Antital.API/Controllers/FundraisersController.cs
+++ b/Antital.API/Controllers/FundraisersController.cs
@@ -12,6 +12,10 @@ using Antital.Application.Features.Fundraisers.Investors.GetFundraiserQiiPartici
 using Antital.Application.Features.Fundraisers.Investors.ListFundraiserInvestorMessages;
 using Antital.Application.Features.Fundraisers.Investors.ReplyFundraiserInvestorMessage;
 using Antital.Application.Features.Fundraisers.Investors.UpdateFundraiserInvestorMessage;
+using Antital.Application.Features.Fundraisers.Settings.GetFundraiserNotificationPreferences;
+using Antital.Application.Features.Fundraisers.Settings.GetFundraiserSettingsProfile;
+using Antital.Application.Features.Fundraisers.Settings.UpdateFundraiserNotificationPreferences;
+using Antital.Application.Features.Fundraisers.Settings.UpdateFundraiserSettingsProfile;
 using Antital.Domain.Interfaces;
 using BuildingBlocks.API.Controllers;
 using BuildingBlocks.Application.Exceptions;
@@ -216,6 +220,78 @@ public class FundraisersController(IMediator mediator) : BaseController
     public async Task<IActionResult> GetInvestorAnalytics(CancellationToken cancellationToken = default)
     {
         var result = await mediator.Send(new GetFundraiserInvestorAnalyticsQuery(), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpGet("me/settings/profile")]
+    [SwaggerOperation(
+        "Get Fundraiser Settings Profile",
+        "Returns company and primary contact fields for the authenticated fundraiser settings pages.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserSettingsProfileResponse>))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    public async Task<IActionResult> GetSettingsProfile(CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(new GetFundraiserSettingsProfileQuery(), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpPut("me/settings/profile")]
+    [SwaggerOperation(
+        "Update Fundraiser Settings Profile",
+        "Updates editable company and primary contact fields for the authenticated fundraiser.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserSettingsProfileResponse>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    public async Task<IActionResult> UpdateSettingsProfile(
+        [FromBody] UpdateFundraiserSettingsProfileRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new UpdateFundraiserSettingsProfileCommand(
+                request.CompanyName,
+                request.RegistrationNumber,
+                request.Bio,
+                request.Website,
+                request.PublicEmail,
+                request.Headquarters,
+                request.Contact),
+            cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpGet("me/settings/notifications")]
+    [SwaggerOperation(
+        "Get Fundraiser Notification Preferences",
+        "Returns email, in-app, and marketing notification preferences for the authenticated fundraiser.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserNotificationPreferencesResponse>))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    public async Task<IActionResult> GetNotificationPreferences(CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(new GetFundraiserNotificationPreferencesQuery(), cancellationToken);
+        return ApiResult(result);
+    }
+
+    [HttpPut("me/settings/notifications")]
+    [SwaggerOperation(
+        "Update Fundraiser Notification Preferences",
+        "Upserts email, in-app, and marketing notification preferences for the authenticated fundraiser.")]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(Result<FundraiserNotificationPreferencesResponse>))]
+    [SwaggerResponse(StatusCodes.Status400BadRequest, "Validation error", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status401Unauthorized, "Not authenticated", typeof(void))]
+    [SwaggerResponse(StatusCodes.Status403Forbidden, "Not a fundraiser", typeof(void))]
+    public async Task<IActionResult> UpdateNotificationPreferences(
+        [FromBody] UpdateFundraiserNotificationPreferencesRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new UpdateFundraiserNotificationPreferencesCommand(
+                request.Email,
+                request.InApp,
+                request.Marketing),
+            cancellationToken);
         return ApiResult(result);
     }
 

--- a/Antital.Application/DTOs/Fundraisers/FundraiserNotificationPreferencesDtos.cs
+++ b/Antital.Application/DTOs/Fundraisers/FundraiserNotificationPreferencesDtos.cs
@@ -1,0 +1,29 @@
+namespace Antital.Application.DTOs.Fundraisers;
+
+public record FundraiserEmailNotificationPrefsDto(
+    bool CampaignUpdates,
+    bool NewInvestments,
+    bool SecurityAlerts,
+    bool Muted);
+
+public record FundraiserInAppNotificationPrefsDto(
+    bool RealTimeActivity,
+    bool ChatMessages,
+    bool SystemStatus,
+    bool Muted);
+
+public record FundraiserMarketingNotificationPrefsDto(
+    bool ProductNews,
+    bool InvestorTips,
+    bool Partner,
+    bool Muted);
+
+public record FundraiserNotificationPreferencesResponse(
+    FundraiserEmailNotificationPrefsDto Email,
+    FundraiserInAppNotificationPrefsDto InApp,
+    FundraiserMarketingNotificationPrefsDto Marketing);
+
+public record UpdateFundraiserNotificationPreferencesRequest(
+    FundraiserEmailNotificationPrefsDto Email,
+    FundraiserInAppNotificationPrefsDto InApp,
+    FundraiserMarketingNotificationPrefsDto Marketing);

--- a/Antital.Application/DTOs/Fundraisers/FundraiserSettingsProfileDtos.cs
+++ b/Antital.Application/DTOs/Fundraisers/FundraiserSettingsProfileDtos.cs
@@ -1,0 +1,35 @@
+namespace Antital.Application.DTOs.Fundraisers;
+
+public record FundraiserSettingsContactDto(
+    string? FullName,
+    string? EmailAddress,
+    string? PhoneNumber,
+    bool IsWhatsAppConnected,
+    bool HasPublicHelpDesk);
+
+public record FundraiserSettingsProfileResponse(
+    string? CompanyName,
+    string? RegistrationNumber,
+    string? Bio,
+    string? Website,
+    string? PublicEmail,
+    string? Headquarters,
+    string? LocationLabel,
+    string? CompanyAvatarUrl,
+    string? CompanyAvatarFallback,
+    int CompletionPercentage,
+    FundraiserSettingsContactDto Contact);
+
+public record UpdateFundraiserSettingsContactRequest(
+    string? FullName,
+    string? EmailAddress,
+    string? PhoneNumber);
+
+public record UpdateFundraiserSettingsProfileRequest(
+    string CompanyName,
+    string? RegistrationNumber,
+    string? Bio,
+    string? Website,
+    string? PublicEmail,
+    string? Headquarters,
+    UpdateFundraiserSettingsContactRequest? Contact);

--- a/Antital.Application/Features/Fundraisers/Settings/FundraiserNotificationPreferencesMapper.cs
+++ b/Antital.Application/Features/Fundraisers/Settings/FundraiserNotificationPreferencesMapper.cs
@@ -1,0 +1,54 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Models;
+
+namespace Antital.Application.Features.Fundraisers.Settings;
+
+internal static class FundraiserNotificationPreferencesMapper
+{
+    public static FundraiserNotificationPreferencesResponse ToResponse(
+        FundraiserNotificationPreferences? entity) =>
+        entity is null
+            ? Defaults()
+            : new FundraiserNotificationPreferencesResponse(
+                Email: new FundraiserEmailNotificationPrefsDto(
+                    entity.EmailCampaignUpdates,
+                    entity.EmailNewInvestments,
+                    entity.EmailSecurityAlerts,
+                    entity.EmailMuted),
+                InApp: new FundraiserInAppNotificationPrefsDto(
+                    entity.InAppRealTimeActivity,
+                    entity.InAppChatMessages,
+                    entity.InAppSystemStatus,
+                    entity.InAppMuted),
+                Marketing: new FundraiserMarketingNotificationPrefsDto(
+                    entity.MarketingProductNews,
+                    entity.MarketingInvestorTips,
+                    entity.MarketingPartner,
+                    entity.MarketingMuted));
+
+    public static FundraiserNotificationPreferencesResponse Defaults() =>
+        new(
+            Email: new FundraiserEmailNotificationPrefsDto(true, true, true, false),
+            InApp: new FundraiserInAppNotificationPrefsDto(true, true, true, false),
+            Marketing: new FundraiserMarketingNotificationPrefsDto(true, true, false, false));
+
+    public static void ApplyUpdate(
+        FundraiserNotificationPreferences entity,
+        UpdateFundraiserNotificationPreferencesRequest request)
+    {
+        entity.EmailCampaignUpdates = request.Email.CampaignUpdates;
+        entity.EmailNewInvestments = request.Email.NewInvestments;
+        entity.EmailSecurityAlerts = request.Email.SecurityAlerts;
+        entity.EmailMuted = request.Email.Muted;
+
+        entity.InAppRealTimeActivity = request.InApp.RealTimeActivity;
+        entity.InAppChatMessages = request.InApp.ChatMessages;
+        entity.InAppSystemStatus = request.InApp.SystemStatus;
+        entity.InAppMuted = request.InApp.Muted;
+
+        entity.MarketingProductNews = request.Marketing.ProductNews;
+        entity.MarketingInvestorTips = request.Marketing.InvestorTips;
+        entity.MarketingPartner = request.Marketing.Partner;
+        entity.MarketingMuted = request.Marketing.Muted;
+    }
+}

--- a/Antital.Application/Features/Fundraisers/Settings/FundraiserSettingsProfileMapper.cs
+++ b/Antital.Application/Features/Fundraisers/Settings/FundraiserSettingsProfileMapper.cs
@@ -1,0 +1,126 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Models;
+
+namespace Antital.Application.Features.Fundraisers.Settings;
+
+internal static class FundraiserSettingsProfileMapper
+{
+    public static FundraiserSettingsProfileResponse ToResponse(UserInvestmentProfile? profile)
+    {
+        var companyName = NullIfWhiteSpace(profile?.CompanyLegalName)
+            ?? NullIfWhiteSpace(profile?.TradingBrandName);
+        var headquarters = NullIfWhiteSpace(profile?.BusinessAddress)
+            ?? NullIfWhiteSpace(profile?.RegisteredAddress);
+
+        return new FundraiserSettingsProfileResponse(
+            CompanyName: companyName,
+            RegistrationNumber: NullIfWhiteSpace(profile?.RegistrationNumber),
+            Bio: NullIfWhiteSpace(profile?.BusinessDescription),
+            Website: NullIfWhiteSpace(profile?.CompanyWebsite),
+            PublicEmail: NullIfWhiteSpace(profile?.CompanyEmail),
+            Headquarters: headquarters,
+            LocationLabel: DeriveLocationLabel(headquarters),
+            CompanyAvatarUrl: null,
+            CompanyAvatarFallback: DeriveAvatarFallback(companyName),
+            CompletionPercentage: ComputeCompletionPercentage(profile),
+            Contact: new FundraiserSettingsContactDto(
+                FullName: NullIfWhiteSpace(profile?.RepresentativeFullName),
+                EmailAddress: NullIfWhiteSpace(profile?.RepresentativeEmail),
+                PhoneNumber: NullIfWhiteSpace(profile?.RepresentativePhoneNumber),
+                IsWhatsAppConnected: false,
+                HasPublicHelpDesk: false));
+    }
+
+    public static void ApplyUpdate(UserInvestmentProfile profile, UpdateFundraiserSettingsProfileRequest request)
+    {
+        profile.CompanyLegalName = request.CompanyName.Trim();
+        profile.RegistrationNumber = NullIfWhiteSpace(request.RegistrationNumber);
+        profile.BusinessDescription = NullIfWhiteSpace(request.Bio);
+        profile.CompanyWebsite = NullIfWhiteSpace(request.Website);
+        profile.CompanyEmail = NullIfWhiteSpace(request.PublicEmail);
+        profile.BusinessAddress = NullIfWhiteSpace(request.Headquarters);
+
+        if (request.Contact is null)
+        {
+            return;
+        }
+
+        profile.RepresentativeFullName = NullIfWhiteSpace(request.Contact.FullName);
+        profile.RepresentativeEmail = NullIfWhiteSpace(request.Contact.EmailAddress);
+        profile.RepresentativePhoneNumber = NullIfWhiteSpace(request.Contact.PhoneNumber);
+    }
+
+    private static int ComputeCompletionPercentage(UserInvestmentProfile? profile)
+    {
+        if (profile is null)
+        {
+            return 0;
+        }
+
+        var filled = 0;
+        const int total = 9;
+
+        if (!string.IsNullOrWhiteSpace(profile.CompanyLegalName) || !string.IsNullOrWhiteSpace(profile.TradingBrandName))
+            filled++;
+        if (!string.IsNullOrWhiteSpace(profile.RegistrationNumber))
+            filled++;
+        if (!string.IsNullOrWhiteSpace(profile.BusinessDescription))
+            filled++;
+        if (!string.IsNullOrWhiteSpace(profile.CompanyWebsite))
+            filled++;
+        if (!string.IsNullOrWhiteSpace(profile.CompanyEmail))
+            filled++;
+        if (!string.IsNullOrWhiteSpace(profile.BusinessAddress) || !string.IsNullOrWhiteSpace(profile.RegisteredAddress))
+            filled++;
+        if (!string.IsNullOrWhiteSpace(profile.RepresentativeFullName))
+            filled++;
+        if (!string.IsNullOrWhiteSpace(profile.RepresentativeEmail))
+            filled++;
+        if (!string.IsNullOrWhiteSpace(profile.RepresentativePhoneNumber))
+            filled++;
+
+        return (int)Math.Round(filled * 100.0 / total);
+    }
+
+    private static string? DeriveLocationLabel(string? headquarters)
+    {
+        if (string.IsNullOrWhiteSpace(headquarters))
+        {
+            return null;
+        }
+
+        var parts = headquarters
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+        if (parts.Length >= 2)
+        {
+            return $"{parts[^2]}, {parts[^1]}";
+        }
+
+        return parts[0];
+    }
+
+    private static string? DeriveAvatarFallback(string? companyName)
+    {
+        if (string.IsNullOrWhiteSpace(companyName))
+        {
+            return null;
+        }
+
+        var words = companyName
+            .Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+        if (words.Length >= 2)
+        {
+            return $"{char.ToUpperInvariant(words[0][0])}{char.ToUpperInvariant(words[1][0])}";
+        }
+
+        var single = words[0];
+        return single.Length >= 2
+            ? single[..2].ToUpperInvariant()
+            : single.ToUpperInvariant();
+    }
+
+    private static string? NullIfWhiteSpace(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/Antital.Application/Features/Fundraisers/Settings/GetFundraiserNotificationPreferences/GetFundraiserNotificationPreferencesQuery.cs
+++ b/Antital.Application/Features/Fundraisers/Settings/GetFundraiserNotificationPreferences/GetFundraiserNotificationPreferencesQuery.cs
@@ -1,0 +1,29 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Application.Features.Fundraisers.Settings;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Fundraisers.Settings.GetFundraiserNotificationPreferences;
+
+public record GetFundraiserNotificationPreferencesQuery
+    : ICommandQuery<FundraiserNotificationPreferencesResponse>;
+
+public class GetFundraiserNotificationPreferencesQueryHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserNotificationPreferencesRepository preferencesRepository
+) : ICommandQueryHandler<GetFundraiserNotificationPreferencesQuery, FundraiserNotificationPreferencesResponse>
+{
+    public async Task<Result<FundraiserNotificationPreferencesResponse>> Handle(
+        GetFundraiserNotificationPreferencesQuery request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var prefs = await preferencesRepository.GetByUserIdAsync(userId, cancellationToken);
+
+        var response = FundraiserNotificationPreferencesMapper.ToResponse(prefs);
+        var result = new Result<FundraiserNotificationPreferencesResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Fundraisers/Settings/GetFundraiserSettingsProfile/GetFundraiserSettingsProfileQuery.cs
+++ b/Antital.Application/Features/Fundraisers/Settings/GetFundraiserSettingsProfile/GetFundraiserSettingsProfileQuery.cs
@@ -1,0 +1,28 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Application.Features.Fundraisers.Settings;
+using Antital.Domain.Interfaces;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Fundraisers.Settings.GetFundraiserSettingsProfile;
+
+public record GetFundraiserSettingsProfileQuery : ICommandQuery<FundraiserSettingsProfileResponse>;
+
+public class GetFundraiserSettingsProfileQueryHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IUserInvestmentProfileRepository profileRepository
+) : ICommandQueryHandler<GetFundraiserSettingsProfileQuery, FundraiserSettingsProfileResponse>
+{
+    public async Task<Result<FundraiserSettingsProfileResponse>> Handle(
+        GetFundraiserSettingsProfileQuery request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+        var profile = await profileRepository.GetByUserIdAsync(userId, cancellationToken);
+
+        var response = FundraiserSettingsProfileMapper.ToResponse(profile);
+        var result = new Result<FundraiserSettingsProfileResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Fundraisers/Settings/UpdateFundraiserNotificationPreferences/UpdateFundraiserNotificationPreferencesCommand.cs
+++ b/Antital.Application/Features/Fundraisers/Settings/UpdateFundraiserNotificationPreferences/UpdateFundraiserNotificationPreferencesCommand.cs
@@ -1,0 +1,65 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Application.Features.Fundraisers.Settings;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using BuildingBlocks.Application.Features;
+using BuildingBlocks.Domain.Interfaces;
+
+namespace Antital.Application.Features.Fundraisers.Settings.UpdateFundraiserNotificationPreferences;
+
+public record UpdateFundraiserNotificationPreferencesCommand(
+    FundraiserEmailNotificationPrefsDto Email,
+    FundraiserInAppNotificationPrefsDto InApp,
+    FundraiserMarketingNotificationPrefsDto Marketing
+) : ICommandQuery<FundraiserNotificationPreferencesResponse>;
+
+public class UpdateFundraiserNotificationPreferencesCommandHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IFundraiserNotificationPreferencesRepository preferencesRepository,
+    IAntitalUnitOfWork unitOfWork,
+    ICurrentUser currentUser
+) : ICommandQueryHandler<UpdateFundraiserNotificationPreferencesCommand, FundraiserNotificationPreferencesResponse>
+{
+    public async Task<Result<FundraiserNotificationPreferencesResponse>> Handle(
+        UpdateFundraiserNotificationPreferencesCommand request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+
+        var prefs = await preferencesRepository.GetByUserIdAsync(userId, cancellationToken);
+        var isNew = prefs is null;
+        prefs ??= new FundraiserNotificationPreferences { UserId = userId };
+
+        var updateRequest = new UpdateFundraiserNotificationPreferencesRequest(
+            request.Email,
+            request.InApp,
+            request.Marketing);
+
+        FundraiserNotificationPreferencesMapper.ApplyUpdate(prefs, updateRequest);
+
+        var actor = !string.IsNullOrEmpty(currentUser.UserName)
+            ? currentUser.UserName
+            : (!string.IsNullOrEmpty(currentUser.IPAddress) ? currentUser.IPAddress : "System");
+
+        if (isNew)
+        {
+            prefs.Created(actor);
+            await preferencesRepository.AddAsync(prefs, cancellationToken);
+        }
+        else
+        {
+            prefs.Updated(actor);
+            await preferencesRepository.UpdateAsync(prefs, cancellationToken);
+        }
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        var refreshed = await preferencesRepository.GetByUserIdAsync(userId, cancellationToken);
+        var response = FundraiserNotificationPreferencesMapper.ToResponse(refreshed);
+
+        var result = new Result<FundraiserNotificationPreferencesResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Fundraisers/Settings/UpdateFundraiserSettingsProfile/UpdateFundraiserSettingsProfileCommand.cs
+++ b/Antital.Application/Features/Fundraisers/Settings/UpdateFundraiserSettingsProfile/UpdateFundraiserSettingsProfileCommand.cs
@@ -1,0 +1,65 @@
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Application.Features.Fundraisers.Settings;
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using BuildingBlocks.Application.Features;
+
+namespace Antital.Application.Features.Fundraisers.Settings.UpdateFundraiserSettingsProfile;
+
+public record UpdateFundraiserSettingsProfileCommand(
+    string CompanyName,
+    string? RegistrationNumber,
+    string? Bio,
+    string? Website,
+    string? PublicEmail,
+    string? Headquarters,
+    UpdateFundraiserSettingsContactRequest? Contact
+) : ICommandQuery<FundraiserSettingsProfileResponse>;
+
+public class UpdateFundraiserSettingsProfileCommandHandler(
+    IFundraiserUserAccess fundraiserUserAccess,
+    IUserInvestmentProfileRepository profileRepository,
+    IAntitalUnitOfWork unitOfWork
+) : ICommandQueryHandler<UpdateFundraiserSettingsProfileCommand, FundraiserSettingsProfileResponse>
+{
+    public async Task<Result<FundraiserSettingsProfileResponse>> Handle(
+        UpdateFundraiserSettingsProfileCommand request,
+        CancellationToken cancellationToken)
+    {
+        var (userId, _) = await fundraiserUserAccess.RequireFundraiserAsync(cancellationToken);
+
+        var profile = await profileRepository.GetByUserIdAsync(userId, cancellationToken);
+        var isNew = profile is null;
+        profile ??= new UserInvestmentProfile { UserId = userId };
+
+        var updateRequest = new UpdateFundraiserSettingsProfileRequest(
+            request.CompanyName,
+            request.RegistrationNumber,
+            request.Bio,
+            request.Website,
+            request.PublicEmail,
+            request.Headquarters,
+            request.Contact);
+
+        FundraiserSettingsProfileMapper.ApplyUpdate(profile, updateRequest);
+
+        if (isNew)
+        {
+            await profileRepository.AddAsync(profile, cancellationToken);
+        }
+        else
+        {
+            await profileRepository.UpdateAsync(profile, cancellationToken);
+        }
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        var refreshed = await profileRepository.GetByUserIdAsync(userId, cancellationToken);
+        var response = FundraiserSettingsProfileMapper.ToResponse(refreshed);
+
+        var result = new Result<FundraiserSettingsProfileResponse>();
+        result.AddValue(response);
+        result.OK();
+        return result;
+    }
+}

--- a/Antital.Application/Features/Fundraisers/Settings/UpdateFundraiserSettingsProfile/UpdateFundraiserSettingsProfileCommandValidator.cs
+++ b/Antital.Application/Features/Fundraisers/Settings/UpdateFundraiserSettingsProfile/UpdateFundraiserSettingsProfileCommandValidator.cs
@@ -1,0 +1,54 @@
+using BuildingBlocks.Application.Methods;
+using FluentValidation;
+
+namespace Antital.Application.Features.Fundraisers.Settings.UpdateFundraiserSettingsProfile;
+
+public class UpdateFundraiserSettingsProfileCommandValidator
+    : AbstractValidator<UpdateFundraiserSettingsProfileCommand>
+{
+    public UpdateFundraiserSettingsProfileCommandValidator()
+    {
+        RuleFor(x => x.CompanyName)
+            .NotEmpty().WithMessage("Company name is required.")
+            .Must(ValidationHelper.IsValidString).WithMessage("Company name is required.")
+            .MinimumLength(2).WithMessage("Company name must be at least 2 characters long.")
+            .MaximumLength(200).WithMessage("Company name must not exceed 200 characters.");
+
+        RuleFor(x => x.RegistrationNumber)
+            .MaximumLength(100).WithMessage("Registration number must not exceed 100 characters.")
+            .When(x => !string.IsNullOrWhiteSpace(x.RegistrationNumber));
+
+        RuleFor(x => x.Bio)
+            .MaximumLength(2000).WithMessage("Bio must not exceed 2000 characters.")
+            .When(x => !string.IsNullOrWhiteSpace(x.Bio));
+
+        RuleFor(x => x.Website)
+            .MaximumLength(300).WithMessage("Website must not exceed 300 characters.")
+            .When(x => !string.IsNullOrWhiteSpace(x.Website));
+
+        RuleFor(x => x.PublicEmail)
+            .EmailAddress().WithMessage("Public email must be a valid email address.")
+            .MaximumLength(255).WithMessage("Public email must not exceed 255 characters.")
+            .When(x => !string.IsNullOrWhiteSpace(x.PublicEmail));
+
+        RuleFor(x => x.Headquarters)
+            .MaximumLength(500).WithMessage("Headquarters must not exceed 500 characters.")
+            .When(x => !string.IsNullOrWhiteSpace(x.Headquarters));
+
+        When(x => x.Contact is not null, () =>
+        {
+            RuleFor(x => x.Contact!.FullName)
+                .MaximumLength(200).WithMessage("Contact full name must not exceed 200 characters.")
+                .When(x => !string.IsNullOrWhiteSpace(x.Contact!.FullName));
+
+            RuleFor(x => x.Contact!.EmailAddress)
+                .EmailAddress().WithMessage("Contact email must be a valid email address.")
+                .MaximumLength(255).WithMessage("Contact email must not exceed 255 characters.")
+                .When(x => !string.IsNullOrWhiteSpace(x.Contact!.EmailAddress));
+
+            RuleFor(x => x.Contact!.PhoneNumber)
+                .MaximumLength(50).WithMessage("Contact phone number must not exceed 50 characters.")
+                .When(x => !string.IsNullOrWhiteSpace(x.Contact!.PhoneNumber));
+        });
+    }
+}

--- a/Antital.Domain/Interfaces/IFundraiserNotificationPreferencesRepository.cs
+++ b/Antital.Domain/Interfaces/IFundraiserNotificationPreferencesRepository.cs
@@ -1,0 +1,12 @@
+using Antital.Domain.Models;
+
+namespace Antital.Domain.Interfaces;
+
+public interface IFundraiserNotificationPreferencesRepository
+{
+    Task<FundraiserNotificationPreferences?> GetByUserIdAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task AddAsync(FundraiserNotificationPreferences entity, CancellationToken cancellationToken = default);
+
+    Task UpdateAsync(FundraiserNotificationPreferences entity, CancellationToken cancellationToken = default);
+}

--- a/Antital.Domain/Models/FundraiserNotificationPreferences.cs
+++ b/Antital.Domain/Models/FundraiserNotificationPreferences.cs
@@ -1,0 +1,29 @@
+using BuildingBlocks.Domain.Models;
+
+namespace Antital.Domain.Models;
+
+/// <summary>
+/// Fundraiser notification preferences for settings (email, in-app, marketing).
+/// One row per fundraiser user; missing row means defaults.
+/// </summary>
+public class FundraiserNotificationPreferences : TrackableEntity
+{
+    public int UserId { get; set; }
+
+    public bool EmailCampaignUpdates { get; set; } = true;
+    public bool EmailNewInvestments { get; set; } = true;
+    public bool EmailSecurityAlerts { get; set; } = true;
+    public bool EmailMuted { get; set; }
+
+    public bool InAppRealTimeActivity { get; set; } = true;
+    public bool InAppChatMessages { get; set; } = true;
+    public bool InAppSystemStatus { get; set; } = true;
+    public bool InAppMuted { get; set; }
+
+    public bool MarketingProductNews { get; set; } = true;
+    public bool MarketingInvestorTips { get; set; } = true;
+    public bool MarketingPartner { get; set; }
+    public bool MarketingMuted { get; set; }
+
+    public virtual User User { get; set; } = null!;
+}

--- a/Antital.Infrastructure/AntitalDBContext.cs
+++ b/Antital.Infrastructure/AntitalDBContext.cs
@@ -37,6 +37,7 @@ public class AntitalDBContext(
     public DbSet<InvestmentOrder> InvestmentOrders { get; set; }
     public DbSet<PaymentTransaction> PaymentTransactions { get; set; }
     public DbSet<InvestorPaymentMethod> InvestorPaymentMethods { get; set; }
+    public DbSet<FundraiserNotificationPreferences> FundraiserNotificationPreferences { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -152,6 +153,13 @@ public class AntitalDBContext(
         {
             entity.HasOne(e => e.User).WithMany().HasForeignKey(e => e.UserId).OnDelete(DeleteBehavior.Restrict);
             entity.HasIndex(e => e.UserId).IsUnique();
+        });
+
+        // FundraiserNotificationPreferences: one per fundraiser user
+        modelBuilder.Entity<FundraiserNotificationPreferences>(entity =>
+        {
+            entity.HasOne(e => e.User).WithMany().HasForeignKey(e => e.UserId).OnDelete(DeleteBehavior.Restrict);
+            entity.HasIndex(e => e.UserId).IsUnique().HasFilter("\"IsDeleted\" = false");
         });
 
         ConfigureInvestorDashboard(modelBuilder);

--- a/Antital.Infrastructure/Migrations/20260724041057_AddFundraiserNotificationPreferences.Designer.cs
+++ b/Antital.Infrastructure/Migrations/20260724041057_AddFundraiserNotificationPreferences.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Antital.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Antital.Infrastructure.Migrations
 {
     [DbContext(typeof(AntitalDBContext))]
-    partial class AntitalDBContextModelSnapshot : ModelSnapshot
+    [Migration("20260724041057_AddFundraiserNotificationPreferences")]
+    partial class AddFundraiserNotificationPreferences
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Antital.Infrastructure/Migrations/20260724041057_AddFundraiserNotificationPreferences.cs
+++ b/Antital.Infrastructure/Migrations/20260724041057_AddFundraiserNotificationPreferences.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Antital.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFundraiserNotificationPreferences : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FundraiserNotificationPreferences",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    EmailCampaignUpdates = table.Column<bool>(type: "boolean", nullable: false),
+                    EmailNewInvestments = table.Column<bool>(type: "boolean", nullable: false),
+                    EmailSecurityAlerts = table.Column<bool>(type: "boolean", nullable: false),
+                    EmailMuted = table.Column<bool>(type: "boolean", nullable: false),
+                    InAppRealTimeActivity = table.Column<bool>(type: "boolean", nullable: false),
+                    InAppChatMessages = table.Column<bool>(type: "boolean", nullable: false),
+                    InAppSystemStatus = table.Column<bool>(type: "boolean", nullable: false),
+                    InAppMuted = table.Column<bool>(type: "boolean", nullable: false),
+                    MarketingProductNews = table.Column<bool>(type: "boolean", nullable: false),
+                    MarketingInvestorTips = table.Column<bool>(type: "boolean", nullable: false),
+                    MarketingPartner = table.Column<bool>(type: "boolean", nullable: false),
+                    MarketingMuted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedBy = table.Column<string>(type: "text", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedBy = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FundraiserNotificationPreferences", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FundraiserNotificationPreferences_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FundraiserNotificationPreferences_UserId",
+                table: "FundraiserNotificationPreferences",
+                column: "UserId",
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "FundraiserNotificationPreferences");
+        }
+    }
+}

--- a/Antital.Infrastructure/Repositories/FundraiserNotificationPreferencesRepository.cs
+++ b/Antital.Infrastructure/Repositories/FundraiserNotificationPreferencesRepository.cs
@@ -1,0 +1,31 @@
+using Antital.Domain.Interfaces;
+using Antital.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Antital.Infrastructure.Repositories;
+
+public class FundraiserNotificationPreferencesRepository(AntitalDBContext context)
+    : IFundraiserNotificationPreferencesRepository
+{
+    public Task<FundraiserNotificationPreferences?> GetByUserIdAsync(
+        int userId,
+        CancellationToken cancellationToken = default) =>
+        context.FundraiserNotificationPreferences
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.UserId == userId && !e.IsDeleted, cancellationToken);
+
+    public async Task AddAsync(
+        FundraiserNotificationPreferences entity,
+        CancellationToken cancellationToken = default)
+    {
+        await context.FundraiserNotificationPreferences.AddAsync(entity, cancellationToken);
+    }
+
+    public Task UpdateAsync(
+        FundraiserNotificationPreferences entity,
+        CancellationToken cancellationToken = default)
+    {
+        context.FundraiserNotificationPreferences.Update(entity);
+        return Task.CompletedTask;
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/FundraiserNotificationPreferencesControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/FundraiserNotificationPreferencesControllerTests.cs
@@ -1,0 +1,184 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Test.Integration;
+using BuildingBlocks.Application.Features;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Antital.Test.Integration.API.Controllers;
+
+[Collection("IntegrationTests")]
+public class FundraiserNotificationPreferencesControllerTests
+    : IClassFixture<CustomWebApplicationFactory<Program>>, IDisposable
+{
+    private readonly CustomWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+    private readonly IServiceScope _scope;
+    private readonly AntitalDBContext _context;
+    private readonly IConfiguration _config;
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+    };
+
+    public FundraiserNotificationPreferencesControllerTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+        _scope = _factory.Services.CreateScope();
+        _context = _scope.ServiceProvider.GetRequiredService<AntitalDBContext>();
+        _config = _scope.ServiceProvider.GetRequiredService<IConfiguration>();
+        CleanupDatabase();
+    }
+
+    [Fact]
+    public async Task GetNotifications_WithoutAuth_Returns401()
+    {
+        var response = await _client.GetAsync("/api/fundraisers/me/settings/notifications");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetNotifications_NoRow_ReturnsDefaults()
+    {
+        var user = SeedUser("fundraiser-notif-defaults@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/settings/notifications");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserNotificationPreferencesResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Email.CampaignUpdates.Should().BeTrue();
+        result.Value.Email.Muted.Should().BeFalse();
+        result.Value.InApp.RealTimeActivity.Should().BeTrue();
+        result.Value.Marketing.Partner.Should().BeFalse();
+        result.Value.Marketing.Muted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateNotifications_CreatesAndPersists()
+    {
+        var user = SeedUser("fundraiser-notif-update@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        var payload = new UpdateFundraiserNotificationPreferencesRequest(
+            Email: new FundraiserEmailNotificationPrefsDto(false, true, true, true),
+            InApp: new FundraiserInAppNotificationPrefsDto(true, false, true, false),
+            Marketing: new FundraiserMarketingNotificationPrefsDto(false, false, true, false));
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PutAsJsonAsync("/api/fundraisers/me/settings/notifications", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserNotificationPreferencesResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Email.CampaignUpdates.Should().BeFalse();
+        result.Value.Email.Muted.Should().BeTrue();
+        result.Value.InApp.ChatMessages.Should().BeFalse();
+        result.Value.Marketing.Partner.Should().BeTrue();
+
+        var getResponse = await authClient.GetAsync("/api/fundraisers/me/settings/notifications");
+        var getResult = await getResponse.Content.ReadFromJsonAsync<Result<FundraiserNotificationPreferencesResponse>>(JsonOptions);
+        getResult!.Value!.Email.CampaignUpdates.Should().BeFalse();
+        getResult.Value.Marketing.Partner.Should().BeTrue();
+
+        var stored = await _context.FundraiserNotificationPreferences
+            .AsNoTracking()
+            .SingleAsync(p => p.UserId == user.Id);
+        stored.EmailCampaignUpdates.Should().BeFalse();
+        stored.EmailMuted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateNotifications_Investor_Returns403()
+    {
+        var user = SeedUser("investor-notif@example.com", UserTypeEnum.IndividualInvestor);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PutAsJsonAsync(
+            "/api/fundraisers/me/settings/notifications",
+            new UpdateFundraiserNotificationPreferencesRequest(
+                Email: new FundraiserEmailNotificationPrefsDto(true, true, true, false),
+                InApp: new FundraiserInAppNotificationPrefsDto(true, true, true, false),
+                Marketing: new FundraiserMarketingNotificationPrefsDto(true, true, false, false)));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    private User SeedUser(string email, UserTypeEnum userType)
+    {
+        var user = new User
+        {
+            Email = email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
+            UserType = userType,
+            IsEmailVerified = true,
+            FirstName = "Jane",
+            LastName = "Okonkwo",
+            PhoneNumber = "+2348012345678",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            Nationality = "Nigerian",
+            CountryOfResidence = "Nigeria",
+            StateOfResidence = "Lagos",
+            ResidentialAddress = "123 Main Street",
+            HasAgreedToTerms = true,
+        };
+        _context.Users.Add(user);
+        return user;
+    }
+
+    private HttpClient CreateAuthorizedClient(int userId, string email)
+    {
+        var client = _factory.CreateClient();
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_config["Jwt:Key"]!);
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _config["Jwt:Issuer"],
+            Audience = _config["Jwt:Audience"],
+            Expires = DateTime.UtcNow.AddHours(1),
+            Subject = new ClaimsIdentity(
+            [
+                new Claim("UserId", userId.ToString()),
+                new Claim(ClaimTypes.Email, email),
+            ]),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256),
+        };
+
+        var token = tokenHandler.CreateToken(descriptor);
+        var jwt = tokenHandler.WriteToken(token);
+
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+        return client;
+    }
+
+    private void CleanupDatabase()
+    {
+        _context.FundraiserNotificationPreferences.RemoveRange(_context.FundraiserNotificationPreferences);
+        _context.Users.RemoveRange(_context.Users);
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        CleanupDatabase();
+        _scope.Dispose();
+        _client.Dispose();
+    }
+}

--- a/Antital.Test/Integration/API/Controllers/FundraiserSettingsProfileControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/FundraiserSettingsProfileControllerTests.cs
@@ -1,0 +1,299 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using Antital.Application.DTOs.Fundraisers;
+using Antital.Domain.Enums;
+using Antital.Domain.Models;
+using Antital.Infrastructure;
+using Antital.Test.Integration;
+using BuildingBlocks.Application.Features;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Antital.Test.Integration.API.Controllers;
+
+[Collection("IntegrationTests")]
+public class FundraiserSettingsProfileControllerTests
+    : IClassFixture<CustomWebApplicationFactory<Program>>, IDisposable
+{
+    private readonly CustomWebApplicationFactory<Program> _factory;
+    private readonly HttpClient _client;
+    private readonly IServiceScope _scope;
+    private readonly AntitalDBContext _context;
+    private readonly IConfiguration _config;
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+    };
+
+    public FundraiserSettingsProfileControllerTests(CustomWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+        _scope = _factory.Services.CreateScope();
+        _context = _scope.ServiceProvider.GetRequiredService<AntitalDBContext>();
+        _config = _scope.ServiceProvider.GetRequiredService<IConfiguration>();
+        CleanupDatabase();
+    }
+
+    [Fact]
+    public async Task GetSettingsProfile_WithoutAuth_Returns401()
+    {
+        var response = await _client.GetAsync("/api/fundraisers/me/settings/profile");
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetSettingsProfile_InvestorUser_Returns403()
+    {
+        var user = SeedUser("investor-settings-profile@example.com", UserTypeEnum.IndividualInvestor);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/settings/profile");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetSettingsProfile_NoProfile_ReturnsEmptyDefaults()
+    {
+        var user = SeedUser("fundraiser-settings-empty@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/settings/profile");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserSettingsProfileResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.CompanyName.Should().BeNull();
+        result.Value.CompletionPercentage.Should().Be(0);
+        result.Value.Contact.IsWhatsAppConnected.Should().BeFalse();
+        result.Value.Contact.HasPublicHelpDesk.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetSettingsProfile_WithOnboardingData_MapsFields()
+    {
+        var user = SeedUser("fundraiser-settings-get@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+        SeedFundraiserProfile(user.Id);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/fundraisers/me/settings/profile");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserSettingsProfileResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.CompanyName.Should().Be("Acme Fundraise Limited");
+        result.Value.RegistrationNumber.Should().Be("RC-998877");
+        result.Value.Bio.Should().Be("We raise capital for growth.");
+        result.Value.Website.Should().Be("https://acme.example.com");
+        result.Value.PublicEmail.Should().Be("hello@acme.example.com");
+        result.Value.Headquarters.Should().Be("12 Admiralty Way, Victoria Island, Lagos, Nigeria");
+        result.Value.LocationLabel.Should().Be("Lagos, Nigeria");
+        result.Value.CompanyAvatarFallback.Should().Be("AF");
+        result.Value.CompletionPercentage.Should().Be(100);
+        result.Value.Contact.FullName.Should().Be("Ada Okonkwo");
+        result.Value.Contact.EmailAddress.Should().Be("ada@acme.example.com");
+        result.Value.Contact.PhoneNumber.Should().Be("+2348091112233");
+    }
+
+    [Fact]
+    public async Task UpdateSettingsProfile_WithoutAuth_Returns401()
+    {
+        var response = await _client.PutAsJsonAsync(
+            "/api/fundraisers/me/settings/profile",
+            ValidUpdateRequest());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task UpdateSettingsProfile_CreatesAndPersistsProfile()
+    {
+        var user = SeedUser("fundraiser-settings-create@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PutAsJsonAsync(
+            "/api/fundraisers/me/settings/profile",
+            ValidUpdateRequest());
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserSettingsProfileResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.CompanyName.Should().Be("Skyhigh Technologies");
+        result.Value.RegistrationNumber.Should().Be("RC-12345678");
+        result.Value.Contact.FullName.Should().Be("John Doe");
+        result.Value.Contact.EmailAddress.Should().Be("doe@skyhightech.com");
+
+        var getResponse = await authClient.GetAsync("/api/fundraisers/me/settings/profile");
+        var getResult = await getResponse.Content.ReadFromJsonAsync<Result<FundraiserSettingsProfileResponse>>(JsonOptions);
+        getResult!.Value!.CompanyName.Should().Be("Skyhigh Technologies");
+        getResult.Value.Bio.Should().Be("Advanced prosthetic solutions.");
+        getResult.Value.Headquarters.Should().Be("123 Business Way, Victoria Island, Lagos, Nigeria");
+    }
+
+    [Fact]
+    public async Task UpdateSettingsProfile_UpdatesExistingOnboardingFields()
+    {
+        var user = SeedUser("fundraiser-settings-update@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+        SeedFundraiserProfile(user.Id);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PutAsJsonAsync(
+            "/api/fundraisers/me/settings/profile",
+            new UpdateFundraiserSettingsProfileRequest(
+                CompanyName: "Updated Fundraise Co",
+                RegistrationNumber: "RC-000111",
+                Bio: "Updated bio for settings.",
+                Website: "https://updated.example.com",
+                PublicEmail: "ops@updated.example.com",
+                Headquarters: "1 Broad Street, Lagos, Nigeria",
+                Contact: new UpdateFundraiserSettingsContactRequest(
+                    FullName: "Bola Ade",
+                    EmailAddress: "bola@updated.example.com",
+                    PhoneNumber: "+2348010001111")));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<FundraiserSettingsProfileResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.CompanyName.Should().Be("Updated Fundraise Co");
+        result.Value.LocationLabel.Should().Be("Lagos, Nigeria");
+        result.Value.Contact.FullName.Should().Be("Bola Ade");
+
+        var stored = await _context.UserInvestmentProfiles
+            .AsNoTracking()
+            .SingleAsync(p => p.UserId == user.Id);
+        stored.CompanyLegalName.Should().Be("Updated Fundraise Co");
+        stored.BusinessDescription.Should().Be("Updated bio for settings.");
+        stored.RepresentativeEmail.Should().Be("bola@updated.example.com");
+    }
+
+    [Fact]
+    public async Task UpdateSettingsProfile_WithInvalidPayload_Returns400()
+    {
+        var user = SeedUser("fundraiser-settings-invalid@example.com", UserTypeEnum.FundRaiser);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PutAsJsonAsync(
+            "/api/fundraisers/me/settings/profile",
+            new UpdateFundraiserSettingsProfileRequest(
+                CompanyName: "",
+                RegistrationNumber: null,
+                Bio: null,
+                Website: null,
+                PublicEmail: "not-an-email",
+                Headquarters: null,
+                Contact: null));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    private static UpdateFundraiserSettingsProfileRequest ValidUpdateRequest() =>
+        new(
+            CompanyName: "Skyhigh Technologies",
+            RegistrationNumber: "RC-12345678",
+            Bio: "Advanced prosthetic solutions.",
+            Website: "https://skyhightechnologies.com",
+            PublicEmail: "contact@skyhightech.com",
+            Headquarters: "123 Business Way, Victoria Island, Lagos, Nigeria",
+            Contact: new UpdateFundraiserSettingsContactRequest(
+                FullName: "John Doe",
+                EmailAddress: "doe@skyhightech.com",
+                PhoneNumber: "+2348012345678"));
+
+    private void SeedFundraiserProfile(int userId)
+    {
+        var profile = new UserInvestmentProfile
+        {
+            UserId = userId,
+            InvestorCategory = InvestorCategory.Retail,
+            CompanyLegalName = "Acme Fundraise Limited",
+            RegistrationNumber = "RC-998877",
+            BusinessDescription = "We raise capital for growth.",
+            CompanyWebsite = "https://acme.example.com",
+            CompanyEmail = "hello@acme.example.com",
+            BusinessAddress = "12 Admiralty Way, Victoria Island, Lagos, Nigeria",
+            RepresentativeFullName = "Ada Okonkwo",
+            RepresentativeEmail = "ada@acme.example.com",
+            RepresentativePhoneNumber = "+2348091112233",
+        };
+        profile.Created("TestUser");
+        _context.UserInvestmentProfiles.Add(profile);
+    }
+
+    private User SeedUser(string email, UserTypeEnum userType)
+    {
+        var user = new User
+        {
+            Email = email,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
+            UserType = userType,
+            IsEmailVerified = true,
+            FirstName = "Jane",
+            LastName = "Okonkwo",
+            PhoneNumber = "+2348012345678",
+            DateOfBirth = new DateTime(1990, 1, 1),
+            Nationality = "Nigerian",
+            CountryOfResidence = "Nigeria",
+            StateOfResidence = "Lagos",
+            ResidentialAddress = "123 Main Street",
+            HasAgreedToTerms = true,
+        };
+        _context.Users.Add(user);
+        return user;
+    }
+
+    private HttpClient CreateAuthorizedClient(int userId, string email)
+    {
+        var client = _factory.CreateClient();
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.UTF8.GetBytes(_config["Jwt:Key"]!);
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = _config["Jwt:Issuer"],
+            Audience = _config["Jwt:Audience"],
+            Expires = DateTime.UtcNow.AddHours(1),
+            Subject = new ClaimsIdentity(
+            [
+                new Claim("UserId", userId.ToString()),
+                new Claim(ClaimTypes.Email, email),
+            ]),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256),
+        };
+
+        var token = tokenHandler.CreateToken(descriptor);
+        var jwt = tokenHandler.WriteToken(token);
+
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", jwt);
+        return client;
+    }
+
+    private void CleanupDatabase()
+    {
+        _context.UserInvestmentProfiles.RemoveRange(_context.UserInvestmentProfiles);
+        _context.Users.RemoveRange(_context.Users);
+        _context.SaveChanges();
+    }
+
+    public void Dispose()
+    {
+        CleanupDatabase();
+        _scope.Dispose();
+        _client.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `GET/PUT /api/fundraisers/me/settings/profile` for company + contact fields seeded from onboarding profile data.
- Add `GET/PUT /api/fundraisers/me/settings/notifications` with `FundraiserNotificationPreferences` persistence + migration.
- Cover both surfaces with integration tests.

Closes [BloydIntel/antital-ui#226](https://github.com/BloydIntel/antital-ui/issues/226) (API half).

## Test plan
- [x] `GET /api/fundraisers/me/settings/profile` as fundraiser returns mapped onboarding fields
- [x] `PUT` profile persists and subsequent `GET` reflects changes
- [x] Investor token gets 403 on fundraiser settings routes
- [x] `GET/PUT /api/fundraisers/me/settings/notifications` defaults then persists toggles
- [x] Apply migration `AddFundraiserNotificationPreferences` and restart API
- [x] Run `FundraiserSettingsProfileControllerTests` + `FundraiserNotificationPreferencesControllerTests`


Made with [Cursor](https://cursor.com)