### PR TITLE
Add corporate dashboard API coverage

### DIFF
--- a/Antital.Infrastructure/Seed/InvestorDashboardSeed.cs
+++ b/Antital.Infrastructure/Seed/InvestorDashboardSeed.cs
@@ -31,76 +31,83 @@ public static class InvestorDashboardSeed
             return;
         }
 
-        var demoUser = await context.Users
-            .Where(u => u.IsEmailVerified && u.UserType == UserTypeEnum.IndividualInvestor && !u.IsDeleted)
+        var demoUsers = await context.Users
+            .Where(u =>
+                u.IsEmailVerified
+                && !u.IsDeleted
+                && (u.UserType == UserTypeEnum.IndividualInvestor || u.UserType == UserTypeEnum.CorporateInvestor))
             .OrderBy(u => u.Id)
-            .FirstOrDefaultAsync(cancellationToken);
+            .Take(2)
+            .ToListAsync(cancellationToken);
 
-        if (demoUser == null)
+        if (demoUsers.Count == 0)
         {
-            logger.LogInformation("Investor dashboard seed skipped: no verified individual investor user found.");
+            logger.LogInformation("Investor dashboard seed skipped: no verified individual or corporate investor user found.");
             return;
         }
 
         var now = DateTime.UtcNow;
-        var wallet = new InvestorWallet
+        foreach (var (demoUser, userIndex) in demoUsers.Select((user, index) => (user, index)))
         {
-            UserId = demoUser.Id,
-            AvailableBalance = 5_325_400m,
-            Currency = "NGN",
-        };
-        wallet.Created(SeedUser);
-        context.InvestorWallets.Add(wallet);
-
-        var holdings = new List<InvestorHolding>
-        {
-            CreateHolding(demoUser.Id, offerings[0], 25_400_000m, 1_250m, 432_650m, 1234, now.AddDays(-14)),
-            CreateHolding(demoUser.Id, offerings[1], 25_400_000m, 959m, 50_567m, 1245, now.AddDays(-16)),
-        };
-        context.InvestorHoldings.AddRange(holdings);
-
-        foreach (var (offering, changePercent, addedDaysAgo) in new[]
-        {
-            (offerings[0], 4.22m, 2),
-            (offerings[1], 4.13m, 3),
-            (offerings.Count > 2 ? offerings[2] : offerings[0], 6.20m, 4),
-            (offerings.Count > 3 ? offerings[3] : offerings[1], -3.00m, 5),
-        })
-        {
-            var watchlistItem = new InvestorWatchlistItem
+            var wallet = new InvestorWallet
             {
                 UserId = demoUser.Id,
-                OfferingId = offering.Id,
-                ChangePercent = changePercent,
-                AddedAt = now.AddDays(-addedDaysAgo),
+                AvailableBalance = 5_325_400m + (userIndex * 250_000m),
+                Currency = "NGN",
             };
-            watchlistItem.Created(SeedUser);
-            context.InvestorWatchlistItems.Add(watchlistItem);
-        }
+            wallet.Created(SeedUser);
+            context.InvestorWallets.Add(wallet);
 
-        var performanceMonths = Enumerable.Range(0, 7)
-            .Select(offset =>
+            var holdings = new List<InvestorHolding>
             {
-                var monthDate = now.AddMonths(-6 + offset);
-                var point = new InvestorPortfolioPerformancePoint
+                CreateHolding(demoUser.Id, offerings[0], 25_400_000m, 1_250m, 432_650m, 1234, now.AddDays(-(14 + userIndex))),
+                CreateHolding(demoUser.Id, offerings[1], 25_400_000m, 959m, 50_567m, 1245, now.AddDays(-(16 + userIndex))),
+            };
+            context.InvestorHoldings.AddRange(holdings);
+
+            foreach (var (offering, changePercent, addedDaysAgo) in new[]
+            {
+                (offerings[0], 4.22m, 2 + userIndex),
+                (offerings[1], 4.13m, 3 + userIndex),
+                (offerings.Count > 2 ? offerings[2] : offerings[0], 6.20m, 4 + userIndex),
+                (offerings.Count > 3 ? offerings[3] : offerings[1], -3.00m, 5 + userIndex),
+            })
+            {
+                var watchlistItem = new InvestorWatchlistItem
                 {
                     UserId = demoUser.Id,
-                    Year = monthDate.Year,
-                    Month = monthDate.Month,
-                    Value = 10m + offset * 8m,
+                    OfferingId = offering.Id,
+                    ChangePercent = changePercent,
+                    AddedAt = now.AddDays(-addedDaysAgo),
                 };
-                point.Created(SeedUser);
-                return point;
-            })
-            .ToList();
+                watchlistItem.Created(SeedUser);
+                context.InvestorWatchlistItems.Add(watchlistItem);
+            }
 
-        context.InvestorPortfolioPerformancePoints.AddRange(performanceMonths);
+            var performanceMonths = Enumerable.Range(0, 7)
+                .Select(offset =>
+                {
+                    var monthDate = now.AddMonths(-6 + offset);
+                    var point = new InvestorPortfolioPerformancePoint
+                    {
+                        UserId = demoUser.Id,
+                        Year = monthDate.Year,
+                        Month = monthDate.Month,
+                        Value = 10m + offset * 8m + userIndex,
+                    };
+                    point.Created(SeedUser);
+                    return point;
+                })
+                .ToList();
+
+            context.InvestorPortfolioPerformancePoints.AddRange(performanceMonths);
+        }
+
         await context.SaveChangesAsync(cancellationToken);
 
         logger.LogInformation(
-            "Seeded investor dashboard data for user {UserId} ({Email}).",
-            demoUser.Id,
-            demoUser.Email);
+            "Seeded investor dashboard data for {Count} verified individual/corporate user(s).",
+            demoUsers.Count);
     }
 
     private static InvestorHolding CreateHolding(

--- a/Antital.Test/Integration/API/Controllers/InvestorsControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestorsControllerTests.cs
@@ -92,6 +92,29 @@ public class InvestorsControllerTests : IClassFixture<CustomWebApplicationFactor
     }
 
     [Fact]
+    public async Task GetDashboard_CorporateInvestor_ReturnsDashboardBundle()
+    {
+        var user = SeedUser("corporate-dashboard@example.com", userType: UserTypeEnum.CorporateInvestor);
+        var offering = await SeedOfferingAsync("corporate-greentech-solutions");
+        await SeedDashboardDataAsync(user.Id, offering);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+
+        var response = await authClient.GetAsync("/api/investors/me/dashboard?period=this-month");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorDashboardResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Summary.AvailableBalance.Should().Be(5_325_400m);
+        result.Value.Summary.TotalInvested.Should().Be(25_400_000m);
+        result.Value.Summary.Currency.Should().Be("NGN");
+        result.Value.Holdings.Should().ContainSingle(h => h.Slug == "corporate-greentech-solutions");
+        result.Value.ActiveDeals.Should().ContainSingle(d => d.Slug == "corporate-greentech-solutions");
+        result.Value.PortfolioPerformance.Should().NotBeEmpty();
+    }
+
+    [Fact]
     public async Task GetDashboard_NewInvestor_ReturnsEmptyArraysAndZeroSummary()
     {
         var user = SeedUser("empty@example.com");
@@ -111,13 +134,16 @@ public class InvestorsControllerTests : IClassFixture<CustomWebApplicationFactor
         result.Value.PortfolioPerformance.Should().BeEmpty();
     }
 
-    private User SeedUser(string email, string? preferredName = null)
+    private User SeedUser(
+        string email,
+        string? preferredName = null,
+        UserTypeEnum userType = UserTypeEnum.IndividualInvestor)
     {
         var user = new User
         {
             Email = email,
             PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
-            UserType = UserTypeEnum.IndividualInvestor,
+            UserType = userType,
             IsEmailVerified = true,
             FirstName = "Jane",
             LastName = "Okonkwo",


### PR DESCRIPTION
## Summary
- add explicit integration coverage for corporate investors using the investor dashboard endpoint
- broaden local investor dashboard seed data to include verified corporate investors

## Validation
- dotnet test Antital.Test/Antital.Test.csproj --filter "FullyQualifiedName~InvestorsControllerTests"