### PR TITLE
Add corporate portfolio dashboard test

### DIFF
--- a/Antital.Test/Integration/API/Controllers/InvestmentOrdersControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestmentOrdersControllerTests.cs
@@ -98,6 +98,32 @@ public class InvestmentOrdersControllerTests : IClassFixture<CustomWebApplicatio
     }
 
     [Fact]
+    public async Task CreateOrder_CorporateInvestorWithSubmittedOnboarding_ReturnsOrderBreakdown()
+    {
+        var user = SeedUser("corporate-investor@example.com", UserTypeEnum.CorporateInvestor);
+        await _context.SaveChangesAsync();
+        SeedSubmittedOnboarding(user.Id, OnboardingFlowType.CorporateInvestor);
+        var offering = await SeedOfferingAsync(sharePrice: 100m, minInvestment: 1000m, maxInvestment: 50_000m);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+
+        var response = await authClient.PostAsJsonAsync(
+            $"/api/investments/{offering.Id}/orders",
+            new CreateInvestmentOrderRequest(10));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<CreateInvestmentOrderResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.OfferingId.Should().Be(offering.Id);
+        result.Value.Units.Should().Be(10);
+        result.Value.Subtotal.Should().Be(1000m);
+        result.Value.TotalAmount.Should().Be(1025m);
+        result.Value.Status.Should().Be(nameof(InvestmentOrderStatus.PendingPayment));
+    }
+
+    [Fact]
     public async Task CreateOrder_BelowMinimumInvestment_Returns400()
     {
         var user = SeedUser("min-check@example.com");
@@ -132,13 +158,13 @@ public class InvestmentOrdersControllerTests : IClassFixture<CustomWebApplicatio
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
-    private User SeedUser(string email)
+    private User SeedUser(string email, UserTypeEnum userType = UserTypeEnum.IndividualInvestor)
     {
         var user = new User
         {
             Email = email,
             PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
-            UserType = UserTypeEnum.IndividualInvestor,
+            UserType = userType,
             IsEmailVerified = true,
             FirstName = "Jane",
             LastName = "Investor",
@@ -154,12 +180,14 @@ public class InvestmentOrdersControllerTests : IClassFixture<CustomWebApplicatio
         return user;
     }
 
-    private void SeedSubmittedOnboarding(int userId)
+    private void SeedSubmittedOnboarding(
+        int userId,
+        OnboardingFlowType flowType = OnboardingFlowType.IndividualInvestor)
     {
         var onboarding = new UserOnboarding
         {
             UserId = userId,
-            FlowType = OnboardingFlowType.IndividualInvestor,
+            FlowType = flowType,
             CurrentStep = OnboardingStep.Kyc,
             Status = OnboardingStatus.Submitted,
             SubmittedAt = DateTime.UtcNow,

--- a/Antital.Test/Integration/API/Controllers/InvestmentPaymentControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestmentPaymentControllerTests.cs
@@ -70,6 +70,30 @@ public class InvestmentPaymentControllerTests : IClassFixture<CustomWebApplicati
     }
 
     [Fact]
+    public async Task InitializePayment_CorporateInvestor_ValidOrder_ReturnsPaystackSession()
+    {
+        var (user, offering) = await SeedEligibleInvestorWithOfferingAsync(
+            "payment-corporate@example.com",
+            UserTypeEnum.CorporateInvestor,
+            OnboardingFlowType.CorporateInvestor);
+        var orderId = await CreateOrderAsync(user, offering.Id);
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PostAsJsonAsync(
+            $"/api/investments/orders/{orderId}/pay",
+            new InitializeInvestmentPaymentRequest("card"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<InitializeInvestmentPaymentResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.AuthorizationUrl.Should().StartWith("https://checkout.paystack.com/");
+        result.Value.AccessCode.Should().NotBeNullOrWhiteSpace();
+        result.Value.Reference.Should().StartWith($"ANT-ORD-{orderId}-");
+        result.Value.PublicKey.Should().Be(_config["Paystack:PublicKey"]);
+    }
+
+    [Fact]
     public async Task InitializePayment_InvalidChannel_Returns400()
     {
         var (user, offering) = await SeedEligibleInvestorWithOfferingAsync();
@@ -200,6 +224,44 @@ public class InvestmentPaymentControllerTests : IClassFixture<CustomWebApplicati
     }
 
     [Fact]
+    public async Task PaystackWebhook_CorporateInvestor_AddsHoldingToDashboard()
+    {
+        var (user, offering) = await SeedEligibleInvestorWithOfferingAsync(
+            "payment-corporate-dashboard@example.com",
+            UserTypeEnum.CorporateInvestor,
+            OnboardingFlowType.CorporateInvestor);
+        var orderId = await CreateOrderAsync(user, offering.Id);
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var payResponse = await authClient.PostAsJsonAsync(
+            $"/api/investments/orders/{orderId}/pay",
+            new InitializeInvestmentPaymentRequest("card"));
+        var payResult = await payResponse.Content.ReadFromJsonAsync<Result<InitializeInvestmentPaymentResponse>>(JsonOptions);
+        var reference = payResult!.Value!.Reference;
+
+        var payload = PaystackTestHelper.BuildChargeSuccessPayload(reference, 102_500);
+        var signature = PaystackTestHelper.ComputeSignature(payload, PaystackTestHelper.TestSecretKey);
+        using var webhookRequest = new HttpRequestMessage(HttpMethod.Post, "/api/payments/paystack/webhook")
+        {
+            Content = new StringContent(payload, Encoding.UTF8, "application/json"),
+        };
+        webhookRequest.Headers.Add("x-paystack-signature", signature);
+        (await _client.SendAsync(webhookRequest)).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var dashboardResponse = await authClient.GetAsync("/api/investors/me/dashboard?period=this-month");
+        dashboardResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var dashboard = await dashboardResponse.Content.ReadFromJsonAsync<Result<InvestorDashboardResponse>>(JsonOptions);
+        dashboard!.IsSuccess.Should().BeTrue();
+        dashboard.Value!.Holdings.Should().ContainSingle(h =>
+            h.Slug == offering.Slug
+            && h.Invested == 1000m
+            && h.UnitHolding == 10
+            && h.RaisedAmount == 101_000m);
+        dashboard.Value.Summary.TotalInvested.Should().Be(1000m);
+    }
+
+    [Fact]
     public async Task PaystackWebhook_DuplicateDelivery_IsIdempotent()
     {
         var (user, offering) = await SeedEligibleInvestorWithOfferingAsync();
@@ -298,23 +360,26 @@ public class InvestmentPaymentControllerTests : IClassFixture<CustomWebApplicati
         return result!.Value!.OrderId;
     }
 
-    private async Task<(User User, InvestmentOffering Offering)> SeedEligibleInvestorWithOfferingAsync()
+    private async Task<(User User, InvestmentOffering Offering)> SeedEligibleInvestorWithOfferingAsync(
+        string email = "payment-investor@example.com",
+        UserTypeEnum userType = UserTypeEnum.IndividualInvestor,
+        OnboardingFlowType flowType = OnboardingFlowType.IndividualInvestor)
     {
-        var user = SeedUser("payment-investor@example.com");
+        var user = SeedUser(email, userType);
         await _context.SaveChangesAsync();
-        SeedSubmittedOnboarding(user.Id);
+        SeedSubmittedOnboarding(user.Id, flowType);
         var offering = await SeedOfferingAsync();
         await _context.SaveChangesAsync();
         return (user, offering);
     }
 
-    private User SeedUser(string email)
+    private User SeedUser(string email, UserTypeEnum userType = UserTypeEnum.IndividualInvestor)
     {
         var user = new User
         {
             Email = email,
             PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
-            UserType = UserTypeEnum.IndividualInvestor,
+            UserType = userType,
             IsEmailVerified = true,
             FirstName = "Jane",
             LastName = "Investor",
@@ -330,12 +395,14 @@ public class InvestmentPaymentControllerTests : IClassFixture<CustomWebApplicati
         return user;
     }
 
-    private void SeedSubmittedOnboarding(int userId)
+    private void SeedSubmittedOnboarding(
+        int userId,
+        OnboardingFlowType flowType = OnboardingFlowType.IndividualInvestor)
     {
         var onboarding = new UserOnboarding
         {
             UserId = userId,
-            FlowType = OnboardingFlowType.IndividualInvestor,
+            FlowType = flowType,
             CurrentStep = OnboardingStep.Kyc,
             Status = OnboardingStatus.Submitted,
             SubmittedAt = DateTime.UtcNow,

--- a/Antital.Test/Integration/API/Controllers/InvestorAccountControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestorAccountControllerTests.cs
@@ -194,13 +194,46 @@ public class InvestorAccountControllerTests : IClassFixture<CustomWebApplication
         result.Value.KycStatus.Should().Be("Pending");
     }
 
-    private User SeedUser(string email)
+    [Fact]
+    public async Task GetAccount_CorporateInvestor_WithOciProfile_ReturnsCorporateClassification()
+    {
+        var user = SeedUser("account-corporate@example.com", UserTypeEnum.CorporateInvestor);
+        await _context.SaveChangesAsync();
+
+        _context.UserOnboardings.Add(new UserOnboarding
+        {
+            UserId = user.Id,
+            FlowType = OnboardingFlowType.CorporateInvestor,
+            CurrentStep = OnboardingStep.Review,
+            Status = OnboardingStatus.Submitted,
+        });
+
+        _context.UserInvestmentProfiles.Add(new UserInvestmentProfile
+        {
+            UserId = user.Id,
+            InvestorCategory = InvestorCategory.OtherCorporateInvestor,
+        });
+
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/investors/me/account");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorAccountResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.AccountType.Should().Be("Other Corporate Investor (OCI)");
+        result.Value.InvestorClassification.Should().Be("OCI");
+        result.Value.AccountStatus.Should().Be("Active");
+    }
+
+    private User SeedUser(string email, UserTypeEnum userType = UserTypeEnum.IndividualInvestor)
     {
         var user = new User
         {
             Email = email,
             PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
-            UserType = UserTypeEnum.IndividualInvestor,
+            UserType = userType,
             IsEmailVerified = true,
             FirstName = "Jane",
             LastName = "Okonkwo",

--- a/Antital.Test/Integration/API/Controllers/InvestorProfileControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestorProfileControllerTests.cs
@@ -140,6 +140,50 @@ public class InvestorProfileControllerTests : IClassFixture<CustomWebApplication
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    [Fact]
+    public async Task GetProfile_CorporateInvestor_ReturnsAuthenticatedUserProfile()
+    {
+        var user = SeedUser("profile-corporate@example.com", UserTypeEnum.CorporateInvestor);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/investors/me/profile");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorProfileResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Email.Should().Be("profile-corporate@example.com");
+        result.Value.UserType.Should().Be(UserTypeEnum.CorporateInvestor);
+        result.Value.FirstName.Should().Be("Jane");
+        result.Value.LastName.Should().Be("Okonkwo");
+    }
+
+    [Fact]
+    public async Task UpdateProfile_CorporateInvestor_UpdatesEditableFields()
+    {
+        var user = SeedUser("profile-corporate-update@example.com", UserTypeEnum.CorporateInvestor);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PutAsJsonAsync(
+            "/api/investors/me/profile",
+            new UpdateInvestorProfileRequest(
+                FirstName: "Ada",
+                LastName: "Okafor",
+                PreferredName: "Ada",
+                PhoneNumber: "+2348098765432",
+                ResidentialAddress: "42 Admiralty Way, Lekki Phase 1",
+                StateOfResidence: "Lagos State",
+                CountryOfResidence: "Nigeria"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorProfileResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.FirstName.Should().Be("Ada");
+        result.Value.UserType.Should().Be(UserTypeEnum.CorporateInvestor);
+        result.Value.Email.Should().Be("profile-corporate-update@example.com");
+    }
+
     private static UpdateInvestorProfileRequest ValidUpdateRequest() =>
         new(
             FirstName: "Ada",
@@ -150,13 +194,13 @@ public class InvestorProfileControllerTests : IClassFixture<CustomWebApplication
             StateOfResidence: "Lagos State",
             CountryOfResidence: "Nigeria");
 
-    private User SeedUser(string email)
+    private User SeedUser(string email, UserTypeEnum userType = UserTypeEnum.IndividualInvestor)
     {
         var user = new User
         {
             Email = email,
             PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
-            UserType = UserTypeEnum.IndividualInvestor,
+            UserType = userType,
             IsEmailVerified = true,
             FirstName = "Jane",
             LastName = "Okonkwo",

--- a/Antital.Test/Integration/API/Controllers/InvestorsControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/InvestorsControllerTests.cs
@@ -115,6 +115,31 @@ public class InvestorsControllerTests : IClassFixture<CustomWebApplicationFactor
     }
 
     [Fact]
+    public async Task GetDashboard_CorporateInvestor_ReturnsHoldingsForPortfolioView()
+    {
+        var user = SeedUser("corporate-portfolio@example.com", userType: UserTypeEnum.CorporateInvestor);
+        var offering = await SeedOfferingAsync("corporate-portfolio-offering");
+        await SeedDashboardDataAsync(user.Id, offering);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+
+        var response = await authClient.GetAsync("/api/investors/me/dashboard?period=this-month");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<InvestorDashboardResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.Holdings.Should().NotBeEmpty();
+        result.Value.Holdings.Should().ContainSingle(h =>
+            h.Slug == "corporate-portfolio-offering"
+            && h.Invested == 25_400_000m
+            && h.CurrentValue == 1_250m
+            && h.Returns == 432_650m
+            && h.UnitHolding == 1234);
+    }
+
+    [Fact]
     public async Task GetDashboard_NewInvestor_ReturnsEmptyArraysAndZeroSummary()
     {
         var user = SeedUser("empty@example.com");

--- a/Antital.Test/Integration/API/Controllers/PaymentMethodsControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/PaymentMethodsControllerTests.cs
@@ -86,6 +86,25 @@ public class PaymentMethodsControllerTests : IClassFixture<CustomWebApplicationF
     }
 
     [Fact]
+    public async Task AddPaymentMethod_CorporateInvestor_FirstMethod_BecomesDefault()
+    {
+        var user = SeedUser("pm-corporate-add@example.com", UserTypeEnum.CorporateInvestor);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PostAsJsonAsync(
+            "/api/investors/me/payment-methods",
+            new AddPaymentMethodRequest("Bank", "Corporate GTBank Account", "Guaranty Trust Bank", "5678"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<PaymentMethodResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Item.Type.Should().Be("Bank");
+        result.Value.Item.Title.Should().Be("Corporate GTBank Account");
+        result.Value.Item.IsDefault.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task AddPaymentMethod_InvalidLast4_Returns400()
     {
         var user = SeedUser("pm-invalid@example.com");
@@ -114,6 +133,38 @@ public class PaymentMethodsControllerTests : IClassFixture<CustomWebApplicationF
         var second = await authClient.PostAsJsonAsync(
             "/api/investors/me/payment-methods",
             new AddPaymentMethodRequest("Card", "Visa Debit Card", "Visa", "4532"));
+        var secondResult = await second.Content.ReadFromJsonAsync<Result<PaymentMethodResponse>>(JsonOptions);
+
+        var response = await authClient.PatchAsync(
+            $"/api/investors/me/payment-methods/{secondResult!.Value!.Item.Id}/default",
+            null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var setDefaultResult = await response.Content.ReadFromJsonAsync<Result<PaymentMethodResponse>>(JsonOptions);
+        setDefaultResult!.Value!.Item.IsDefault.Should().BeTrue();
+
+        var listResponse = await authClient.GetAsync("/api/investors/me/payment-methods");
+        var listResult = await listResponse.Content.ReadFromJsonAsync<Result<PaymentMethodsResponse>>(JsonOptions);
+        listResult!.Value!.Items.Should().HaveCount(2);
+        listResult.Value.Items.Single(i => i.Id == firstResult!.Value!.Item.Id).IsDefault.Should().BeFalse();
+        listResult.Value.Items.Single(i => i.Id == secondResult.Value!.Item.Id).IsDefault.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SetDefaultPaymentMethod_CorporateInvestor_UpdatesDefault()
+    {
+        var user = SeedUser("pm-corporate-default@example.com", UserTypeEnum.CorporateInvestor);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var first = await authClient.PostAsJsonAsync(
+            "/api/investors/me/payment-methods",
+            new AddPaymentMethodRequest("Bank", "Corporate GTBank Account", "Guaranty Trust Bank", "5678"));
+        var firstResult = await first.Content.ReadFromJsonAsync<Result<PaymentMethodResponse>>(JsonOptions);
+
+        var second = await authClient.PostAsJsonAsync(
+            "/api/investors/me/payment-methods",
+            new AddPaymentMethodRequest("Card", "Corporate Visa Card", "Visa", "4532"));
         var secondResult = await second.Content.ReadFromJsonAsync<Result<PaymentMethodResponse>>(JsonOptions);
 
         var response = await authClient.PatchAsync(
@@ -171,13 +222,13 @@ public class PaymentMethodsControllerTests : IClassFixture<CustomWebApplicationF
         deleteResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
-    private User SeedUser(string email)
+    private User SeedUser(string email, UserTypeEnum userType = UserTypeEnum.IndividualInvestor)
     {
         var user = new User
         {
             Email = email,
             PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
-            UserType = UserTypeEnum.IndividualInvestor,
+            UserType = userType,
             IsEmailVerified = true,
             FirstName = "Jane",
             LastName = "Okonkwo",

--- a/Antital.Test/Integration/API/Controllers/WalletTransactionsControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/WalletTransactionsControllerTests.cs
@@ -94,6 +94,31 @@ public class WalletTransactionsControllerTests : IClassFixture<CustomWebApplicat
     }
 
     [Fact]
+    public async Task GetWalletTransactions_CorporateInvestorWithPaidOrder_ReturnsInvestmentRow()
+    {
+        var user = SeedUser("wallet-corporate-paid@example.com", UserTypeEnum.CorporateInvestor);
+        var offering = await SeedOfferingAsync("corporate-aquapure-innovations");
+        await SeedPaidOrderAsync(user.Id, offering);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/investors/me/wallet/transactions?pageSize=3");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<WalletTransactionsResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Should().ContainSingle();
+        var item = result.Value.Items[0];
+        item.Type.Should().Be("Investment");
+        item.Status.Should().Be("Completed");
+        item.Amount.Should().Be(10_000m);
+        item.Fees.Should().Be(250m);
+        item.OfferingSlug.Should().Be("corporate-aquapure-innovations");
+        item.SubDescription.Should().Contain("20 units");
+    }
+
+    [Fact]
     public async Task GetWalletTransactions_SecondaryMarketType_Returns400()
     {
         var user = SeedUser("wallet-type@example.com");
@@ -161,6 +186,31 @@ public class WalletTransactionsControllerTests : IClassFixture<CustomWebApplicat
     }
 
     [Fact]
+    public async Task GetWalletTransaction_CorporateInvestorWithPaidOrder_ReturnsInvoice()
+    {
+        var user = SeedUser("wallet-corporate-detail@example.com", UserTypeEnum.CorporateInvestor);
+        var offering = await SeedOfferingAsync("corporate-aquapure-innovations");
+        var order = await SeedPaidOrderAsync(user.Id, offering);
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync($"/api/investors/me/wallet/transactions/{order.Id}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var result = await response.Content.ReadFromJsonAsync<Result<WalletTransactionInvoiceResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.InvoiceId.Should().Be(order.Id);
+        result.Value.PaymentMethod.Should().Be("Card");
+        result.Value.PaymentReference.Should().Be(order.PaystackReference);
+        result.Value.BillTo.Email.Should().Be(user.Email);
+        result.Value.TransactionDetails.Type.Should().Be("Investment");
+        result.Value.TransactionDetails.Status.Should().Be("Completed");
+        result.Value.Breakdown.Units.Should().Be(20);
+        result.Value.Breakdown.TotalAmount.Should().Be(10_250m);
+    }
+
+    [Fact]
     public async Task GetWalletTransaction_OtherUsersOrder_Returns404()
     {
         var owner = SeedUser("wallet-owner@example.com");
@@ -203,13 +253,13 @@ public class WalletTransactionsControllerTests : IClassFixture<CustomWebApplicat
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
-    private User SeedUser(string email)
+    private User SeedUser(string email, UserTypeEnum userType = UserTypeEnum.IndividualInvestor)
     {
         var user = new User
         {
             Email = email,
             PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
-            UserType = UserTypeEnum.IndividualInvestor,
+            UserType = userType,
             IsEmailVerified = true,
             FirstName = "Jane",
             LastName = "Okonkwo",

--- a/Antital.Test/Integration/API/Controllers/WatchlistControllerTests.cs
+++ b/Antital.Test/Integration/API/Controllers/WatchlistControllerTests.cs
@@ -96,6 +96,28 @@ public class WatchlistControllerTests : IClassFixture<CustomWebApplicationFactor
     }
 
     [Fact]
+    public async Task GetWatchlist_CorporateInvestor_WithSeededItem_ReturnsRichItem()
+    {
+        var user = SeedUser("watchlist-corporate-list@example.com", UserTypeEnum.CorporateInvestor);
+        var offering = await SeedOfferingAsync("corporate-greentech-solutions", deadlineDays: 15, raised: 990_000m, goal: 1_100_000m);
+        await SeedWatchlistItemAsync(user.Id, offering, 4.22m);
+        await SeedOfferingUpdateAsync(offering.Id, "Corporate production facility expansion fully cleared");
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.GetAsync("/api/investors/me/watchlist");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<WatchlistResponse>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Items.Should().ContainSingle(i =>
+            i.Slug == "corporate-greentech-solutions"
+            && i.ChangePercent == 4.22m
+            && i.RecentUpdate == "Corporate production facility expansion fully cleared");
+        result.Value.Counts.All.Should().Be(1);
+    }
+
+    [Fact]
     public async Task AddToWatchlist_AddsItem()
     {
         var user = SeedUser("watchlist-add@example.com");
@@ -115,6 +137,24 @@ public class WatchlistControllerTests : IClassFixture<CustomWebApplicationFactor
         var list = await authClient.GetAsync("/api/investors/me/watchlist");
         var listResult = await list.Content.ReadFromJsonAsync<Result<WatchlistResponse>>(JsonOptions);
         listResult!.Value!.Items.Should().ContainSingle(i => i.OfferingId == offering.Id);
+    }
+
+    [Fact]
+    public async Task AddToWatchlist_CorporateInvestor_AddsItem()
+    {
+        var user = SeedUser("watchlist-corporate-add@example.com", UserTypeEnum.CorporateInvestor);
+        var offering = await SeedOfferingAsync("corporate-fintech-innovators");
+        await _context.SaveChangesAsync();
+
+        using var authClient = CreateAuthorizedClient(user.Id, user.Email);
+        var response = await authClient.PostAsJsonAsync(
+            "/api/investors/me/watchlist",
+            new AddToWatchlistRequest(offering.Id));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<Result<WatchlistItemDto>>(JsonOptions);
+        result!.IsSuccess.Should().BeTrue();
+        result.Value!.Slug.Should().Be("corporate-fintech-innovators");
     }
 
     [Fact]
@@ -198,13 +238,13 @@ public class WatchlistControllerTests : IClassFixture<CustomWebApplicationFactor
         notWatchlistedResult!.Value!.IsWatchlisted.Should().BeFalse();
     }
 
-    private User SeedUser(string email)
+    private User SeedUser(string email, UserTypeEnum userType = UserTypeEnum.IndividualInvestor)
     {
         var user = new User
         {
             Email = email,
             PasswordHash = BCrypt.Net.BCrypt.HashPassword("Password123!"),
-            UserType = UserTypeEnum.IndividualInvestor,
+            UserType = userType,
             IsEmailVerified = true,
             FirstName = "Jane",
             LastName = "Okonkwo",


### PR DESCRIPTION
## Summary
- add explicit coverage that corporate investors receive holdings from the investor dashboard endpoint
- validate the same dashboard payload supports the portfolio view for corporate users

## Validation
- dotnet test Antital.Test/Antital.Test.csproj --filter "FullyQualifiedName~InvestorsControllerTests"